### PR TITLE
fix: oGCD挿入位置の判定をアニメーションロック基準に修正 #84

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -360,9 +360,19 @@ export function Timeline({
   );
 
   /**
+   * oGCD挿入用の幅関数: アニメーションロックを基準にする。
+   * GCDのリキャスト幅（2.5s）ではなく、アニメーションロック（0.65s）を使うことで、
+   * GCDリキャスト中のウィービング位置を正しく判定する。
+   */
+  const getAnimLockWidth = useCallback(
+    (skill: Skill, _activeBuffs: ActiveBuff[]): number => skill.animationLock,
+    []
+  );
+
+  /**
    * ドラッグ中のマウス位置から挿入インデックス（resolvedEntries上）を計算する。
    * GCD: GCDエントリのみで計算し、combined変換（GCDリキャスト境界間に配置）
-   * oGCD: 全エントリで計算（任意の位置に配置）
+   * oGCD: 全エントリで計算、アニメーションロック基準の中央で判定（ウィービング対応）
    */
   const calcCombinedInsertIndex = useCallback(
     (mouseX: number, scrollLeft: number, type: "gcd" | "ogcd"): number => {
@@ -370,9 +380,9 @@ export function Timeline({
         const gcdIdx = calcInsertIndex(mouseX, scrollLeft, gcdResolvedEntries, skillMap, getEntryRecastTime);
         return mapGcdIndexToCombined(gcdIdx);
       }
-      return calcInsertIndex(mouseX, scrollLeft, resolvedEntries, skillMap, getEntryRecastTime);
+      return calcInsertIndex(mouseX, scrollLeft, resolvedEntries, skillMap, getAnimLockWidth);
     },
-    [resolvedEntries, gcdResolvedEntries, skillMap, getEntryRecastTime, mapGcdIndexToCombined]
+    [resolvedEntries, gcdResolvedEntries, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToCombined]
   );
 
   const handleDragOver = useCallback(


### PR DESCRIPTION
## 概要

oGCDスキルをタイムラインにドラッグ&ドロップする際、挿入予定位置のインジケーターが実際の配置位置とズレる問題を修正。

## 原因

`calcInsertIndex` でoGCD挿入時の判定に、GCDエントリの「リキャスト幅の中央」（startTime + 2.5/2 = startTime + 1.25s）を使用していた。oGCDはGCDリキャスト中にウィービングされるため、リキャスト幅の中央を基準にすると、ユーザーがGCDブロックの後半にドラッグしても「GCDの前に挿入」と判定されてしまう。

## 変更点

- oGCD挿入時はアニメーションロック（0.65s）を基準に中央を計算する `getAnimLockWidth` 関数を追加
- `calcCombinedInsertIndex` でoGCD挿入時に `getAnimLockWidth` を使用するよう変更
- GCD挿入時は従来通り `getEntryRecastTime` を使用（変更なし）

## 修正前後の比較

例: GCD1(t=0) → GCD2(t=2.5) のタイムラインでt=1.0地点にoGCDをドラッグ

| | 判定基準 | 結果 |
|------|---------|------|
| 修正前 | GCD1 center = 1.25 → 1.0 < 1.25 | GCD1の前に挿入（❌） |
| 修正後 | GCD1 center = 0.325 → 1.0 > 0.325 | GCD1の後に挿入（✅） |

## テスト

- `npx vitest run` で全30テスト通過
- TypeScript型チェック通過

closes #84