### PR TITLE
refactor: ステータスON/OFFトグルを廃止し常にステータス有効で計算 #67

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -37,7 +37,6 @@ export function App() {
   const [level, setLevel] = useState<PlayerLevel>(100);
   const [entries, setEntries] = useState<TimelineEntry[]>([]);
   const [stats, setStats] = useState<CharacterStats>(DEFAULT_STATS);
-  const [statsEnabled, setStatsEnabled] = useState(false);
   const [untargetableWindows, setUntargetableWindows] = useState<BossUntargetableWindow[]>([]);
   const [ppsRange, setPpsRange] = useState<PpsRange | null>(null);
 
@@ -80,8 +79,8 @@ export function App() {
   );
 
   const timelineResult = useMemo(
-    () => resolveTimeline(entries, skillMap, levelResources, statsEnabled ? stats : undefined, levelBuffs, untargetableWindows),
-    [entries, skillMap, levelResources, stats, statsEnabled, levelBuffs, untargetableWindows]
+    () => resolveTimeline(entries, skillMap, levelResources, stats, levelBuffs, untargetableWindows),
+    [entries, skillMap, levelResources, stats, levelBuffs, untargetableWindows]
   );
 
   const resolvedEntries = timelineResult.entries;
@@ -117,13 +116,12 @@ export function App() {
   const totalPotency = directPotency + timelineResult.dotTotalPotency;
 
   const expectedMultiplier = useMemo(
-    () => (statsEnabled ? calcExpectedMultiplier(stats) : null),
-    [stats, statsEnabled]
+    () => calcExpectedMultiplier(stats),
+    [stats]
   );
 
   // per-entryのクリティカル率ボーナスを考慮した合計期待威力
   const totalExpectedPotency = useMemo(() => {
-    if (!statsEnabled) return null;
     const directExpected = resolvedEntries.reduce((sum, entry) => {
       const hasError = entry.resourceErrors.length > 0 || entry.comboErrors.length > 0 || entry.untargetableError || entry.recastError;
       if (hasError) return sum;
@@ -135,7 +133,7 @@ export function App() {
     // DoTはスナップショット時のバフ倍率が既に適用済み、基本の期待倍率を掛ける
     const dotExpected = Math.floor(timelineResult.dotTotalPotency * calcExpectedMultiplier(stats));
     return directExpected + dotExpected;
-  }, [statsEnabled, stats, resolvedEntries, skillMap, timelineResult.dotTotalPotency]);
+  }, [stats, resolvedEntries, skillMap, timelineResult.dotTotalPotency]);
 
   // 全体PPS: 0 〜 最後のGCDリキャスト完了まで（DoTは最終GCDまでで打ち切り）
   const overallPps = useMemo(() => {
@@ -145,9 +143,10 @@ export function App() {
       skillMap,
       timelineResult.dotTicks,
       0,
-      timelineResult.lastGcdEndTime
+      timelineResult.lastGcdEndTime,
+      stats
     );
-  }, [resolvedEntries, skillMap, timelineResult.dotTicks, timelineResult.lastGcdEndTime]);
+  }, [resolvedEntries, skillMap, timelineResult.dotTicks, timelineResult.lastGcdEndTime, stats]);
 
   // 範囲選択PPS
   const rangePps = useMemo(() => {
@@ -157,9 +156,10 @@ export function App() {
       skillMap,
       timelineResult.dotTicks,
       ppsRange.startTime,
-      ppsRange.endTime
+      ppsRange.endTime,
+      stats
     );
-  }, [resolvedEntries, skillMap, timelineResult.dotTicks, ppsRange]);
+  }, [resolvedEntries, skillMap, timelineResult.dotTicks, ppsRange, stats]);
 
   return (
     <div style={styles.app}>
@@ -171,9 +171,7 @@ export function App() {
         <SkillPalette
           skills={skills}
           stats={stats}
-          statsEnabled={statsEnabled}
           onStatsChange={setStats}
-          onStatsEnabledChange={setStatsEnabled}
           level={level}
           onLevelChange={setLevel}
           selectedJob={selectedJob}
@@ -189,8 +187,7 @@ export function App() {
           buffs={levelBuffs}
           expectedMultiplier={expectedMultiplier}
           totalExpectedPotency={totalExpectedPotency}
-          statsEnabled={statsEnabled}
-          stats={statsEnabled ? stats : undefined}
+          stats={stats}
           dotTicks={timelineResult.dotTicks}
           activeDoTs={timelineResult.activeDoTs}
           dotTotalPotency={timelineResult.dotTotalPotency}

--- a/src/client/components/SkillPalette.tsx
+++ b/src/client/components/SkillPalette.tsx
@@ -36,9 +36,7 @@ function CollapsibleSection({ title, defaultOpen = true, children }: Collapsible
 interface SkillPaletteProps {
   skills: Skill[];
   stats: CharacterStats;
-  statsEnabled: boolean;
   onStatsChange: (stats: CharacterStats) => void;
-  onStatsEnabledChange: (enabled: boolean) => void;
   level: PlayerLevel;
   onLevelChange: (level: PlayerLevel) => void;
   selectedJob: JobId;
@@ -48,9 +46,7 @@ interface SkillPaletteProps {
 export function SkillPalette({
   skills,
   stats,
-  statsEnabled,
   onStatsChange,
-  onStatsEnabledChange,
   level,
   onLevelChange,
   selectedJob,
@@ -117,27 +113,7 @@ export function SkillPalette({
 
       {/* ステータス入力セクション */}
       <CollapsibleSection title="ステータス">
-        <div style={styles.statHeader}>
-          <label style={styles.toggleLabel}>
-            <input
-              type="checkbox"
-              checked={statsEnabled}
-              onChange={(e) => onStatsEnabledChange(e.target.checked)}
-              style={styles.checkbox}
-            />
-            <span style={{
-              ...styles.toggleText,
-              color: statsEnabled ? "#4fc3f7" : "#666",
-            }}>
-              {statsEnabled ? "ON" : "OFF"}
-            </span>
-          </label>
-        </div>
-        <div style={{
-          ...styles.statInputs,
-          opacity: statsEnabled ? 1 : 0.4,
-          pointerEvents: statsEnabled ? "auto" : "none",
-        }}>
+        <div style={styles.statInputs}>
           <div style={styles.statRow}>
             <label style={styles.statLabel}>CRT</label>
             <input
@@ -335,30 +311,10 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: "4px",
     border: "1px solid rgba(255, 167, 38, 0.3)",
   },
-  statHeader: {
-    display: "flex",
-    justifyContent: "flex-end",
-    alignItems: "center",
-    marginBottom: "8px",
-  },
-  toggleLabel: {
-    display: "flex",
-    alignItems: "center",
-    gap: "4px",
-    cursor: "pointer",
-  },
-  checkbox: {
-    cursor: "pointer",
-  },
-  toggleText: {
-    fontSize: "12px",
-    fontWeight: "bold",
-  },
   statInputs: {
     display: "flex",
     flexDirection: "column",
     gap: "6px",
-    transition: "opacity 0.2s",
   },
   statRow: {
     display: "flex",

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -41,10 +41,9 @@ interface TimelineProps {
   totalPotency: number;
   resources: ResourceDefinition[];
   buffs: BuffDefinition[];
-  expectedMultiplier: number | null;
-  totalExpectedPotency: number | null;
-  statsEnabled: boolean;
-  stats?: CharacterStats;
+  expectedMultiplier: number;
+  totalExpectedPotency: number;
+  stats: CharacterStats;
   dotTicks: DoTTick[];
   activeDoTs: ActiveDoT[];
   dotTotalPotency: number;
@@ -105,7 +104,6 @@ export function Timeline({
   buffs,
   expectedMultiplier,
   totalExpectedPotency,
-  statsEnabled,
   stats,
   dotTicks,
   activeDoTs,
@@ -607,7 +605,7 @@ export function Timeline({
                 {" "}(DoT: {dotTotalPotency})
               </span>
             )}
-            {totalExpectedPotency !== null && (
+            {totalExpectedPotency > 0 && (
               <span style={styles.expectedPotency}>
                 {" "}(期待値: {totalExpectedPotency})
               </span>

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -12,7 +12,7 @@ import type {
   TimelineResult,
   BossUntargetableWindow,
 } from "../types/skill";
-import { calcGcd } from "./stat-calc";
+import { calcGcd, calcExpectedMultiplier } from "./stat-calc";
 
 /** DoTティック間隔（秒） */
 const DOT_TICK_INTERVAL = 3;
@@ -492,7 +492,8 @@ export function calcPps(
   skillMap: Map<string, Skill>,
   dotTicks: DoTTick[],
   rangeStart: number,
-  rangeEnd: number
+  rangeEnd: number,
+  stats: CharacterStats
 ): { pps: number; totalPotency: number; directPotency: number; dotPotency: number } {
   const duration = rangeEnd - rangeStart;
   if (duration <= 0) return { pps: 0, totalPotency: 0, directPotency: 0, dotPotency: 0 };
@@ -504,14 +505,17 @@ export function calcPps(
       const hasError = entry.resourceErrors.length > 0 || entry.comboErrors.length > 0 || entry.untargetableError || entry.recastError;
       if (hasError) continue;
       const skill = skillMap.get(entry.skillId);
-      directPotency += Math.floor((skill?.potency ?? 0) * entry.buffMultiplier);
+      const buffedPotency = Math.floor((skill?.potency ?? 0) * entry.buffMultiplier);
+      const entryMul = calcExpectedMultiplier(stats, entry.critRateBonus);
+      directPotency += Math.floor(buffedPotency * entryMul);
     }
   }
 
   let dotPotency = 0;
+  const dotMul = calcExpectedMultiplier(stats);
   for (const tick of dotTicks) {
     if (tick.time >= rangeStart && tick.time < rangeEnd) {
-      dotPotency += tick.potency;
+      dotPotency += Math.floor(tick.potency * dotMul);
     }
   }
 


### PR DESCRIPTION
## 概要
ステータスON/OFFの切り替え機能を廃止し、常にステータスON（CRT/DH/DET/SS有効）の状態で威力計算を行うようにした。
PPS計算も期待値ベース（クリティカル・DH・DET補正込み）で算出するように変更。

## 変更点
- `statsEnabled`ステートとON/OFFチェックボックスUIを削除
- `resolveTimeline`に常に`stats`を渡すように変更（GCD短縮が常に有効に）
- `calcPps`関数に`stats`パラメータを追加し、エントリごとの期待値倍率（`calcExpectedMultiplier`）を適用
- DoTのPPS計算にも基本の期待値倍率を適用
- `Timeline`コンポーネントの`expectedMultiplier`/`totalExpectedPotency`の型を`number | null`から`number`に変更

## テスト
- Viteビルド成功を確認
- TypeScript型チェックでプロジェクト固有エラー以外の新規エラーなし

closes #67