### PR TITLE
fix: スキルのドラッグ&ドロップ先予測表示を修正 #45

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -370,11 +370,26 @@ export function Timeline({
    * GCD: GCDエントリのみを使って表示位置を計算（GCDリキャスト境界間）
    * oGCD: 全エントリを使って表示位置を計算
    */
+  /**
+   * 挿入位置直前の全エントリの終了時刻（animationLock基準）を算出。
+   * GCDの実行可能時刻は max(GCDリキャスト明け, 直前アクションの硬直明け) なので、
+   * oGCDの硬直がGCDリキャストを超える場合に正しい位置を表示するために必要。
+   */
+  const getActionAvailableAt = useCallback(
+    (combinedInsertIdx: number): number => {
+      if (combinedInsertIdx <= 0) return 0;
+      const prevEntry = resolvedEntries[combinedInsertIdx - 1];
+      if (!prevEntry) return 0;
+      const skill = skillMap.get(prevEntry.skillId);
+      return prevEntry.startTime + (skill?.animationLock ?? 0);
+    },
+    [resolvedEntries, skillMap]
+  );
+
   const indicatorX = useMemo(() => {
     if (insertIndex === null || dragType === null) return null;
     if (dragType === "gcd") {
-      // GCD: insertIndex（combined）をGCDフィルタ済みの位置に逆変換してGCDエントリで表示
-      // combined indexが指すエントリがGCDならそのGCDインデックス、そうでなければ直前のGCD
+      // combined indexからGCDフィルタ済みインデックスに逆変換
       let gcdIdx = 0;
       for (let i = 0; i < gcdResolvedEntries.length; i++) {
         const combinedPos = resolvedEntries.findIndex((e) => e.uid === gcdResolvedEntries[i].uid);
@@ -384,10 +399,17 @@ export function Timeline({
         }
         gcdIdx = i + 1;
       }
-      return calcInsertIndicatorX(gcdIdx, gcdResolvedEntries, skillMap, getEntryRecastTime);
+
+      // GCDエントリベースで基本位置を算出
+      const baseX = calcInsertIndicatorX(gcdIdx, gcdResolvedEntries, skillMap, getEntryRecastTime);
+
+      // 直前の全エントリの硬直明け時刻でクランプ（oGCD硬直がGCDリキャストを超える場合の補正）
+      const actionAvailAt = getActionAvailableAt(insertIndex);
+      const actionAvailX = actionAvailAt * PX_PER_SEC + 4;
+      return Math.max(baseX, actionAvailX);
     }
     return calcInsertIndicatorX(insertIndex, resolvedEntries, skillMap, getEntryRecastTime);
-  }, [insertIndex, dragType, resolvedEntries, gcdResolvedEntries, skillMap, getEntryRecastTime]);
+  }, [insertIndex, dragType, resolvedEntries, gcdResolvedEntries, skillMap, getEntryRecastTime, getActionAvailableAt]);
 
   // タイムライン上の全バフ期間を収集（重複排除）
   // スタック付きバフの場合、スタックが0になった時点でバフ終了とみなす


### PR DESCRIPTION
## 概要
ボス離脱タイミング設定時にoGCDスキルのドラッグ&ドロップ先予測インジケーターが正しい位置に表示されないバグを修正。

## 変更点
- ドラッグ時の挿入位置計算を**タイプ別フィルタ済みエントリ**から**全エントリ**ベースに変更
- `handleDragOver`: 全`resolvedEntries`に対して`calcInsertIndex`を実行
- `handleDrop`: 同様に全エントリベースで挿入位置を計算
- `indicatorX`: 全エントリベースで表示位置を計算
- 不要になった`filterEntriesByType`・`mapFilteredIndexToCombined`を削除

### 原因
従来はoGCDのみをフィルタしたリストで挿入位置を計算していたため、oGCDエントリがタイムライン末尾に集中している場合、マウスがタイムライン左側にあってもインジケーターが常に末尾付近に表示されていた。

## テスト
- Playwrightで以下を確認:
  - ボス離脱タイミング設定時にoGCDドラッグのインジケーターがマウス位置に追従すること
  - GCDドラッグのインジケーターが引き続き正常に動作すること
  - oGCDのドロップ先が正しい位置（マウス位置に対応するタイムライン上の位置）になること

closes #45