### PR TITLE
fix: autoTransform対象スキルをジョブパレットから除外 #76

### DIFF
--- a/src/client/logic/__tests__/skill-level.test.ts
+++ b/src/client/logic/__tests__/skill-level.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { getSkillsForLevel } from "../skill-level";
+import type { Skill, PlayerLevel } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+describe("getSkillsForLevel", () => {
+  describe("autoTransform変換先スキルのフィルタリング", () => {
+    it("autoTransformの変換先スキルがパレットから除外される", () => {
+      const skills: Skill[] = [
+        makeSkill({
+          id: "true-thrust",
+          autoTransform: { buffId: "dragons-eye", skillId: "raiden-thrust" },
+        }),
+        makeSkill({ id: "raiden-thrust", acquiredLevel: 76 }),
+      ];
+
+      const result = getSkillsForLevel(skills, 100 as PlayerLevel, new Set(), new Set());
+
+      const ids = result.map((s) => s.id);
+      expect(ids).toContain("true-thrust");
+      expect(ids).not.toContain("raiden-thrust");
+    });
+
+    it("autoTransformの変換元スキルはパレットに残る", () => {
+      const skills: Skill[] = [
+        makeSkill({
+          id: "doom-spike",
+          autoTransform: { buffId: "dragons-eye", skillId: "draconian-fury" },
+        }),
+        makeSkill({ id: "draconian-fury", acquiredLevel: 82 }),
+        makeSkill({ id: "other-skill" }),
+      ];
+
+      const result = getSkillsForLevel(skills, 100 as PlayerLevel, new Set(), new Set());
+
+      const ids = result.map((s) => s.id);
+      expect(ids).toContain("doom-spike");
+      expect(ids).toContain("other-skill");
+      expect(ids).not.toContain("draconian-fury");
+    });
+
+    it("変換先スキルが未習得の場合でもフィルタリングが正しく動作する", () => {
+      const skills: Skill[] = [
+        makeSkill({
+          id: "true-thrust",
+          autoTransform: { buffId: "dragons-eye", skillId: "raiden-thrust" },
+        }),
+        makeSkill({ id: "raiden-thrust", acquiredLevel: 76 }),
+      ];
+
+      // Lv70ではraiden-thrustは未習得なのでそもそもフィルタ対象外
+      const result = getSkillsForLevel(skills, 70 as PlayerLevel, new Set(), new Set());
+
+      const ids = result.map((s) => s.id);
+      expect(ids).toContain("true-thrust");
+      expect(ids).not.toContain("raiden-thrust");
+    });
+
+    it("replacesSkillIdフィルタリングに影響しない", () => {
+      const skills: Skill[] = [
+        makeSkill({ id: "full-thrust", acquiredLevel: 26 }),
+        makeSkill({ id: "heavens-thrust", acquiredLevel: 86, replacesSkillId: "full-thrust" }),
+      ];
+
+      const result = getSkillsForLevel(skills, 100 as PlayerLevel, new Set(), new Set());
+
+      const ids = result.map((s) => s.id);
+      expect(ids).toContain("heavens-thrust");
+      expect(ids).not.toContain("full-thrust");
+    });
+  });
+});

--- a/src/client/logic/skill-level.ts
+++ b/src/client/logic/skill-level.ts
@@ -51,7 +51,15 @@ export function getSkillsForLevel(
       .filter((s) => s.replacesSkillId)
       .map((s) => s.replacesSkillId!),
   );
-  const filtered = available.filter((s) => !replacedIds.has(s.id));
+
+  // 3. autoTransformの変換先スキルを除外（パレットには変換元のみ表示）
+  const autoTransformTargetIds = new Set(
+    available
+      .filter((s) => s.autoTransform)
+      .map((s) => s.autoTransform!.skillId),
+  );
+
+  const filtered = available.filter((s) => !replacedIds.has(s.id) && !autoTransformTargetIds.has(s.id));
 
   // 3. 特性による威力変動を適用
   // 4. レベル未満のバフ・リソースへの参照を除外


### PR DESCRIPTION
## 概要

`autoTransform` の変換先スキル（竜眼雷電、竜眼蒼穹など）がジョブパレットに表示されていた問題を修正。

## 変更点

- `skill-level.ts` の `getSkillsForLevel` に `autoTransform.skillId` で参照されるスキルを除外するフィルタリングを追加
- 既存の `replacesSkillId` フィルタリングと同じパターンで実装
- `skill-level.test.ts` にユニットテスト4件を追加

## テスト

- `npx vitest run` で全12テスト通過（既存8件 + 新規4件）
- テストケース:
  - autoTransform変換先スキルがパレットから除外される
  - 変換元スキルはパレットに残る
  - 変換先スキルが未習得レベルでも正しくフィルタされる
  - 既存のreplacesSkillIdフィルタリングに影響がない

closes #76