### PR TITLE
fix: 竜騎士アビリティにバフ条件による使用制限を追加 #80

### DIFF
--- a/src/client/data/drg-buffs.ts
+++ b/src/client/data/drg-buffs.ts
@@ -6,6 +6,11 @@ import lifeSurgeIcon from "../assets/icons/drg/Life_Surge.png";
 import lifeOfTheDragonIcon from "../assets/icons/drg/traits/Life_of_the_Dragon.png";
 import raidenThrustIcon from "../assets/icons/drg/Raiden_Thrust.png";
 import disembowelIcon from "../assets/icons/drg/Disembowel.png";
+import mirageDiveIcon from "../assets/icons/drg/Mirage_Dive.png";
+import dragonfireDiveIcon from "../assets/icons/drg/Dragonfire_Dive.png";
+import nastrondIcon from "../assets/icons/drg/Nastrond.png";
+import stardiverIcon from "../assets/icons/drg/Stardiver.png";
+import starcrossIcon from "../assets/icons/drg/Starcross.png";
 
 /**
  * 竜騎士（DRG）バフ定義
@@ -99,5 +104,60 @@ export const DRG_BUFFS: BuffDefinition[] = [
     ],
     color: "#f44336",
     acquiredLevel: 70,
+  },
+  {
+    id: "dive-ready",
+    name: "ダイブレディ",
+    shortName: "ﾀﾞｲﾌﾞ\nﾚﾃﾞｨ",
+    icon: mirageDiveIcon,
+    duration: 15,
+    effects: [],
+    color: "#7c4dff",
+    maxStacks: 1,
+    acquiredLevel: 68,
+  },
+  {
+    id: "dragons-flight",
+    name: "ドラゴンフライト",
+    shortName: "ﾄﾞﾗｺﾞﾝ\nﾌﾗｲﾄ",
+    icon: dragonfireDiveIcon,
+    duration: 30,
+    effects: [],
+    color: "#ff6d00",
+    maxStacks: 1,
+    acquiredLevel: 92,
+  },
+  {
+    id: "nastrond-ready",
+    name: "ナーストレンドレディ",
+    shortName: "ﾅｰｽ\nﾚﾃﾞｨ",
+    icon: nastrondIcon,
+    duration: 20,
+    effects: [],
+    color: "#d50000",
+    maxStacks: 1,
+    acquiredLevel: 70,
+  },
+  {
+    id: "stardiver-ready",
+    name: "スターダイバーレディ",
+    shortName: "ｽﾀﾀﾞｲ\nﾚﾃﾞｨ",
+    icon: stardiverIcon,
+    duration: 20,
+    effects: [],
+    color: "#aa00ff",
+    maxStacks: 1,
+    acquiredLevel: 80,
+  },
+  {
+    id: "starcross-ready",
+    name: "スタークロスレディ",
+    shortName: "ｽﾀｸﾛ\nﾚﾃﾞｨ",
+    icon: starcrossIcon,
+    duration: 20,
+    effects: [],
+    color: "#6200ea",
+    maxStacks: 1,
+    acquiredLevel: 100,
   },
 ];

--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -387,6 +387,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 30,
     acquiredLevel: 30,
+    buffApplications: ["dive-ready"],
   },
   {
     id: "high-jump",
@@ -400,6 +401,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     cooldown: 30,
     acquiredLevel: 74,
     replacesSkillId: "jump",
+    buffApplications: ["dive-ready"],
   },
   {
     id: "mirage-dive",
@@ -412,6 +414,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 1,
     acquiredLevel: 68,
+    buffConsumptions: [{ buffId: "dive-ready", stacks: 1 }],
   },
   {
     id: "dragonfire-dive",
@@ -424,6 +427,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 120,
     acquiredLevel: 50,
+    buffApplications: ["dragons-flight"],
   },
   {
     id: "rise-of-the-dragon",
@@ -436,6 +440,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 1,
     acquiredLevel: 92,
+    buffConsumptions: [{ buffId: "dragons-flight", stacks: 1 }],
   },
   {
     id: "stardiver",
@@ -448,6 +453,8 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 30,
     acquiredLevel: 80,
+    buffConsumptions: [{ buffId: "stardiver-ready", stacks: 1 }],
+    buffApplications: ["starcross-ready"],
   },
   {
     id: "starcross",
@@ -460,6 +467,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 1,
     acquiredLevel: 100,
+    buffConsumptions: [{ buffId: "starcross-ready", stacks: 1 }],
   },
 
   // ============================================================
@@ -476,7 +484,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 60,
     acquiredLevel: 60,
-    buffApplications: ["life-of-the-dragon"],
+    buffApplications: ["life-of-the-dragon", "nastrond-ready", "stardiver-ready"],
     traitPotencyOverrides: [
       { traitLevel: 90, potency: 280 },
     ],
@@ -492,6 +500,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 2,
     acquiredLevel: 70,
+    buffConsumptions: [{ buffId: "nastrond-ready", stacks: 1 }],
     traitPotencyOverrides: [
       { traitLevel: 90, potency: 720 },
     ],

--- a/src/client/logic/__tests__/drg-buff-conditions.test.ts
+++ b/src/client/logic/__tests__/drg-buff-conditions.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "ogcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 0.65,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+/** テスト用のレディバフ定義 */
+function makeReadyBuff(id: string): BuffDefinition {
+  return {
+    id,
+    name: id,
+    shortName: id,
+    icon: "",
+    duration: 20,
+    effects: [],
+    color: "#000",
+    maxStacks: 1,
+  };
+}
+
+describe("竜騎士バフ条件による使用制限", () => {
+  const diveReady = makeReadyBuff("dive-ready");
+  const dragonsFlightBuff = makeReadyBuff("dragons-flight");
+  const nastrondReady = makeReadyBuff("nastrond-ready");
+  const stardiverReady = makeReadyBuff("stardiver-ready");
+  const starcrossReady = makeReadyBuff("starcross-ready");
+
+  const allBuffs = [diveReady, dragonsFlightBuff, nastrondReady, stardiverReady, starcrossReady];
+
+  describe("ミラージュダイブ → ダイブレディが必要", () => {
+    it("ダイブレディなしで使用するとcomboErrorになる", () => {
+      const mirageDive = makeSkill({
+        id: "mirage-dive",
+        buffConsumptions: [{ buffId: "dive-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([[mirageDive.id, mirageDive]]);
+
+      const result = resolveTimeline([makeEntry("mirage-dive")], skillMap, [], undefined, allBuffs);
+
+      expect(result.entries[0].comboErrors).toContain("dive-ready");
+    });
+
+    it("ハイジャンプ後にダイブレディが付与されミラージュダイブが使える", () => {
+      const highJump = makeSkill({
+        id: "high-jump",
+        cooldown: 30,
+        buffApplications: ["dive-ready"],
+      });
+      const mirageDive = makeSkill({
+        id: "mirage-dive",
+        buffConsumptions: [{ buffId: "dive-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([
+        [highJump.id, highJump],
+        [mirageDive.id, mirageDive],
+      ]);
+
+      const result = resolveTimeline(
+        [makeEntry("high-jump"), makeEntry("mirage-dive")],
+        skillMap, [], undefined, allBuffs,
+      );
+
+      expect(result.entries[0].comboErrors).toHaveLength(0);
+      expect(result.entries[1].comboErrors).toHaveLength(0);
+    });
+  });
+
+  describe("ドラゴンライズ → ドラゴンフライトが必要", () => {
+    it("ドラゴンフライトなしで使用するとcomboErrorになる", () => {
+      const riseOfDragon = makeSkill({
+        id: "rise-of-the-dragon",
+        buffConsumptions: [{ buffId: "dragons-flight", stacks: 1 }],
+      });
+      const skillMap = new Map([[riseOfDragon.id, riseOfDragon]]);
+
+      const result = resolveTimeline([makeEntry("rise-of-the-dragon")], skillMap, [], undefined, allBuffs);
+
+      expect(result.entries[0].comboErrors).toContain("dragons-flight");
+    });
+
+    it("ドラゴンダイブ後にドラゴンフライトが付与されドラゴンライズが使える", () => {
+      const dragonfireDive = makeSkill({
+        id: "dragonfire-dive",
+        cooldown: 120,
+        buffApplications: ["dragons-flight"],
+      });
+      const riseOfDragon = makeSkill({
+        id: "rise-of-the-dragon",
+        buffConsumptions: [{ buffId: "dragons-flight", stacks: 1 }],
+      });
+      const skillMap = new Map([
+        [dragonfireDive.id, dragonfireDive],
+        [riseOfDragon.id, riseOfDragon],
+      ]);
+
+      const result = resolveTimeline(
+        [makeEntry("dragonfire-dive"), makeEntry("rise-of-the-dragon")],
+        skillMap, [], undefined, allBuffs,
+      );
+
+      expect(result.entries[0].comboErrors).toHaveLength(0);
+      expect(result.entries[1].comboErrors).toHaveLength(0);
+    });
+  });
+
+  describe("ナーストレンド → ナーストレンドレディが必要", () => {
+    it("ナーストレンドレディなしで使用するとcomboErrorになる", () => {
+      const nastrond = makeSkill({
+        id: "nastrond",
+        buffConsumptions: [{ buffId: "nastrond-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([[nastrond.id, nastrond]]);
+
+      const result = resolveTimeline([makeEntry("nastrond")], skillMap, [], undefined, allBuffs);
+
+      expect(result.entries[0].comboErrors).toContain("nastrond-ready");
+    });
+  });
+
+  describe("ゲイルスコグル → ナーストレンド・スターダイバーの連携", () => {
+    it("ゲイルスコグル後にナーストレンドとスターダイバーが使える", () => {
+      const geirskogul = makeSkill({
+        id: "geirskogul",
+        cooldown: 60,
+        buffApplications: ["life-of-the-dragon", "nastrond-ready", "stardiver-ready"],
+      });
+      const nastrond = makeSkill({
+        id: "nastrond",
+        cooldown: 2,
+        buffConsumptions: [{ buffId: "nastrond-ready", stacks: 1 }],
+      });
+      const stardiver = makeSkill({
+        id: "stardiver",
+        cooldown: 30,
+        buffConsumptions: [{ buffId: "stardiver-ready", stacks: 1 }],
+        buffApplications: ["starcross-ready"],
+      });
+      const skillMap = new Map([
+        [geirskogul.id, geirskogul],
+        [nastrond.id, nastrond],
+        [stardiver.id, stardiver],
+      ]);
+
+      const result = resolveTimeline(
+        [makeEntry("geirskogul"), makeEntry("nastrond"), makeEntry("stardiver")],
+        skillMap, [], undefined, [...allBuffs],
+      );
+
+      expect(result.entries[0].comboErrors).toHaveLength(0);
+      expect(result.entries[1].comboErrors).toHaveLength(0);
+      expect(result.entries[2].comboErrors).toHaveLength(0);
+    });
+
+    it("ナーストレンドを2回使用すると2回目でcomboErrorになる", () => {
+      const geirskogul = makeSkill({
+        id: "geirskogul",
+        cooldown: 60,
+        buffApplications: ["life-of-the-dragon", "nastrond-ready", "stardiver-ready"],
+      });
+      const nastrond = makeSkill({
+        id: "nastrond",
+        cooldown: 2,
+        buffConsumptions: [{ buffId: "nastrond-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([
+        [geirskogul.id, geirskogul],
+        [nastrond.id, nastrond],
+      ]);
+
+      const result = resolveTimeline(
+        [makeEntry("geirskogul"), makeEntry("nastrond"), makeEntry("nastrond")],
+        skillMap, [], undefined, allBuffs,
+      );
+
+      expect(result.entries[1].comboErrors).toHaveLength(0);
+      expect(result.entries[2].comboErrors).toContain("nastrond-ready");
+    });
+  });
+
+  describe("スターダイバー → スタークロッサーの連携", () => {
+    it("スターダイバー後にスタークロッサーが使える", () => {
+      const geirskogul = makeSkill({
+        id: "geirskogul",
+        cooldown: 60,
+        buffApplications: ["life-of-the-dragon", "nastrond-ready", "stardiver-ready"],
+      });
+      const stardiver = makeSkill({
+        id: "stardiver",
+        cooldown: 30,
+        buffConsumptions: [{ buffId: "stardiver-ready", stacks: 1 }],
+        buffApplications: ["starcross-ready"],
+      });
+      const starcross = makeSkill({
+        id: "starcross",
+        cooldown: 1,
+        buffConsumptions: [{ buffId: "starcross-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([
+        [geirskogul.id, geirskogul],
+        [stardiver.id, stardiver],
+        [starcross.id, starcross],
+      ]);
+
+      const result = resolveTimeline(
+        [makeEntry("geirskogul"), makeEntry("stardiver"), makeEntry("starcross")],
+        skillMap, [], undefined, allBuffs,
+      );
+
+      expect(result.entries[0].comboErrors).toHaveLength(0);
+      expect(result.entries[1].comboErrors).toHaveLength(0);
+      expect(result.entries[2].comboErrors).toHaveLength(0);
+    });
+
+    it("スターダイバーなしでスタークロッサーを使用するとcomboErrorになる", () => {
+      const starcross = makeSkill({
+        id: "starcross",
+        cooldown: 1,
+        buffConsumptions: [{ buffId: "starcross-ready", stacks: 1 }],
+      });
+      const skillMap = new Map([[starcross.id, starcross]]);
+
+      const result = resolveTimeline([makeEntry("starcross")], skillMap, [], undefined, allBuffs);
+
+      expect(result.entries[0].comboErrors).toContain("starcross-ready");
+    });
+  });
+});


### PR DESCRIPTION
## 概要

竜騎士の特定アビリティに、FF14仕様に準拠したバフ条件による使用制限を追加。条件未達時はタイムライン上でエラー表示される。

## 変更点

### 新規バフ定義（drg-buffs.ts）
- `dive-ready`（ダイブレディ）: ハイジャンプ/ジャンプ後に付与、ミラージュダイブで消費
- `dragons-flight`（ドラゴンフライト）: ドラゴンダイブ後に付与、ドラゴンライズで消費
- `nastrond-ready`（ナーストレンドレディ）: ゲイルスコグル後に付与、ナーストレンドで消費
- `stardiver-ready`（スターダイバーレディ）: ゲイルスコグル後に付与、スターダイバーで消費
- `starcross-ready`（スタークロスレディ）: スターダイバー後に付与、スタークロッサーで消費

### スキルデータ修正（drg-skills.ts）
- ジャンプ/ハイジャンプ: `buffApplications` に `dive-ready` 追加
- ドラゴンダイブ: `buffApplications` に `dragons-flight` 追加
- ゲイルスコグル: `buffApplications` に `nastrond-ready`, `stardiver-ready` 追加
- ミラージュダイブ/ドラゴンライズ/ナーストレンド/スターダイバー/スタークロッサー: `buffConsumptions` 追加
- スターダイバー: `buffApplications` に `starcross-ready` 追加

## テスト

- `npx vitest run` で全24テスト通過（既存15件 + 新規9件）
- テストケース:
  - 各スキルがバフ条件なしで使用するとcomboErrorになる
  - 付与元スキル使用後に条件付きスキルが正常に使える
  - ゲイルスコグル→ナーストレンド・スターダイバーの連携
  - ナーストレンド2回目でエラー（1回消費）
  - スターダイバー→スタークロッサーの連携

closes #80