### PR TITLE
fix: スキルカード子要素のネイティブドラッグを抑制しゴースト画像を統一 #101

### DIFF
--- a/src/client/components/SkillPalette.tsx
+++ b/src/client/components/SkillPalette.tsx
@@ -186,6 +186,7 @@ export function SkillPalette({
                 src={skill.icon}
                 alt={skill.name}
                 style={styles.skillIcon}
+                draggable={false}
               />
               <div style={styles.skillInfo}>
                 <div style={styles.skillName}>{skill.name}</div>
@@ -210,6 +211,7 @@ export function SkillPalette({
                 src={skill.icon}
                 alt={skill.name}
                 style={styles.skillIcon}
+                draggable={false}
               />
               <div style={styles.skillInfo}>
                 <div style={styles.skillName}>{skill.name}</div>
@@ -382,6 +384,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   skillInfo: {
     minWidth: 0,
+    pointerEvents: "none" as const,
   },
   skillName: {
     fontSize: "13px",


### PR DESCRIPTION
## 概要

SkillPaletteのスキルカード内の子要素（アイコン画像・テキスト）がブラウザネイティブのドラッグ動作を持つことで、ドラッグ開始位置によりゴースト画像が異なる問題とChromeクラッシュの問題を修正。

## 変更点

- `img` 要素に `draggable={false}` を追加し、ブラウザネイティブの画像ドラッグを抑制
- `skillInfo` スタイルに `pointerEvents: "none"` を追加し、テキスト選択によるドラッグ競合を防止
- GCD / oGCD 両セクションのスキルカードに適用

## テスト

- 既存テスト全32件パス
- ドラッグ操作はカード全体の `draggable` 属性に統一されるため、どの位置からドラッグしてもカード全体がゴースト画像として表示される

closes #101