### PR TITLE
fix: タイムラインの縦方向スクロールを有効化 #86

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1292,7 +1292,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   scrollContainer: {
     overflowX: "auto",
-    overflowY: "hidden",
+    overflowY: "auto",
     flex: 1,
     minHeight: 0,
     padding: "12px 0",


### PR DESCRIPTION
## 概要

タイムラインの `scrollContainer` で `overflowY: "hidden"` が設定されていたため、バフ・リキャスト・リソースのレーンが多い場合に縦方向にスクロールできない問題を修正。

## 変更点

- `Timeline.tsx` の `scrollContainer` スタイルで `overflowY: "hidden"` → `overflowY: "auto"` に変更

## テスト

- `npx vitest run` で全30テスト通過
- TypeScript型チェック通過

closes #86