### PR TITLE
fix: スキル自身が付与するバフを威力計算から除外 #78

### DIFF
--- a/src/client/logic/__tests__/buff-potency-timing.test.ts
+++ b/src/client/logic/__tests__/buff-potency-timing.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("バフ適用タイミングと威力計算", () => {
+  const potencyBuff: BuffDefinition = {
+    id: "power-buff",
+    name: "パワーバフ",
+    shortName: "パワー",
+    icon: "",
+    duration: 20,
+    effects: [{ type: "potency", value: 1.1 }],
+    color: "#ff0000",
+  };
+
+  it("スキル自身が付与するバフ（buffApplications）は自分の威力倍率に含まれない", () => {
+    const buffSkill = makeSkill({
+      id: "buff-attack",
+      potency: 200,
+      buffApplications: ["power-buff"],
+    });
+    const nextSkill = makeSkill({ id: "next-attack", potency: 100 });
+    const skillMap = new Map([
+      [buffSkill.id, buffSkill],
+      [nextSkill.id, nextSkill],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("buff-attack"), makeEntry("next-attack")],
+      skillMap,
+      [],
+      undefined,
+      [potencyBuff],
+    );
+
+    // バフ付与スキル自身: バフは適用されない → 倍率1.0
+    expect(result.entries[0].buffMultiplier).toBe(1);
+    // 次のスキル: バフが適用される → 倍率1.1
+    expect(result.entries[1].buffMultiplier).toBeCloseTo(1.1);
+  });
+
+  it("スキル自身が付与するバフ（comboBuffApplications）は自分の威力倍率に含まれない", () => {
+    const comboStart = makeSkill({ id: "combo-start", potency: 100 });
+    const comboBuffSkill = makeSkill({
+      id: "combo-buff-attack",
+      potency: 200,
+      comboFrom: ["combo-start"],
+      comboBuffApplications: ["power-buff"],
+    });
+    const nextSkill = makeSkill({ id: "next-attack", potency: 100 });
+    const skillMap = new Map([
+      [comboStart.id, comboStart],
+      [comboBuffSkill.id, comboBuffSkill],
+      [nextSkill.id, nextSkill],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("combo-start"), makeEntry("combo-buff-attack"), makeEntry("next-attack")],
+      skillMap,
+      [],
+      undefined,
+      [potencyBuff],
+    );
+
+    // コンボバフ付与スキル: バフは自分に適用されない → 倍率1.0
+    expect(result.entries[1].buffMultiplier).toBe(1);
+    // 次のスキル: バフが適用される → 倍率1.1
+    expect(result.entries[2].buffMultiplier).toBeCloseTo(1.1);
+  });
+
+  it("既存のバフは引き続きスキルに適用される", () => {
+    const buffSkill = makeSkill({
+      id: "buff-only",
+      type: "ogcd",
+      potency: 0,
+      recastTime: 0.65,
+      buffApplications: ["power-buff"],
+    });
+    const attack1 = makeSkill({ id: "attack-1", potency: 100 });
+    const attack2 = makeSkill({ id: "attack-2", potency: 100 });
+    const skillMap = new Map([
+      [buffSkill.id, buffSkill],
+      [attack1.id, attack1],
+      [attack2.id, attack2],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("attack-1"), makeEntry("buff-only"), makeEntry("attack-2")],
+      skillMap,
+      [],
+      undefined,
+      [potencyBuff],
+    );
+
+    // バフ適用前: 倍率1.0
+    expect(result.entries[0].buffMultiplier).toBe(1);
+    // バフ適用後の攻撃: 倍率1.1
+    expect(result.entries[2].buffMultiplier).toBeCloseTo(1.1);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -410,6 +410,11 @@ export function resolveTimeline(
     // （wsComboErrorはハードエラーではない: スキルは実行されるが非コンボ威力になる）
     const hasError = resourceErrors.length > 0 || comboErrors.length > 0 || untargetableError || recastError;
 
+    // 威力倍率・クリティカル判定をバフ適用前に計算（スキル自身が付与するバフは自分には適用されない）
+    const buffMultiplierBeforeApply = hasError ? 1 : getPotencyMultiplier(currentActiveBuffs, buffDefMap);
+    const guaranteedCritBeforeApply = !hasError && skill.type === "gcd" && hasGuaranteedCrit(currentActiveBuffs, buffDefMap);
+    const critRateBonusBeforeApply = hasError ? 0 : (guaranteedCritBeforeApply ? 1 : getCritRateBonus(currentActiveBuffs, buffDefMap));
+
     if (!hasError) {
       // リソース変動を適用
       if (skill.resourceChanges) {
@@ -534,7 +539,7 @@ export function resolveTimeline(
       // DoT適用: スキルにdotPotency/dotDurationがあればDoTを適用
       // コンボ不成立時はDoTを適用しない（コンボ成立時の追加効果扱い）
       if (skill.dotPotency && skill.dotDuration && !wsComboError) {
-        const buffMultiplier = getPotencyMultiplier(currentActiveBuffs, buffDefMap);
+        const buffMultiplier = buffMultiplierBeforeApply;
         const endTime = Math.round((startTime + skill.dotDuration) * 1000) / 1000;
 
         const existing = dotStreams.get(skill.id);
@@ -556,11 +561,10 @@ export function resolveTimeline(
       }
     }
 
-    // エラーがない場合のみバフ倍率を適用
-    const buffMultiplier = hasError ? 1 : getPotencyMultiplier(currentActiveBuffs, buffDefMap);
-    // GCDスキルに確定クリティカルバフが適用される場合、クリティカル率を100%にする
-    const guaranteedCrit = !hasError && skill.type === "gcd" && hasGuaranteedCrit(currentActiveBuffs, buffDefMap);
-    const critRateBonus = hasError ? 0 : (guaranteedCrit ? 1 : getCritRateBonus(currentActiveBuffs, buffDefMap));
+    // バフ適用前に計算済みの値を使用（スキル自身が付与するバフは自分の威力に含めない）
+    const buffMultiplier = buffMultiplierBeforeApply;
+    const guaranteedCrit = guaranteedCritBeforeApply;
+    const critRateBonus = critRateBonusBeforeApply;
 
     // GCDスキル実行後、確定クリティカルバフを自動消費
     if (!hasError && skill.type === "gcd" && guaranteedCrit) {


### PR DESCRIPTION
## 概要

スキルが付与するバフ（`buffApplications` / `comboBuffApplications`）がそのスキル自体の威力倍率に含まれていた問題を修正。FF14の仕様ではバフは次のスキル以降に適用される。

## 変更点

- `resolve-timeline.ts` で威力倍率・クリティカル判定をバフ適用ブロックの**前**に移動
- DoTスナップショットのバフ倍率もバフ適用前の値を使用するよう修正
- `buff-potency-timing.test.ts` にユニットテスト3件を追加

## テスト

- `npx vitest run` で全15テスト通過（既存12件 + 新規3件）
- テストケース:
  - `buffApplications` で付与されるバフが自分の威力倍率に含まれない
  - `comboBuffApplications` で付与されるバフが自分の威力倍率に含まれない
  - 既存のバフは引き続き正しく適用される

closes #78