### PR TITLE
fix: 挿入インジケーターを実際の配置位置に表示するよう改修 #59

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1291,6 +1291,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   laneLabel: {
     width: LANE_LABEL_WIDTH,
+    boxSizing: "border-box" as const,
     flexShrink: 0,
     fontSize: "12px",
     fontWeight: "bold",
@@ -1407,6 +1408,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   resourceLaneLabel: {
     width: LANE_LABEL_WIDTH,
+    boxSizing: "border-box" as const,
     flexShrink: 0,
     fontSize: "11px",
     color: "#777",
@@ -1456,6 +1458,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   buffLaneLabel: {
     width: LANE_LABEL_WIDTH,
+    boxSizing: "border-box" as const,
     flexShrink: 0,
     fontSize: "11px",
     color: "#777",
@@ -1544,6 +1547,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   dotLaneLabel: {
     width: LANE_LABEL_WIDTH,
+    boxSizing: "border-box" as const,
     flexShrink: 0,
     fontSize: "11px",
     color: "#777",
@@ -1613,6 +1617,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   recastLaneLabel: {
     width: LANE_LABEL_WIDTH,
+    boxSizing: "border-box" as const,
     flexShrink: 0,
     fontSize: "11px",
     color: "#777",


### PR DESCRIPTION
## 概要
挿入予定位置のインジケーターが、挿入後にスキルが実際に配置される位置（最速実行可能時刻）を正確に示すように改修。

## 変更点
- `calcInsertIndicatorX`（前後エントリの中間位置を表示する旧方式）を廃止
- `timelineStateAtIndex`を新設: 各エントリ処理後の`gcdAvailableAt`/`actionAvailableAt`を事前計算
- `indicatorX`をA方式に変更: `resolveTimeline`と同じロジックで挿入後のスキル開始時刻を算出
  - GCD挿入: `max(GCDリキャスト明け, 直前アクション硬直明け)`
  - oGCD挿入: `直前アクション硬直明け`
- 未使用となった`getEntryActionLockTime`、`getActionAvailableAt`を削除

## テスト
- TypeScript型チェック: エラーなし
- Viteビルド: 成功

closes #59