### PR TITLE
fix: スキル挿入時のインデックスズレを修正 #51

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -55,13 +55,16 @@ export function App() {
 
   const resolvedEntries = timelineResult.entries;
 
-  const handleAddEntry = useCallback((skillId: string, insertIndex?: number) => {
+  const handleAddEntry = useCallback((skillId: string, insertBeforeUid?: string) => {
     const uid = `entry-${nextUid++}`;
     setEntries((prev) => {
-      if (insertIndex !== undefined && insertIndex >= 0 && insertIndex < prev.length) {
-        const next = [...prev];
-        next.splice(insertIndex, 0, { uid, skillId });
-        return next;
+      if (insertBeforeUid) {
+        const targetIndex = prev.findIndex((e) => e.uid === insertBeforeUid);
+        if (targetIndex >= 0) {
+          const next = [...prev];
+          next.splice(targetIndex, 0, { uid, skillId });
+          return next;
+        }
       }
       return [...prev, { uid, skillId }];
     });

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -33,7 +33,7 @@ const RESOURCE_DOT_SIZE = 10;
 interface TimelineProps {
   skills: Skill[];
   resolvedEntries: ResolvedTimelineEntry[];
-  onAddEntry: (skillId: string, insertIndex?: number) => void;
+  onAddEntry: (skillId: string, insertBeforeUid?: string) => void;
   onRemoveEntry: (uid: string) => void;
   totalPotency: number;
   resources: ResourceDefinition[];
@@ -355,7 +355,7 @@ export function Timeline({
         if (isInsertMiddle) {
           shouldAutoScrollRef.current = false;
         }
-        onAddEntry(skillId, isInsertMiddle ? idx : undefined);
+        onAddEntry(skillId, isInsertMiddle ? resolvedEntries[idx].uid : undefined);
       } else {
         onAddEntry(skillId);
       }


### PR DESCRIPTION
## 概要
レベル変更後にスキルを挿入すると、挿入予定箇所と異なる位置に配置されるバグを修正。

## 変更点
- `onAddEntry` のインターフェースを数値インデックス (`insertIndex`) からUID指定 (`insertBeforeUid`) に変更
- `handleDrop` で `resolvedEntries[idx].uid` を渡すように変更（`App.tsx` の `Timeline.tsx`）
- `handleAddEntry` で UID を使って `entries` 配列上の正しい位置を特定するように変更

### 原因
`resolvedEntries`（レベルで無効なスキルをスキップ）上のインデックスを、`entries`（全エントリ、無効スキル含む）の `splice` にそのまま使用していたため、レベル変更で無効化されたエントリが存在する場合にインデックスがズレていた。

### 再現手順
1. レベル70でエアロラ → ストンジャ → エアロラを配置
2. レベル100に戻す（Lv70スキルは非表示だが entries に残る）
3. ソラス × 2 を追加
4. ミゼリを2番目に挿入 → 1番目に配置される（修正前）

## テスト
Playwrightで以下を検証:
- [x] レベル変更後の挿入が正しい位置に配置されること（メインのバグ修正）
- [x] 通常のGCD挿入（先頭・中間・末尾）が正常動作
- [x] oGCD混在タイムラインでのGCD挿入が正常動作

closes #51