### PR TITLE
docs: 技術スタック・コーディング規約を追加 #3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,12 @@ test: ローテーションエンジンのユニットテスト追加 #8
 | ORM | Prisma | 型安全なDB操作 |
 | デプロイ | pm2 or systemd + Nginx | オンプレUbuntu + Cloudflare |
 
-## インフラ構成
+## 開発環境
+
+- WSL（Windows Subsystem for Linux）上に**開発コンテナ（Dev Container）**を作成して開発する
+- コンテナ内にNode.js、SQLite等の依存をすべて閉じ込め、環境差異を排除する
+
+## インフラ構成（本番）
 
 ```
 [Cloudflare] → [Nginx (リバースプロキシ)] → [Node.js (Hono API + Vite静的配信)]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,9 +111,15 @@ Claude CodeがIssueの内容を読み取り、以下を行います。
 | ORM | Prisma |
 | デプロイ | pm2 or systemd + Nginx + Cloudflare |
 
+### 開発環境
+
+WSL上に**開発コンテナ（Dev Container）**を作成して開発します。コンテナ内にNode.js、SQLite等の依存がすべて含まれるため、ローカル環境への個別インストールは不要です。
+
 ### ローカル開発（予定）
 
 ```bash
+# 開発コンテナ内で実行
+
 # 依存インストール
 npm install
 


### PR DESCRIPTION
## 概要

技術スタック（パターンA: TypeScript統一・軽量構成）の決定事項をCLAUDE.mdとCONTRIBUTING.mdに反映。

## 変更点

- **CLAUDE.md**
  - 技術スタックセクション追加（React + Vite / Hono / SQLite + Prisma）
  - インフラ構成図追加（Cloudflare → Nginx → Node.js → SQLite）
  - コーディング規約追加（TypeScript統一、命名規約、ディレクトリ構成）
- **CONTRIBUTING.md**
  - 技術スタック一覧追加
  - ローカル開発手順（予定）追加

## テスト

ドキュメント変更のみ。テスト不要。

closes #3