### PR TITLE
feat: PPS計算機能を実装 #30

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -1,12 +1,12 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { SkillPalette } from "./SkillPalette";
 import { Timeline } from "./Timeline";
-import { resolveTimeline } from "../logic/resolve-timeline";
+import { resolveTimeline, calcPps } from "../logic/resolve-timeline";
 import { resolveIconUrl } from "../utils/resolve-icon-url";
 import { WHM_RESOURCES } from "../data/whm-resources";
 import { WHM_BUFFS } from "../data/whm-buffs";
 import { DEFAULT_STATS, calcExpectedMultiplier } from "../logic/stat-calc";
-import type { Skill, TimelineEntry, CharacterStats, BossUntargetableWindow } from "../types/skill";
+import type { Skill, TimelineEntry, CharacterStats, BossUntargetableWindow, PpsRange } from "../types/skill";
 
 let nextUid = 1;
 
@@ -17,6 +17,7 @@ export function App() {
   const [stats, setStats] = useState<CharacterStats>(DEFAULT_STATS);
   const [statsEnabled, setStatsEnabled] = useState(false);
   const [untargetableWindows, setUntargetableWindows] = useState<BossUntargetableWindow[]>([]);
+  const [ppsRange, setPpsRange] = useState<PpsRange | null>(null);
 
   useEffect(() => {
     fetch("/api/skills")
@@ -73,6 +74,30 @@ export function App() {
     [stats, statsEnabled]
   );
 
+  // 全体PPS: 0 〜 最後のGCDリキャスト完了まで（DoTは最終GCDまでで打ち切り）
+  const overallPps = useMemo(() => {
+    if (timelineResult.lastGcdEndTime <= 0) return null;
+    return calcPps(
+      resolvedEntries,
+      skillMap,
+      timelineResult.dotTicks,
+      0,
+      timelineResult.lastGcdEndTime
+    );
+  }, [resolvedEntries, skillMap, timelineResult.dotTicks, timelineResult.lastGcdEndTime]);
+
+  // 範囲選択PPS
+  const rangePps = useMemo(() => {
+    if (!ppsRange) return null;
+    return calcPps(
+      resolvedEntries,
+      skillMap,
+      timelineResult.dotTicks,
+      ppsRange.startTime,
+      ppsRange.endTime
+    );
+  }, [resolvedEntries, skillMap, timelineResult.dotTicks, ppsRange]);
+
   if (loading) {
     return (
       <div style={styles.app}>
@@ -111,6 +136,11 @@ export function App() {
           dotTotalPotency={timelineResult.dotTotalPotency}
           untargetableWindows={untargetableWindows}
           onUntargetableWindowsChange={setUntargetableWindows}
+          overallPps={overallPps}
+          rangePps={rangePps}
+          ppsRange={ppsRange}
+          onPpsRangeChange={setPpsRange}
+          lastGcdEndTime={timelineResult.lastGcdEndTime}
         />
       </div>
       <footer style={styles.footer}>

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
-import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow } from "../types/skill";
+import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow, PpsRange } from "../types/skill";
 import { calcGcd } from "../logic/stat-calc";
 import "./timeline.css";
 
@@ -46,6 +46,11 @@ interface TimelineProps {
   dotTotalPotency: number;
   untargetableWindows: BossUntargetableWindow[];
   onUntargetableWindowsChange: (windows: BossUntargetableWindow[]) => void;
+  overallPps: { pps: number; totalPotency: number; directPotency: number; dotPotency: number } | null;
+  rangePps: { pps: number; totalPotency: number; directPotency: number; dotPotency: number } | null;
+  ppsRange: PpsRange | null;
+  onPpsRangeChange: (range: PpsRange | null) => void;
+  lastGcdEndTime: number;
 }
 
 /**
@@ -127,6 +132,11 @@ export function Timeline({
   dotTotalPotency,
   untargetableWindows,
   onUntargetableWindowsChange,
+  overallPps,
+  rangePps,
+  ppsRange,
+  onPpsRangeChange,
+  lastGcdEndTime,
 }: TimelineProps) {
   const [dragOver, setDragOver] = useState(false);
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
@@ -134,6 +144,7 @@ export function Timeline({
   const [showBuffs, setShowBuffs] = useState(true);
   const [showDoTs, setShowDoTs] = useState(true);
   const [showUntargetableEditor, setShowUntargetableEditor] = useState(false);
+  const [showPpsRange, setShowPpsRange] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   /** 末尾追加時のみ自動スクロールするためのフラグ */
   const shouldAutoScrollRef = useRef(true);
@@ -434,6 +445,25 @@ export function Timeline({
               {showResources ? "リソース ▼" : "リソース ▶"}
             </button>
           )}
+          <button
+            style={{
+              ...styles.toggleButton,
+              ...(ppsRange ? { borderColor: "rgba(255, 183, 77, 0.5)", color: "#ffb74d" } : {}),
+            }}
+            onClick={() => {
+              const next = !showPpsRange;
+              setShowPpsRange(next);
+              if (next && !ppsRange) {
+                onPpsRangeChange({ startTime: 0, endTime: Math.max(lastGcdEndTime, 10) });
+              }
+              if (!next) {
+                onPpsRangeChange(null);
+              }
+            }}
+            title="PPS範囲選択"
+          >
+            {showPpsRange ? "PPS範囲 ▼" : "PPS範囲 ▶"}
+          </button>
           <div style={styles.potencyDisplay}>
             合計威力: <span style={styles.potencyValue}>{totalPotency}</span>
             {dotTotalPotency > 0 && (
@@ -446,9 +476,79 @@ export function Timeline({
                 {" "}(期待値: {Math.floor(totalPotency * expectedMultiplier)})
               </span>
             )}
+            {overallPps !== null && (
+              <span style={styles.ppsDisplay}>
+                {" "}PPS: <span style={styles.ppsValue}>{overallPps.pps.toFixed(2)}</span>
+              </span>
+            )}
           </div>
         </div>
       </div>
+
+      {showPpsRange && (
+        <div style={styles.ppsRangeEditor}>
+          <div style={styles.ppsRangeHeader}>
+            <span style={styles.ppsRangeTitle}>PPS範囲選択</span>
+          </div>
+          <div style={styles.ppsRangeRow}>
+            <label style={styles.ppsRangeLabel}>
+              開始:
+              <input
+                type="number"
+                step="0.5"
+                min="0"
+                value={ppsRange?.startTime ?? 0}
+                style={styles.ppsRangeInput}
+                onChange={(e) => {
+                  const val = parseFloat(e.target.value);
+                  if (isNaN(val) || val < 0) return;
+                  onPpsRangeChange({
+                    startTime: val,
+                    endTime: ppsRange?.endTime ?? lastGcdEndTime,
+                  });
+                }}
+              />
+              s
+            </label>
+            <label style={styles.ppsRangeLabel}>
+              終了:
+              <input
+                type="number"
+                step="0.5"
+                min="0"
+                value={ppsRange?.endTime ?? lastGcdEndTime}
+                style={styles.ppsRangeInput}
+                onChange={(e) => {
+                  const val = parseFloat(e.target.value);
+                  if (isNaN(val) || val < 0) return;
+                  onPpsRangeChange({
+                    startTime: ppsRange?.startTime ?? 0,
+                    endTime: val,
+                  });
+                }}
+              />
+              s
+            </label>
+            <button
+              style={styles.ppsRangeResetButton}
+              onClick={() => onPpsRangeChange({ startTime: 0, endTime: lastGcdEndTime })}
+              title="全体範囲にリセット"
+            >
+              全体
+            </button>
+          </div>
+          {rangePps !== null && (
+            <div style={styles.ppsRangeResult}>
+              <span>
+                範囲PPS: <span style={styles.ppsValue}>{rangePps.pps.toFixed(2)}</span>
+              </span>
+              <span style={styles.ppsRangeDetail}>
+                (威力: {rangePps.totalPotency} = 直接{rangePps.directPotency} + DoT{rangePps.dotPotency})
+              </span>
+            </div>
+          )}
+        </div>
+      )}
 
       {showUntargetableEditor && (
         <div style={styles.untargetableEditor}>
@@ -844,6 +944,29 @@ export function Timeline({
                   </div>
                 );
               })}
+
+              {/* PPS範囲選択オーバーレイ */}
+              {ppsRange && showPpsRange && (() => {
+                const left = LANE_LABEL_WIDTH + ppsRange.startTime * PX_PER_SEC;
+                const width = (ppsRange.endTime - ppsRange.startTime) * PX_PER_SEC;
+                return (
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      bottom: RULER_HEIGHT,
+                      left,
+                      width,
+                      backgroundColor: "rgba(255, 183, 77, 0.08)",
+                      borderLeft: "2px solid rgba(255, 183, 77, 0.6)",
+                      borderRight: "2px solid rgba(255, 183, 77, 0.6)",
+                      zIndex: 4,
+                      pointerEvents: "none",
+                    }}
+                    title={`PPS範囲 (${ppsRange.startTime}s - ${ppsRange.endTime}s)`}
+                  />
+                );
+              })()}
 
               {/* 時間軸ルーラー */}
               <div style={styles.ruler}>
@@ -1346,5 +1469,79 @@ const styles: Record<string, React.CSSProperties> = {
     padding: "2px 8px",
     cursor: "pointer",
     lineHeight: 1,
+  },
+  // PPS表示
+  ppsDisplay: {
+    fontSize: "14px",
+    color: "#ffb74d",
+    marginLeft: "8px",
+  },
+  ppsValue: {
+    fontSize: "18px",
+    fontWeight: "bold",
+    color: "#ffb74d",
+  },
+  // PPS範囲選択エディタ
+  ppsRangeEditor: {
+    backgroundColor: "rgba(255, 183, 77, 0.05)",
+    border: "1px solid rgba(255, 183, 77, 0.2)",
+    borderRadius: "6px",
+    padding: "8px 12px",
+    marginBottom: "8px",
+  },
+  ppsRangeHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: "6px",
+  },
+  ppsRangeTitle: {
+    fontSize: "13px",
+    fontWeight: "bold",
+    color: "#ffb74d",
+  },
+  ppsRangeRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    marginBottom: "4px",
+  },
+  ppsRangeLabel: {
+    fontSize: "12px",
+    color: "#aaa",
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+  },
+  ppsRangeInput: {
+    width: "60px",
+    backgroundColor: "#1a1a3e",
+    border: "1px solid #444",
+    borderRadius: "4px",
+    color: "#e0e0e0",
+    padding: "2px 6px",
+    fontSize: "12px",
+    textAlign: "right" as const,
+  },
+  ppsRangeResetButton: {
+    background: "none",
+    border: "1px solid rgba(255, 183, 77, 0.4)",
+    borderRadius: "4px",
+    color: "#ffb74d",
+    fontSize: "12px",
+    padding: "2px 10px",
+    cursor: "pointer",
+  },
+  ppsRangeResult: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    fontSize: "13px",
+    color: "#e0e0e0",
+    marginTop: "4px",
+  },
+  ppsRangeDetail: {
+    fontSize: "12px",
+    color: "#888",
   },
 };

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -409,12 +409,62 @@ export function resolveTimeline(
   // ティックを時刻順にソート
   dotTicks.sort((a, b) => a.time - b.time);
 
+  // 最後のGCDのリキャスト完了時刻を算出
+  let lastGcdEndTime = 0;
+  for (const entry of resolved) {
+    const skill = skillMap.get(entry.skillId);
+    if (!skill || skill.type !== "gcd") continue;
+    const baseRecast = stats ? calcGcd(skill.recastTime, stats) : skill.recastTime;
+    const speedMul = getSpeedMultiplier(entry.activeBuffs, buffDefMap);
+    const recastTime = Math.round(baseRecast * speedMul * 1000) / 1000;
+    const endTime = entry.startTime + recastTime;
+    if (endTime > lastGcdEndTime) lastGcdEndTime = endTime;
+  }
+
   return {
     entries: resolved,
     dotTicks,
     dotTotalPotency,
     activeDoTs: allDoTs,
+    lastGcdEndTime,
   };
+}
+
+/**
+ * 指定範囲内のPPS（Power Per Second）を計算する。
+ * - 直接威力: startTime が範囲内にあるスキルの威力を合算
+ * - DoT威力: time が範囲内にあるDoTティックの威力を合算
+ * - PPS = 合計威力 / 範囲の秒数
+ */
+export function calcPps(
+  resolvedEntries: ResolvedTimelineEntry[],
+  skillMap: Map<string, Skill>,
+  dotTicks: DoTTick[],
+  rangeStart: number,
+  rangeEnd: number
+): { pps: number; totalPotency: number; directPotency: number; dotPotency: number } {
+  const duration = rangeEnd - rangeStart;
+  if (duration <= 0) return { pps: 0, totalPotency: 0, directPotency: 0, dotPotency: 0 };
+
+  let directPotency = 0;
+  for (const entry of resolvedEntries) {
+    if (entry.startTime >= rangeStart && entry.startTime < rangeEnd) {
+      const skill = skillMap.get(entry.skillId);
+      directPotency += skill?.potency ?? 0;
+    }
+  }
+
+  let dotPotency = 0;
+  for (const tick of dotTicks) {
+    if (tick.time >= rangeStart && tick.time < rangeEnd) {
+      dotPotency += tick.potency;
+    }
+  }
+
+  const totalPotency = directPotency + dotPotency;
+  const pps = totalPotency / duration;
+
+  return { pps, totalPotency, directPotency, dotPotency };
 }
 
 /**

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -177,6 +177,14 @@ export interface BossUntargetableWindow {
   endTime: number;
 }
 
+/** PPS範囲選択 */
+export interface PpsRange {
+  /** 範囲開始時刻（秒） */
+  startTime: number;
+  /** 範囲終了時刻（秒） */
+  endTime: number;
+}
+
 /** resolveTimelineの計算結果 */
 export interface TimelineResult {
   /** 各スキルの計算結果 */
@@ -187,6 +195,8 @@ export interface TimelineResult {
   dotTotalPotency: number;
   /** アクティブDoT期間一覧（タイムライン表示用） */
   activeDoTs: ActiveDoT[];
+  /** 最後のGCDスキルのリキャスト完了時刻 */
+  lastGcdEndTime: number;
 }
 
 /** 時間情報付きタイムラインエントリ（計算結果） */


### PR DESCRIPTION
## 概要
スキル回し評価のためにPPS（Power Per Second）の計算機能を実装しました。タイムライン全体および任意の範囲内でのPPS計算が可能です。

## 変更点
- **PPS計算ロジック** (`resolve-timeline.ts`):
  - `calcPps()` 関数を追加（指定範囲内の直接威力 + DoTティック威力を秒数で割る）
  - `lastGcdEndTime`（最後のGCDリキャスト完了時刻）を `TimelineResult` に追加
- **全体PPS表示**: タイムラインヘッダーの合計威力の横にPPS値を常時表示（0 〜 最後のGCD完了まで）
- **範囲選択PPS** (`Timeline.tsx`):
  - 「PPS範囲」ボタンで範囲選択UIを開閉
  - 開始・終了時刻を数値入力で指定可能
  - 選択範囲内のPPS・威力内訳（直接/DoT）を表示
  - タイムライン上にオレンジ色のオーバーレイで範囲を視覚表示
  - 「全体」ボタンで全体範囲にリセット
- **型定義** (`skill.ts`):
  - `PpsRange` インターフェースを追加
  - `TimelineResult` に `lastGcdEndTime` フィールドを追加

## テスト
- TypeScriptの型チェック（`npx tsc --noEmit`）: パス
- Viteビルド（`npx vite build`）: 成功

closes #30