### PR TITLE
fix: 竜騎士スキルの威力を公式ジョブガイド準拠に修正 #93

### DIFF
--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -56,7 +56,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "true-thrust",
     name: "トゥルースラスト",
-    potency: 230,
+    potency: 170,
     type: "gcd",
     target: "enemy",
     icon: trueThrustIcon,
@@ -64,12 +64,15 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 1,
     autoTransform: { buffId: "dragons-eye", skillId: "raiden-thrust" },
+    traitPotencyOverrides: [
+      { traitLevel: 76, potency: 230 },
+    ],
   },
   {
     id: "vorpal-thrust",
     name: "ボーパルスラスト",
-    potency: 280,
-    nonComboPotency: 130,
+    potency: 250,
+    nonComboPotency: 100,
     comboFrom: ["true-thrust", "raiden-thrust"],
     type: "gcd",
     target: "enemy",
@@ -77,6 +80,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 4,
+    traitPotencyOverrides: [
+      { traitLevel: 76, potency: 280, nonComboPotency: 130 },
+    ],
   },
   {
     id: "full-thrust",
@@ -113,8 +119,8 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "disembowel",
     name: "ディセムボウル",
-    potency: 250,
-    nonComboPotency: 140,
+    potency: 210,
+    nonComboPotency: 100,
     comboFrom: ["true-thrust", "raiden-thrust"],
     comboBuffApplications: ["power-surge"],
     type: "gcd",
@@ -123,6 +129,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 18,
+    traitPotencyOverrides: [
+      { traitLevel: 76, potency: 250, nonComboPotency: 140 },
+    ],
   },
   {
     id: "chaos-thrust",
@@ -161,7 +170,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "drakesbane",
     name: "雲蒸竜変",
-    potency: 400,
+    potency: 460,
     type: "gcd",
     target: "enemy",
     icon: drakesbaneIcon,
@@ -171,6 +180,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     comboFrom: ["fang-and-claw", "wheeling-thrust"],
     comboBuffApplications: ["dragons-eye"],
     traitPotencyOverrides: [
+      { traitLevel: 86, potency: 400 },
       { traitLevel: 94, potency: 460 },
     ],
   },
@@ -207,6 +217,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 15,
+    traitPotencyOverrides: [
+      { traitLevel: 76, potency: 200 },
+    ],
   },
 
   // ============================================================

--- a/src/client/logic/skill-level.ts
+++ b/src/client/logic/skill-level.ts
@@ -9,6 +9,7 @@ function applyTraitOverrides(skill: Skill, level: number): Skill {
   }
 
   let potency = skill.potency;
+  let nonComboPotency = skill.nonComboPotency;
   let dotPotency = skill.dotPotency;
   let maxCharges = skill.maxCharges;
 
@@ -17,16 +18,17 @@ function applyTraitOverrides(skill: Skill, level: number): Skill {
   for (const override of sorted) {
     if (level >= override.traitLevel) {
       if (override.potency !== undefined) potency = override.potency;
+      if (override.nonComboPotency !== undefined) nonComboPotency = override.nonComboPotency;
       if (override.dotPotency !== undefined) dotPotency = override.dotPotency;
       if (override.maxCharges !== undefined) maxCharges = override.maxCharges;
     }
   }
 
-  if (potency === skill.potency && dotPotency === skill.dotPotency && maxCharges === skill.maxCharges) {
+  if (potency === skill.potency && nonComboPotency === skill.nonComboPotency && dotPotency === skill.dotPotency && maxCharges === skill.maxCharges) {
     return skill;
   }
 
-  return { ...skill, potency, dotPotency, maxCharges };
+  return { ...skill, potency, nonComboPotency, dotPotency, maxCharges };
 }
 
 /**

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -26,6 +26,8 @@ export interface TraitPotencyOverride {
   traitLevel: number;
   /** 変更後の威力（undefinedの場合は変更なし） */
   potency?: number;
+  /** 変更後の非コンボ時威力（undefinedの場合は変更なし） */
+  nonComboPotency?: number;
   /** 変更後のDoT威力（undefinedの場合は変更なし） */
   dotPotency?: number;
   /** 変更後の最大チャージ数（undefinedの場合は変更なし） */


### PR DESCRIPTION
## 概要

竜騎士スキルの威力を公式ジョブガイドおよびトレイト情報と照合し、不一致を修正。

## 変更点

### 型定義
- `TraitPotencyOverride` に `nonComboPotency?: number` を追加
- `applyTraitOverrides` で `nonComboPotency` のトレイト適用を処理

### 威力修正（公式ジョブガイド・トレイト準拠）

| スキル | 修正前 base | 修正後 base | トレイト |
|--------|-----------|-----------|---------|
| トゥルースラスト | 230 | **170** | Lv76(Lance Mastery): 230 |
| ボーパルスラスト | 280/130 | **250/100** | Lv76: 280/130 |
| ピアシングタロン | 150 | 150 | **Lv76: 200** (追加) |
| ディセムボウル | 250/140 | **210/100** | Lv76: 250/140 |
| 雲蒸竜変 | 400 | **460** | **Lv86: 400** (追加), Lv94: 460 |

### 照合済み（変更不要）
フルスラスト、竜牙竜爪、竜尾大車輪、桜華狂咲、ドゥームスパイク、ソニックスラスト、クルザントーメント、竜眼雷電、竜眼蒼穹、ヘヴンスラスト、桜華繚乱、スラストラッシュ、スパイラルブロウ、全oGCDスキル — いずれも公式値と一致。

## テスト

- `npx vitest run` で全32テスト通過
- TypeScript型チェック通過

closes #93