### PR TITLE
feat: キャラクタのレベル設定の導入 #49

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -6,17 +6,42 @@ import { WHM_ATTACK_SKILLS } from "../data/whm-skills";
 import { WHM_RESOURCES } from "../data/whm-resources";
 import { WHM_BUFFS } from "../data/whm-buffs";
 import { DEFAULT_STATS, calcExpectedMultiplier } from "../logic/stat-calc";
-import type { TimelineEntry, CharacterStats, BossUntargetableWindow, PpsRange } from "../types/skill";
+import { getSkillsForLevel, getBuffsForLevel, getResourcesForLevel } from "../logic/skill-level";
+import type { TimelineEntry, CharacterStats, BossUntargetableWindow, PpsRange, PlayerLevel } from "../types/skill";
 
 let nextUid = 1;
 
 export function App() {
-  const skills = WHM_ATTACK_SKILLS;
+  const [level, setLevel] = useState<PlayerLevel>(100);
   const [entries, setEntries] = useState<TimelineEntry[]>([]);
   const [stats, setStats] = useState<CharacterStats>(DEFAULT_STATS);
   const [statsEnabled, setStatsEnabled] = useState(false);
   const [untargetableWindows, setUntargetableWindows] = useState<BossUntargetableWindow[]>([]);
   const [ppsRange, setPpsRange] = useState<PpsRange | null>(null);
+
+  // レベルに応じたバフ・リソースをフィルタ
+  const levelBuffs = useMemo(
+    () => getBuffsForLevel(WHM_BUFFS, level),
+    [level]
+  );
+  const levelResources = useMemo(
+    () => getResourcesForLevel(WHM_RESOURCES, level),
+    [level]
+  );
+
+  // レベルに応じたスキルをフィルタ・威力調整
+  const availableBuffIds = useMemo(
+    () => new Set(levelBuffs.map((b) => b.id)),
+    [levelBuffs]
+  );
+  const availableResourceIds = useMemo(
+    () => new Set(levelResources.map((r) => r.id)),
+    [levelResources]
+  );
+  const skills = useMemo(
+    () => getSkillsForLevel(WHM_ATTACK_SKILLS, level, availableBuffIds, availableResourceIds),
+    [level, availableBuffIds, availableResourceIds]
+  );
 
   const skillMap = useMemo(
     () => new Map(skills.map((s) => [s.id, s])),
@@ -24,8 +49,8 @@ export function App() {
   );
 
   const timelineResult = useMemo(
-    () => resolveTimeline(entries, skillMap, WHM_RESOURCES, statsEnabled ? stats : undefined, WHM_BUFFS, untargetableWindows),
-    [entries, skillMap, stats, statsEnabled, untargetableWindows]
+    () => resolveTimeline(entries, skillMap, levelResources, statsEnabled ? stats : undefined, levelBuffs, untargetableWindows),
+    [entries, skillMap, levelResources, stats, statsEnabled, levelBuffs, untargetableWindows]
   );
 
   const resolvedEntries = timelineResult.entries;
@@ -97,6 +122,8 @@ export function App() {
           statsEnabled={statsEnabled}
           onStatsChange={setStats}
           onStatsEnabledChange={setStatsEnabled}
+          level={level}
+          onLevelChange={setLevel}
         />
         <Timeline
           skills={skills}
@@ -104,8 +131,8 @@ export function App() {
           onAddEntry={handleAddEntry}
           onRemoveEntry={handleRemoveEntry}
           totalPotency={totalPotency}
-          resources={WHM_RESOURCES}
-          buffs={WHM_BUFFS}
+          resources={levelResources}
+          buffs={levelBuffs}
           expectedMultiplier={expectedMultiplier}
           statsEnabled={statsEnabled}
           stats={statsEnabled ? stats : undefined}

--- a/src/client/components/SkillPalette.tsx
+++ b/src/client/components/SkillPalette.tsx
@@ -1,6 +1,8 @@
-import type { Skill, CharacterStats } from "../types/skill";
+import type { Skill, CharacterStats, PlayerLevel } from "../types/skill";
 import { calcCritRate, calcCritMultiplier, calcDhRate, calcDetMultiplier, calcGcd } from "../logic/stat-calc";
 import "./timeline.css";
+
+const SUPPORTED_LEVELS: PlayerLevel[] = [70, 80, 90, 100];
 
 interface SkillPaletteProps {
   skills: Skill[];
@@ -8,6 +10,8 @@ interface SkillPaletteProps {
   statsEnabled: boolean;
   onStatsChange: (stats: CharacterStats) => void;
   onStatsEnabledChange: (enabled: boolean) => void;
+  level: PlayerLevel;
+  onLevelChange: (level: PlayerLevel) => void;
 }
 
 export function SkillPalette({
@@ -16,6 +20,8 @@ export function SkillPalette({
   statsEnabled,
   onStatsChange,
   onStatsEnabledChange,
+  level,
+  onLevelChange,
 }: SkillPaletteProps) {
   const gcdSkills = skills.filter((s) => s.type === "gcd");
   const ogcdSkills = skills.filter((s) => s.type === "ogcd");
@@ -32,9 +38,37 @@ export function SkillPalette({
     onStatsChange({ ...stats, [key]: num });
   };
 
+  const handleLevelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onLevelChange(Number(e.target.value) as PlayerLevel);
+  };
+
   return (
     <div className="custom-scrollbar" style={styles.container}>
       <h2 style={styles.title}>スキルパレット</h2>
+
+      {/* レベル設定 */}
+      <div style={styles.section}>
+        <h3 style={styles.sectionTitle}>レベル</h3>
+        <div style={styles.levelRow}>
+          <label style={styles.levelLabel}>Lv.</label>
+          <select
+            value={level}
+            onChange={handleLevelChange}
+            style={styles.levelSelect}
+          >
+            {SUPPORTED_LEVELS.map((lv) => (
+              <option key={lv} value={lv}>
+                {lv}
+              </option>
+            ))}
+          </select>
+        </div>
+        {level < 100 && (
+          <div style={styles.levelWarning}>
+            Lv{level}の威力値は正確でない可能性があります
+          </div>
+        )}
+      </div>
 
       {/* ステータス入力セクション */}
       <div style={styles.section}>
@@ -191,6 +225,37 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#888",
     textTransform: "uppercase" as const,
     letterSpacing: "1px",
+  },
+  levelRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+  },
+  levelLabel: {
+    fontSize: "14px",
+    fontWeight: "bold",
+    color: "#e0e0e0",
+    flexShrink: 0,
+  },
+  levelSelect: {
+    flex: 1,
+    padding: "6px 8px",
+    fontSize: "14px",
+    backgroundColor: "#16213e",
+    border: "1px solid #444",
+    borderRadius: "4px",
+    color: "#e0e0e0",
+    outline: "none",
+    cursor: "pointer",
+  },
+  levelWarning: {
+    marginTop: "6px",
+    padding: "4px 8px",
+    fontSize: "11px",
+    color: "#ffa726",
+    backgroundColor: "rgba(255, 167, 38, 0.1)",
+    borderRadius: "4px",
+    border: "1px solid rgba(255, 167, 38, 0.3)",
   },
   statHeader: {
     display: "flex",

--- a/src/client/data/whm-buffs.ts
+++ b/src/client/data/whm-buffs.ts
@@ -30,5 +30,6 @@ export const WHM_BUFFS: BuffDefinition[] = [
     effects: [],
     color: "#ffcc00",
     maxStacks: 3,
+    acquiredLevel: 92,
   },
 ];

--- a/src/client/data/whm-resources.ts
+++ b/src/client/data/whm-resources.ts
@@ -23,5 +23,6 @@ export const WHM_RESOURCES: ResourceDefinition[] = [
     shortName: "B.ﾘﾘｰ",
     maxStacks: 3,
     color: "#ef5350",
+    acquiredLevel: 74,
   },
 ];

--- a/src/client/data/whm-skills.ts
+++ b/src/client/data/whm-skills.ts
@@ -26,10 +26,11 @@ const DEFAULT_ANIMATION_LOCK = 0.65;
 
 /**
  * 白魔道士（WHM）攻撃スキル一覧
- * パッチ7.x準拠の威力値
+ * 威力はジョブガイド準拠（基本値 = 特性適用前）
+ * Lv94特性「White Magic Mastery」による威力変動はtraitPotencyOverridesで定義
  */
 export const WHM_ATTACK_SKILLS: Skill[] = [
-  // === GCD ===
+  // === GCD: ストーン系（単体攻撃魔法チェーン） ===
   {
     id: "stone",
     name: "ストーン",
@@ -39,7 +40,73 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: stoneIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 1,
   },
+  {
+    id: "stone2",
+    name: "ストンラ",
+    potency: 190,
+    type: "gcd",
+    target: "enemy",
+    icon: stone2Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 18,
+    replacesSkillId: "stone",
+  },
+  {
+    id: "stone3",
+    name: "ストンガ",
+    potency: 220,
+    type: "gcd",
+    target: "enemy",
+    icon: stone3Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 54,
+    replacesSkillId: "stone2",
+  },
+  {
+    id: "stone4",
+    name: "ストンジャ",
+    potency: 260,
+    type: "gcd",
+    target: "enemy",
+    icon: stone4Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 64,
+    replacesSkillId: "stone3",
+  },
+  {
+    id: "glare",
+    name: "グレア",
+    potency: 290,
+    type: "gcd",
+    target: "enemy",
+    icon: glareIcon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 72,
+    replacesSkillId: "stone4",
+  },
+  {
+    id: "glare3",
+    name: "グレアガ",
+    potency: 310,
+    type: "gcd",
+    target: "enemy",
+    icon: glare3Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 82,
+    replacesSkillId: "glare",
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 350 },
+    ],
+  },
+
+  // === GCD: エアロ系（DoTチェーン） ===
   {
     id: "aero",
     name: "エアロ",
@@ -51,16 +118,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     dotPotency: 30,
     dotDuration: 18,
-  },
-  {
-    id: "stone2",
-    name: "ストンラ",
-    potency: 190,
-    type: "gcd",
-    target: "enemy",
-    icon: stone2Icon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 4,
   },
   {
     id: "aero2",
@@ -71,74 +129,30 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: aero2Icon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    dotPotency: 60,
+    dotPotency: 50,
     dotDuration: 18,
-  },
-  {
-    id: "stone3",
-    name: "ストンガ",
-    potency: 220,
-    type: "gcd",
-    target: "enemy",
-    icon: stone3Icon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
-  },
-  {
-    id: "stone4",
-    name: "ストンジャ",
-    potency: 260,
-    type: "gcd",
-    target: "enemy",
-    icon: stone4Icon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 46,
+    replacesSkillId: "aero",
   },
   {
     id: "dia",
     name: "ディア",
-    potency: 85,
+    potency: 60,
     type: "gcd",
     target: "enemy",
     icon: diaIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    dotPotency: 75,
+    dotPotency: 60,
     dotDuration: 30,
-  },
-  {
-    id: "glare",
-    name: "グレア",
-    potency: 290,
-    type: "gcd",
-    target: "enemy",
-    icon: glareIcon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
-  },
-  {
-    id: "glare3",
-    name: "グレアガ",
-    potency: 350,
-    type: "gcd",
-    target: "enemy",
-    icon: glare3Icon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
-  },
-  {
-    id: "glare4",
-    name: "グレアジャ",
-    potency: 640,
-    type: "gcd",
-    target: "enemy",
-    icon: glare4Icon,
-    recastTime: GCD_RECAST,
-    animationLock: DEFAULT_ANIMATION_LOCK,
-    buffConsumptions: [
-      { buffId: "sacred-sight", stacks: 1 },
+    acquiredLevel: 72,
+    replacesSkillId: "aero2",
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 85, dotPotency: 85 },
     ],
   },
+
+  // === GCD: ホーリー系（範囲攻撃魔法チェーン） ===
   {
     id: "holy",
     name: "ホーリー",
@@ -148,6 +162,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: holyIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 45,
   },
   {
     id: "holy3",
@@ -158,8 +173,27 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: holy3Icon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 82,
+    replacesSkillId: "holy",
   },
-  // === リリー関連GCD ===
+
+  // === GCD: グレアジャ（神速魔効果アップ Lv92） ===
+  {
+    id: "glare4",
+    name: "グレアジャ",
+    potency: 640,
+    type: "gcd",
+    target: "enemy",
+    icon: glare4Icon,
+    recastTime: GCD_RECAST,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 92,
+    buffConsumptions: [
+      { buffId: "sacred-sight", stacks: 1 },
+    ],
+  },
+
+  // === GCD: リリー関連 ===
   {
     id: "heart-of-solace",
     name: "ハート・オブ・ソラス",
@@ -169,6 +203,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: afflatus_solaceIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 52,
     resourceChanges: [
       { resourceId: "healing-lily", amount: -1 },
       { resourceId: "blood-lily", amount: 1 },
@@ -183,6 +218,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: afflatus_raptureIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 76,
     resourceChanges: [
       { resourceId: "healing-lily", amount: -1 },
       { resourceId: "blood-lily", amount: 1 },
@@ -191,14 +227,18 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
   {
     id: "heart-of-misery",
     name: "ハート・オブ・ミゼリ",
-    potency: 1400,
+    potency: 1240,
     type: "gcd",
     target: "enemy",
     icon: afflatus_miseryIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 74,
     resourceChanges: [
       { resourceId: "blood-lily", amount: -3 },
+    ],
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 1400 },
     ],
   },
 
@@ -212,6 +252,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: assizeIcon,
     recastTime: DEFAULT_ANIMATION_LOCK,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 56,
   },
   {
     id: "presence-of-mind",
@@ -222,6 +263,7 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     icon: presenceOfMindIcon,
     recastTime: DEFAULT_ANIMATION_LOCK,
     animationLock: DEFAULT_ANIMATION_LOCK,
+    acquiredLevel: 30,
     buffApplications: ["presence-of-mind", "sacred-sight"],
   },
 ];

--- a/src/client/logic/skill-level.ts
+++ b/src/client/logic/skill-level.ts
@@ -1,0 +1,99 @@
+import type { Skill, BuffDefinition, ResourceDefinition, PlayerLevel } from "../types/skill";
+
+/**
+ * 特性による威力変動を適用したスキルを返す
+ */
+function applyTraitOverrides(skill: Skill, level: number): Skill {
+  if (!skill.traitPotencyOverrides || skill.traitPotencyOverrides.length === 0) {
+    return skill;
+  }
+
+  let potency = skill.potency;
+  let dotPotency = skill.dotPotency;
+
+  // traitLevelの昇順で適用（低い方から順に上書き）
+  const sorted = [...skill.traitPotencyOverrides].sort((a, b) => a.traitLevel - b.traitLevel);
+  for (const override of sorted) {
+    if (level >= override.traitLevel) {
+      if (override.potency !== undefined) potency = override.potency;
+      if (override.dotPotency !== undefined) dotPotency = override.dotPotency;
+    }
+  }
+
+  if (potency === skill.potency && dotPotency === skill.dotPotency) {
+    return skill;
+  }
+
+  return { ...skill, potency, dotPotency };
+}
+
+/**
+ * プレイヤーレベルに応じたスキル一覧を返す
+ * - 習得レベル以下のスキルのみ表示
+ * - 置き換えチェーンでは最上位のスキルのみ表示
+ * - 特性による威力変動を適用
+ * - レベル未満のリソースを参照するresourceChangesを除外
+ */
+export function getSkillsForLevel(
+  allSkills: Skill[],
+  level: PlayerLevel,
+  availableBuffIds: Set<string>,
+  availableResourceIds: Set<string>,
+): Skill[] {
+  // 1. 習得レベルでフィルタ
+  const available = allSkills.filter((s) => s.acquiredLevel <= level);
+
+  // 2. 置き換え済みスキルを除外（replacedByが存在するスキルを非表示）
+  const replacedIds = new Set(
+    available
+      .filter((s) => s.replacesSkillId)
+      .map((s) => s.replacesSkillId!),
+  );
+  const filtered = available.filter((s) => !replacedIds.has(s.id));
+
+  // 3. 特性による威力変動を適用
+  // 4. レベル未満のバフ・リソースへの参照を除外
+  return filtered.map((skill) => {
+    let adjusted = applyTraitOverrides(skill, level);
+
+    // バフ付与: レベル未満のバフを除外
+    if (adjusted.buffApplications) {
+      const filteredBuffs = adjusted.buffApplications.filter((id) => availableBuffIds.has(id));
+      if (filteredBuffs.length !== adjusted.buffApplications.length) {
+        adjusted = { ...adjusted, buffApplications: filteredBuffs.length > 0 ? filteredBuffs : undefined };
+      }
+    }
+
+    // リソース変動: レベル未満のリソースを除外
+    if (adjusted.resourceChanges) {
+      const filteredResources = adjusted.resourceChanges.filter((rc) => availableResourceIds.has(rc.resourceId));
+      if (filteredResources.length !== adjusted.resourceChanges.length) {
+        adjusted = { ...adjusted, resourceChanges: filteredResources.length > 0 ? filteredResources : undefined };
+      }
+    }
+
+    // バフ消費: レベル未満のバフを除外
+    if (adjusted.buffConsumptions) {
+      const filteredConsumptions = adjusted.buffConsumptions.filter((bc) => availableBuffIds.has(bc.buffId));
+      if (filteredConsumptions.length !== adjusted.buffConsumptions.length) {
+        adjusted = { ...adjusted, buffConsumptions: filteredConsumptions.length > 0 ? filteredConsumptions : undefined };
+      }
+    }
+
+    return adjusted;
+  });
+}
+
+/**
+ * プレイヤーレベルに応じたバフ一覧を返す
+ */
+export function getBuffsForLevel(allBuffs: BuffDefinition[], level: PlayerLevel): BuffDefinition[] {
+  return allBuffs.filter((b) => !b.acquiredLevel || b.acquiredLevel <= level);
+}
+
+/**
+ * プレイヤーレベルに応じたリソース一覧を返す
+ */
+export function getResourcesForLevel(allResources: ResourceDefinition[], level: PlayerLevel): ResourceDefinition[] {
+  return allResources.filter((r) => !r.acquiredLevel || r.acquiredLevel <= level);
+}

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -20,13 +20,26 @@ export interface BuffConsumption {
   stacks: number;
 }
 
+/** 特性による威力変動 */
+export interface TraitPotencyOverride {
+  /** この特性が適用されるレベル */
+  traitLevel: number;
+  /** 変更後の威力（undefinedの場合は変更なし） */
+  potency?: number;
+  /** 変更後のDoT威力（undefinedの場合は変更なし） */
+  dotPotency?: number;
+}
+
+/** サポートするプレイヤーレベル */
+export type PlayerLevel = 70 | 80 | 90 | 100;
+
 /** スキルの定義データ */
 export interface Skill {
   /** スキルの一意識別子 */
   id: string;
   /** スキル名（日本語） */
   name: string;
-  /** 威力 */
+  /** 威力（基本値。特性適用前） */
   potency: number;
   /** GCD or oGCD */
   type: SkillType;
@@ -38,13 +51,19 @@ export interface Skill {
   recastTime: number;
   /** アニメーションロック（秒）。デフォルト0.65s */
   animationLock: number;
+  /** 習得レベル */
+  acquiredLevel: number;
+  /** このスキルが置き換える元スキルのID */
+  replacesSkillId?: string;
+  /** 特性による威力変動テーブル */
+  traitPotencyOverrides?: TraitPotencyOverride[];
   /** リソース変動（未設定の場合はリソースに影響なし） */
   resourceChanges?: ResourceChange[];
   /** 使用時に付与するバフのIDリスト */
   buffApplications?: string[];
   /** 使用時に消費するバフスタック */
   buffConsumptions?: BuffConsumption[];
-  /** DoT威力（1ティックあたり）。未設定の場合はDoTなし */
+  /** DoT威力（1ティックあたり。基本値。特性適用前） */
   dotPotency?: number;
   /** DoT持続時間（秒）。dotPotency設定時は必須 */
   dotDuration?: number;
@@ -74,6 +93,8 @@ export interface ResourceDefinition {
   autoGenerateInterval?: number;
   /** 表示色 */
   color: string;
+  /** 習得レベル（特性により解放されるレベル。未設定の場合は常に利用可能） */
+  acquiredLevel?: number;
 }
 
 /** 特定時点のリソース状態 */
@@ -132,6 +153,8 @@ export interface BuffDefinition {
   color: string;
   /** スタック付きバフの最大スタック数（未設定の場合はスタックなし） */
   maxStacks?: number;
+  /** 習得レベル（特性により解放されるレベル。未設定の場合は常に利用可能） */
+  acquiredLevel?: number;
 }
 
 /** タイムライン上のアクティブなバフ */


### PR DESCRIPTION
## 概要
ステータス欄にレベル選択UI（Lv70/80/90/100）を追加し、レベルに応じたスキルの表示フィルタリング・威力変動・バフ/リソースの制御を実装。

## 変更点
- **型定義 (skill.ts)**: `Skill`に`acquiredLevel`, `replacesSkillId`, `traitPotencyOverrides`を追加。`BuffDefinition`・`ResourceDefinition`に`acquiredLevel`を追加。`PlayerLevel`型を追加。
- **スキルデータ (whm-skills.ts)**: 全スキルに習得レベル・置き換え関係を定義。Lv94特性「White Magic Mastery」による威力変動（グレアガ310→350、ディア60/60→85/85、ミゼリ1240→1400）をtraitPotencyOverridesで定義。エアロラ・ディアのdotPotencyをジョブガイド準拠に修正。
- **バフ・リソースデータ**: sacred-sightにacquiredLevel:92、blood-lilyにacquiredLevel:74を追加。
- **レベル解決ロジック (skill-level.ts)**: 新規作成。`getSkillsForLevel`（スキルフィルタ・威力調整・バフ/リソース参照制御）、`getBuffsForLevel`、`getResourcesForLevel`。
- **App.tsx**: レベルstate追加。レベルに応じたスキル・バフ・リソースを導出してコンポーネントに渡す。
- **SkillPalette.tsx**: レベル選択ドロップダウン追加。Lv100未満では威力値の正確性に関する注釈を表示。

## テスト
- Viteビルド成功を確認
- 既存テストファイルなし（テスト対象外）

closes #49