### PR TITLE
feat: リキャスト概念の追加と時間軸タイムラインUI #11

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { SkillPalette } from "./SkillPalette";
 import { Timeline } from "./Timeline";
 import { WHM_ATTACK_SKILLS } from "../data/whm-skills";
+import { resolveTimeline } from "../logic/resolve-timeline";
 import type { TimelineEntry } from "../types/skill";
 
 let nextUid = 1;
@@ -12,6 +13,11 @@ export function App() {
   const skillMap = useMemo(
     () => new Map(WHM_ATTACK_SKILLS.map((s) => [s.id, s])),
     []
+  );
+
+  const resolvedEntries = useMemo(
+    () => resolveTimeline(entries, skillMap),
+    [entries, skillMap]
   );
 
   const handleAddEntry = useCallback((skillId: string) => {
@@ -40,7 +46,7 @@ export function App() {
         <SkillPalette skills={WHM_ATTACK_SKILLS} />
         <Timeline
           skills={WHM_ATTACK_SKILLS}
-          entries={entries}
+          resolvedEntries={resolvedEntries}
           onAddEntry={handleAddEntry}
           onRemoveEntry={handleRemoveEntry}
           totalPotency={totalPotency}

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1,9 +1,24 @@
-import { useState, useCallback } from "react";
-import type { Skill, TimelineEntry } from "../types/skill";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import type { Skill, ResolvedTimelineEntry } from "../types/skill";
+
+/** 1秒あたりのピクセル数 */
+const PX_PER_SEC = 80;
+
+/** スキルアイコンのサイズ（px） */
+const ICON_SIZE = 40;
+
+/** レーンの高さ（px） */
+const LANE_HEIGHT = 72;
+
+/** 時間軸の高さ（px） */
+const RULER_HEIGHT = 28;
+
+/** レーンラベルの幅（px） */
+const LANE_LABEL_WIDTH = 52;
 
 interface TimelineProps {
   skills: Skill[];
-  entries: TimelineEntry[];
+  resolvedEntries: ResolvedTimelineEntry[];
   onAddEntry: (skillId: string) => void;
   onRemoveEntry: (uid: string) => void;
   totalPotency: number;
@@ -11,18 +26,22 @@ interface TimelineProps {
 
 export function Timeline({
   skills,
-  entries,
+  resolvedEntries,
   onAddEntry,
   onRemoveEntry,
   totalPotency,
 }: TimelineProps) {
   const [dragOver, setDragOver] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  const skillMap = new Map(skills.map((s) => [s.id, s]));
+  const skillMap = useMemo(
+    () => new Map(skills.map((s) => [s.id, s])),
+    [skills]
+  );
 
-  const gcdEntries: (TimelineEntry & { skill: Skill })[] = [];
-  const ogcdEntries: (TimelineEntry & { skill: Skill })[] = [];
-  for (const entry of entries) {
+  const gcdEntries: (ResolvedTimelineEntry & { skill: Skill })[] = [];
+  const ogcdEntries: (ResolvedTimelineEntry & { skill: Skill })[] = [];
+  for (const entry of resolvedEntries) {
     const skill = skillMap.get(entry.skillId);
     if (!skill) continue;
     if (skill.type === "gcd") {
@@ -31,6 +50,41 @@ export function Timeline({
       ogcdEntries.push({ ...entry, skill });
     }
   }
+
+  const totalDuration = useMemo(() => {
+    if (resolvedEntries.length === 0) return 0;
+    let maxEnd = 0;
+    for (const entry of resolvedEntries) {
+      const skill = skillMap.get(entry.skillId);
+      if (!skill) continue;
+      const end = entry.startTime + skill.recastTime;
+      if (end > maxEnd) maxEnd = end;
+    }
+    return maxEnd;
+  }, [resolvedEntries, skillMap]);
+
+  const timelineWidth = Math.max(totalDuration * PX_PER_SEC + 100, 600);
+
+  const rulerTicks = useMemo(() => {
+    const ticks: number[] = [];
+    const maxTime = Math.ceil(totalDuration + 1);
+    for (let t = 0; t <= maxTime; t += 0.5) {
+      ticks.push(t);
+    }
+    return ticks;
+  }, [totalDuration]);
+
+  useEffect(() => {
+    if (scrollRef.current && resolvedEntries.length > 0) {
+      const last = resolvedEntries[resolvedEntries.length - 1];
+      const skill = skillMap.get(last.skillId);
+      const endPx = (last.startTime + (skill?.recastTime ?? 0)) * PX_PER_SEC;
+      const container = scrollRef.current;
+      if (endPx > container.scrollLeft + container.clientWidth - 100) {
+        container.scrollLeft = endPx - container.clientWidth + 150;
+      }
+    }
+  }, [resolvedEntries, skillMap]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -72,70 +126,125 @@ export function Timeline({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        {entries.length === 0 ? (
+        {resolvedEntries.length === 0 ? (
           <div style={styles.placeholder}>
             スキルパレットからドラッグ＆ドロップしてスキルを追加
           </div>
         ) : (
-          <div style={styles.timelineContent}>
-            {/* GCD行 */}
-            <div style={styles.lane}>
-              <div style={styles.laneLabel}>GCD</div>
-              <div style={styles.laneSlots}>
-                {gcdEntries.map((entry, index) => (
-                  <div key={entry.uid} style={styles.slotWrapper}>
+          <div ref={scrollRef} style={styles.scrollContainer}>
+            <div style={{ ...styles.timelineContent, width: timelineWidth }}>
+              {/* GCD行 */}
+              <div style={styles.lane}>
+                <div style={styles.laneLabel}>GCD</div>
+                <div style={styles.laneContent}>
+                  {gcdEntries.map((entry) => (
                     <div
-                      style={styles.skillSlot}
-                      title={`${entry.skill.name} (威力: ${entry.skill.potency})`}
-                      onClick={() => onRemoveEntry(entry.uid)}
+                      key={entry.uid}
+                      style={{
+                        ...styles.skillBlock,
+                        left: entry.startTime * PX_PER_SEC,
+                        width: entry.skill.recastTime * PX_PER_SEC,
+                      }}
                     >
-                      <img
-                        src={entry.skill.icon}
-                        alt={entry.skill.name}
-                        style={styles.slotIcon}
+                      <div
+                        style={styles.recastBar}
+                        title={`リキャスト: ${entry.skill.recastTime}s`}
                       />
+                      <div
+                        style={styles.animLockBar}
+                        title={`アニメーションロック: ${entry.skill.animationLock}s`}
+                      >
+                        <div
+                          style={{
+                            ...styles.animLockFill,
+                            width:
+                              (entry.skill.animationLock /
+                                entry.skill.recastTime) *
+                                100 +
+                              "%",
+                          }}
+                        />
+                      </div>
+                      <div
+                        style={styles.skillIcon}
+                        title={`${entry.skill.name} (威力: ${entry.skill.potency}) [${entry.startTime.toFixed(2)}s]`}
+                        onClick={() => onRemoveEntry(entry.uid)}
+                      >
+                        <img
+                          src={entry.skill.icon}
+                          alt={entry.skill.name}
+                          style={styles.iconImage}
+                        />
+                      </div>
+                      <div style={styles.skillPotency}>
+                        {entry.skill.potency}
+                      </div>
                     </div>
-                    <div style={styles.slotPotency}>
-                      {entry.skill.potency}
-                    </div>
-                    <div style={styles.slotIndex}>{index + 1}</div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
 
-            {/* oGCD行 */}
-            <div style={styles.lane}>
-              <div style={styles.laneLabel}>oGCD</div>
-              <div style={styles.laneSlots}>
-                {ogcdEntries.map((entry, index) => (
-                  <div key={entry.uid} style={styles.slotWrapper}>
+              {/* oGCD行 */}
+              <div style={styles.lane}>
+                <div style={styles.laneLabel}>oGCD</div>
+                <div style={styles.laneContent}>
+                  {ogcdEntries.map((entry) => (
                     <div
-                      style={{ ...styles.skillSlot, ...styles.ogcdSlot }}
-                      title={`${entry.skill.name} (威力: ${entry.skill.potency})`}
-                      onClick={() => onRemoveEntry(entry.uid)}
+                      key={entry.uid}
+                      style={{
+                        ...styles.ogcdBlock,
+                        left: entry.startTime * PX_PER_SEC,
+                      }}
                     >
-                      <img
-                        src={entry.skill.icon}
-                        alt={entry.skill.name}
-                        style={styles.slotIcon}
-                      />
+                      <div
+                        style={styles.ogcdIcon}
+                        title={`${entry.skill.name} (威力: ${entry.skill.potency}) [${entry.startTime.toFixed(2)}s]`}
+                        onClick={() => onRemoveEntry(entry.uid)}
+                      >
+                        <img
+                          src={entry.skill.icon}
+                          alt={entry.skill.name}
+                          style={styles.iconImage}
+                        />
+                      </div>
+                      <div style={styles.skillPotency}>
+                        {entry.skill.potency}
+                      </div>
                     </div>
-                    <div style={styles.slotPotency}>
-                      {entry.skill.potency}
-                    </div>
-                    <div style={styles.slotIndex}>{index + 1}</div>
-                  </div>
-                ))}
+                  ))}
+                </div>
+              </div>
+
+              {/* 時間軸ルーラー */}
+              <div style={styles.ruler}>
+                <div style={styles.rulerLabel} />
+                <div style={styles.rulerContent}>
+                  {rulerTicks.map((t) => {
+                    const isMajor = t % 1 === 0;
+                    return (
+                      <div
+                        key={t}
+                        style={{
+                          ...styles.rulerTick,
+                          left: t * PX_PER_SEC,
+                          height: isMajor ? "12px" : "6px",
+                        }}
+                      >
+                        <div style={styles.rulerTickLine} />
+                        {isMajor && (
+                          <div style={styles.rulerTickLabel}>{t}s</div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           </div>
         )}
       </div>
 
-      <div style={styles.hint}>
-        クリックでスキルを削除
-      </div>
+      <div style={styles.hint}>クリックでスキルを削除</div>
     </div>
   );
 }
@@ -172,10 +281,9 @@ const styles: Record<string, React.CSSProperties> = {
     flex: 1,
     border: "2px dashed #444",
     borderRadius: "8px",
-    padding: "16px",
     transition: "border-color 0.2s, background-color 0.2s",
     minHeight: "200px",
-    overflow: "auto",
+    overflow: "hidden",
   },
   dropZoneActive: {
     borderColor: "#ffd700",
@@ -190,65 +298,142 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#666",
     fontSize: "14px",
   },
+  scrollContainer: {
+    overflowX: "auto",
+    overflowY: "hidden",
+    height: "100%",
+    padding: "12px 0",
+  },
   timelineContent: {
-    display: "flex",
-    flexDirection: "column",
-    gap: "16px",
+    position: "relative",
+    minWidth: "100%",
+    paddingLeft: 0,
   },
   lane: {
     display: "flex",
-    alignItems: "flex-start",
-    gap: "12px",
+    height: LANE_HEIGHT,
+    position: "relative",
+    marginBottom: "4px",
   },
   laneLabel: {
-    width: "48px",
+    width: LANE_LABEL_WIDTH,
     flexShrink: 0,
     fontSize: "12px",
     fontWeight: "bold",
     color: "#888",
     textTransform: "uppercase" as const,
-    paddingTop: "10px",
-    textAlign: "right" as const,
-  },
-  laneSlots: {
     display: "flex",
-    flexWrap: "wrap" as const,
-    gap: "8px",
-    flex: 1,
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingRight: "8px",
   },
-  slotWrapper: {
+  laneContent: {
+    position: "relative",
+    flex: 1,
+    borderBottom: "1px solid #2a2a4a",
+  },
+  skillBlock: {
+    position: "absolute",
+    top: "4px",
+    height: LANE_HEIGHT - 8,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+  },
+  recastBar: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: "4px",
+    backgroundColor: "rgba(100, 149, 237, 0.3)",
+    borderRadius: "2px",
+  },
+  animLockBar: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: "4px",
+    borderRadius: "2px",
+    overflow: "hidden",
+  },
+  animLockFill: {
+    height: "100%",
+    backgroundColor: "rgba(255, 100, 100, 0.6)",
+    borderRadius: "2px",
+  },
+  skillIcon: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    borderRadius: "6px",
+    overflow: "hidden",
+    cursor: "pointer",
+    border: "1px solid rgba(255,255,255,0.2)",
+    marginTop: "8px",
+    flexShrink: 0,
+    transition: "opacity 0.15s",
+  },
+  ogcdBlock: {
+    position: "absolute",
+    top: "8px",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "2px",
   },
-  skillSlot: {
-    width: "48px",
-    height: "48px",
-    borderRadius: "6px",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    cursor: "pointer",
-    transition: "opacity 0.15s",
-    border: "1px solid rgba(255,255,255,0.2)",
-    overflow: "hidden",
-  },
-  ogcdSlot: {
+  ogcdIcon: {
+    width: ICON_SIZE - 4,
+    height: ICON_SIZE - 4,
     borderRadius: "50%",
+    overflow: "hidden",
+    cursor: "pointer",
+    border: "1px solid rgba(255,255,255,0.2)",
+    flexShrink: 0,
+    transition: "opacity 0.15s",
   },
-  slotIcon: {
+  iconImage: {
     width: "100%",
     height: "100%",
     objectFit: "contain" as const,
   },
-  slotPotency: {
+  skillPotency: {
     fontSize: "9px",
     color: "#888",
+    marginTop: "2px",
+    textAlign: "center" as const,
   },
-  slotIndex: {
-    fontSize: "9px",
-    color: "#666",
+  ruler: {
+    display: "flex",
+    height: RULER_HEIGHT,
+    position: "relative",
+    borderTop: "1px solid #444",
+    marginTop: "4px",
+  },
+  rulerLabel: {
+    width: LANE_LABEL_WIDTH,
+    flexShrink: 0,
+  },
+  rulerContent: {
+    position: "relative",
+    flex: 1,
+  },
+  rulerTick: {
+    position: "absolute",
+    top: 0,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  rulerTickLine: {
+    width: "1px",
+    height: "100%",
+    backgroundColor: "#555",
+  },
+  rulerTickLabel: {
+    fontSize: "10px",
+    color: "#777",
+    marginTop: "2px",
+    whiteSpace: "nowrap" as const,
   },
   hint: {
     marginTop: "8px",

--- a/src/client/data/whm-skills.ts
+++ b/src/client/data/whm-skills.ts
@@ -15,6 +15,12 @@ import holy3Icon from "../assets/icons/whm/Holy_III.png";
 import afflatus_miseryIcon from "../assets/icons/whm/Afflatus_Misery.png";
 import assizeIcon from "../assets/icons/whm/Assize.png";
 
+/** GCDのデフォルトリキャストタイム（秒） */
+const GCD_RECAST = 2.5;
+
+/** デフォルトのアニメーションロック（秒） */
+const DEFAULT_ANIMATION_LOCK = 0.65;
+
 /**
  * 白魔道士（WHM）攻撃スキル一覧
  * パッチ7.x準拠の威力値
@@ -27,6 +33,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 140,
     type: "gcd",
     icon: stoneIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "aero",
@@ -34,6 +42,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 50,
     type: "gcd",
     icon: aeroIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "stone2",
@@ -41,6 +51,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 190,
     type: "gcd",
     icon: stone2Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "aero2",
@@ -48,6 +60,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 50,
     type: "gcd",
     icon: aero2Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "stone3",
@@ -55,6 +69,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 220,
     type: "gcd",
     icon: stone3Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "stone4",
@@ -62,6 +78,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 260,
     type: "gcd",
     icon: stone4Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "dia",
@@ -69,6 +87,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 85,
     type: "gcd",
     icon: diaIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "glare",
@@ -76,6 +96,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 290,
     type: "gcd",
     icon: glareIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "glare3",
@@ -83,6 +105,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 350,
     type: "gcd",
     icon: glare3Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "glare4",
@@ -90,6 +114,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 640,
     type: "gcd",
     icon: glare4Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "holy",
@@ -97,6 +123,8 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 140,
     type: "gcd",
     icon: holyIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
   {
     id: "holy3",
@@ -104,14 +132,17 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 150,
     type: "gcd",
     icon: holy3Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
-
   {
     id: "heart-of-misery",
     name: "ハート・オブ・ミゼリ",
     potency: 1400,
     type: "gcd",
     icon: afflatus_miseryIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
 
   // === oGCD ===
@@ -121,5 +152,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     potency: 400,
     type: "ogcd",
     icon: assizeIcon,
+    recastTime: DEFAULT_ANIMATION_LOCK,
+    animationLock: DEFAULT_ANIMATION_LOCK,
   },
 ];

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -1,0 +1,44 @@
+import type { Skill, TimelineEntry, ResolvedTimelineEntry } from "../types/skill";
+
+/**
+ * タイムラインエントリにリキャスト・アニメーションロックに基づく開始時刻を計算する。
+ *
+ * ルール:
+ * - GCDスキル: 前のGCDのリキャスト完了後 かつ 前のアクションのアニメーションロック完了後
+ * - oGCDスキル: 前のアクションのアニメーションロック完了後（GCDリキャスト中に使用可能）
+ */
+export function resolveTimeline(
+  entries: TimelineEntry[],
+  skillMap: Map<string, Skill>
+): ResolvedTimelineEntry[] {
+  const resolved: ResolvedTimelineEntry[] = [];
+
+  /** 次のGCDが使用可能になる時刻 */
+  let gcdAvailableAt = 0;
+  /** 次のアクション（GCD/oGCD問わず）が使用可能になる時刻 */
+  let actionAvailableAt = 0;
+
+  for (const entry of entries) {
+    const skill = skillMap.get(entry.skillId);
+    if (!skill) continue;
+
+    let startTime: number;
+
+    if (skill.type === "gcd") {
+      startTime = Math.max(gcdAvailableAt, actionAvailableAt);
+      gcdAvailableAt = startTime + skill.recastTime;
+      actionAvailableAt = startTime + skill.animationLock;
+    } else {
+      startTime = actionAvailableAt;
+      actionAvailableAt = startTime + skill.animationLock;
+    }
+
+    resolved.push({
+      uid: entry.uid,
+      skillId: entry.skillId,
+      startTime: Math.round(startTime * 1000) / 1000,
+    });
+  }
+
+  return resolved;
+}

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -13,6 +13,10 @@ export interface Skill {
   type: SkillType;
   /** スキルアイコン画像のパス */
   icon: string;
+  /** リキャストタイム（秒）。GCDスキルは2.5s、oGCDはスキル固有値 */
+  recastTime: number;
+  /** アニメーションロック（秒）。デフォルト0.65s */
+  animationLock: number;
 }
 
 /** タイムラインに配置されたスキル */
@@ -21,4 +25,14 @@ export interface TimelineEntry {
   uid: string;
   /** 参照するスキルのID */
   skillId: string;
+}
+
+/** 時間情報付きタイムラインエントリ（計算結果） */
+export interface ResolvedTimelineEntry {
+  /** タイムラインエントリの一意ID */
+  uid: string;
+  /** 参照するスキルのID */
+  skillId: string;
+  /** 開始時刻（秒） */
+  startTime: number;
 }


### PR DESCRIPTION
## 概要
スキルのリキャスト概念を実装し、タイムラインを時間軸ベースのレイアウトに変更しました。

## 変更点
- **`Skill` 型に `recastTime` と `animationLock` を追加** (`src/client/types/skill.ts`)
  - GCDスキル: リキャスト2.5s、アニメーションロック0.65s
  - oGCDスキル: リキャスト=アニメーションロック=0.65s（スキル毎固有値を設定可能）
- **`ResolvedTimelineEntry` 型を追加** - 計算された開始時刻を持つエントリ
- **WHMスキルデータにリキャスト値を設定** (`src/client/data/whm-skills.ts`)
- **時間配置ロジックの新規実装** (`src/client/logic/resolve-timeline.ts`)
  - GCDスキル: 前のGCDリキャスト完了後 かつ 前アクションのアニメーションロック完了後に配置
  - oGCDスキル: 前アクションのアニメーションロック完了後に配置（GCDリキャスト中に使用可能）
- **タイムラインUIの時間軸ベース化** (`src/client/components/Timeline.tsx`)
  - 横軸に時間目盛り（0.5秒刻み、整数秒にラベル表示）
  - スキルを時間位置に応じて絶対配置
  - GCDスキルにリキャストバー（青）とアニメーションロックバー（赤）を表示
  - 横スクロール対応、スキル追加時に自動スクロール

## テスト
- TypeScriptの型チェック: エラーなし（prisma設定の既存エラーを除く）
- Viteプロダクションビルド: 成功
- GCDスキルが2.5秒間隔で配置されること
- oGCDスキルがGCDリキャスト中のアニメーションロック後に配置されること
- 時間軸ルーラーが正しく表示されること

closes #11