### PR TITLE
fix: ドラッグオーバーのrAFスロットリングでクラッシュを防止 #88

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -130,6 +130,8 @@ export function Timeline({
   const scrollRef = useRef<HTMLDivElement>(null);
   /** 末尾追加時のみ自動スクロールするためのフラグ */
   const shouldAutoScrollRef = useRef(true);
+  /** ドラッグオーバーのrAFスロットリング用 */
+  const dragRafRef = useRef<number | null>(null);
 
   const handleRemoveEntry = useCallback(
     (uid: string) => {
@@ -389,31 +391,46 @@ export function Timeline({
     (e: React.DragEvent) => {
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
-      setDragOver(true);
+
+      // rAFでスロットリング: 前フレームの更新がまだ処理中なら新しいリクエストをスキップ
+      if (dragRafRef.current !== null) return;
 
       const type = detectDragType(e);
-      setDragType(type);
+      const mouseX = scrollRef.current ? e.clientX - scrollRef.current.getBoundingClientRect().left : 0;
+      const scrollLeft = scrollRef.current?.scrollLeft ?? 0;
 
-      if (scrollRef.current && resolvedEntries.length > 0) {
-        const rect = scrollRef.current.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-        const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
-        setInsertIndex(idx);
-      } else {
-        setInsertIndex(null);
-      }
+      dragRafRef.current = requestAnimationFrame(() => {
+        dragRafRef.current = null;
+        setDragOver(true);
+        setDragType(type);
+
+        if (scrollRef.current && resolvedEntries.length > 0) {
+          const idx = calcCombinedInsertIndex(mouseX, scrollLeft, type);
+          setInsertIndex(idx);
+        } else {
+          setInsertIndex(null);
+        }
+      });
     },
     [resolvedEntries, detectDragType, calcCombinedInsertIndex]
   );
 
   const handleDragLeave = useCallback(() => {
+    if (dragRafRef.current !== null) {
+      cancelAnimationFrame(dragRafRef.current);
+      dragRafRef.current = null;
+    }
     setDragOver(false);
     setInsertIndex(null);
     setDragType(null);
   }, []);
 
   const handleDrop = useCallback(
-    (e: React.DragEvent) => {
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (dragRafRef.current !== null) {
+        cancelAnimationFrame(dragRafRef.current);
+        dragRafRef.current = null;
+      }
       e.preventDefault();
       setDragOver(false);
 


### PR DESCRIPTION
## 概要

スキルのドラッグ&ドロップ時にChromeがクラッシュする問題を修正。`handleDragOver` の高頻度発火による大量の再レンダリングが原因。

## 原因

`dragover` イベントはマウス移動中に毎フレーム（数十回/秒）発火し、毎回3つの `setState`（`setDragOver`, `setDragType`, `setInsertIndex`）が呼ばれていた。これにより毎フレームでReact再レンダリングが走り、タイムラインの重い描画処理（多数のレーン・バフバー・リソースマーカー等）が繰り返されてブラウザが応答不能になっていた。

## 変更点

- `handleDragOver` に `requestAnimationFrame` ベースのスロットリングを追加
  - 前フレームの更新がまだ処理中の場合、新しいリクエストをスキップ
  - 1フレームあたり最大1回のみ状態更新を実行
- `handleDragLeave` / `handleDrop` で未処理のrAFをクリーンアップ

## テスト

- `npx vitest run` で全30テスト通過
- TypeScript型チェック通過

closes #88