### PR TITLE
fix: リソースドットの半透明boxShadow蓄積による色濃化を修正 #85

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -955,10 +955,6 @@ export function Timeline({
                                     i < count
                                       ? res.color
                                       : "rgba(255,255,255,0.15)",
-                                  boxShadow:
-                                    i < count
-                                      ? `0 0 4px ${res.color}80`
-                                      : "none",
                                 }}
                               />
                             ))}


### PR DESCRIPTION
## 概要

天竜眼（リソースゲージ）のスタック表示色がスキル追加・削除で段々濃くなる問題を修正。

## 原因

`resourceMarker` が `position: absolute` で各エントリの `startTime` に配置されるため、近い時刻のエントリ（GCDとoGCD等）のマーカーが同じ位置に重なる。各ドットの `boxShadow: 0 0 4px ${res.color}80`（50%透明度）が視覚的に蓄積し、色が濃く見えていた。

## 変更点

- リソースドットから `boxShadow` を削除
- `backgroundColor`（不透明）のみで表示するため、重なっても色が変わらない

## テスト

- `npx vitest run` で全30テスト通過
- TypeScript型チェック通過

closes #85