### PR TITLE
fix: DoTのTickタイミングをサーバーティック（3の倍数秒）に統一 #47

### DIFF
--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -382,8 +382,12 @@ export function resolveTimeline(
       });
     }
 
-    // ティック生成: 最初の適用時刻基準で3秒毎、最終endTimeまで
-    let tickTime = stream.firstAppliedAt + DOT_TICK_INTERVAL;
+    // ティック生成: サーバーティック（3の倍数秒）に合わせて生成、最終endTimeまで
+    // 付与時刻の直後の3の倍数秒から開始（付与時刻ちょうどは含めない）
+    let tickTime = Math.ceil(stream.firstAppliedAt / DOT_TICK_INTERVAL) * DOT_TICK_INTERVAL;
+    if (tickTime <= stream.firstAppliedAt) {
+      tickTime += DOT_TICK_INTERVAL;
+    }
     while (tickTime <= stream.currentEndTime) {
       // このティック時点で有効なセグメントのバフ倍率を取得
       // （最後に適用されたセグメントで appliedAt <= tickTime のもの）


### PR DESCRIPTION
## 概要
DoTのTickタイミングが付与時刻基準（付与から3秒後、6秒後...）になっていたのを、FF14のサーバーティック仕様に合わせて3の倍数秒（0, 3, 6, 9...）でTickするよう修正。

## 変更点
- `resolve-timeline.ts`: DoTティック生成の開始時刻計算を変更
  - 旧: `stream.firstAppliedAt + DOT_TICK_INTERVAL`（付与時刻基準）
  - 新: `Math.ceil(firstAppliedAt / DOT_TICK_INTERVAL) * DOT_TICK_INTERVAL`（サーバーティック境界）
  - 付与時刻がちょうど3の倍数の場合は次のティック（+3秒）から開始し、二重カウントを防止

## テスト
- 手動検証シナリオ:
  - ディア(30s)をt=2.5sに付与 → Tick: 3,6,9,...,30 = 10回 ✓
  - ディア(30s)をt=3.0sに付与 → Tick: 6,9,12,...,33 = 10回（二重カウントなし）✓
  - ディア(30s)をt=0.0sに付与 → Tick: 3,6,9,...,30 = 10回 ✓
  - DoT再適用時のティックタイマー非リセット → 既存動作維持 ✓

closes #47