### PR TITLE
fix: イルーシブジャンプ後のピアシングタロン威力上昇（350）を反映 #133

### DIFF
--- a/src/client/data/drg-buffs.ts
+++ b/src/client/data/drg-buffs.ts
@@ -12,6 +12,7 @@ import nastrondIcon from "../assets/icons/drg/Nastrond.png";
 import stardiverIcon from "../assets/icons/drg/Stardiver.png";
 import starcrossIcon from "../assets/icons/drg/Starcross.png";
 import drakesbaneIcon from "../assets/icons/drg/Drakesbane.png";
+import piercingTalonIcon from "../assets/icons/drg/Piercing_Talon.png";
 
 /**
  * 竜騎士（DRG）バフ定義
@@ -176,5 +177,16 @@ export const DRG_BUFFS: BuffDefinition[] = [
     color: "#795548",
     maxStacks: 1,
     acquiredLevel: 64,
+  },
+  {
+    id: "enhanced-piercing-talon",
+    name: "エンハンスドピアシングタロン",
+    shortName: "PT\n強化",
+    icon: piercingTalonIcon,
+    duration: 15,
+    effects: [],
+    color: "#00bcd4",
+    maxStacks: 1,
+    acquiredLevel: 76,
   },
 ];

--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -220,6 +220,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     traitPotencyOverrides: [
       { traitLevel: 76, potency: 200 },
     ],
+    conditionalPotencyBuffs: [
+      { buffId: "enhanced-piercing-talon", potency: 350 },
+    ],
   },
 
   // ============================================================
@@ -552,6 +555,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 30,
     acquiredLevel: 35,
+    buffApplications: ["enhanced-piercing-talon"],
   },
   {
     id: "winged-glide",

--- a/src/client/logic/__tests__/drg-enhanced-piercing-talon.test.ts
+++ b/src/client/logic/__tests__/drg-enhanced-piercing-talon.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+const enhancedPiercingTalon: BuffDefinition = {
+  id: "enhanced-piercing-talon",
+  name: "エンハンスドピアシングタロン",
+  shortName: "PT強化",
+  icon: "",
+  duration: 15,
+  effects: [],
+  color: "#00bcd4",
+  maxStacks: 1,
+};
+
+describe("イルーシブジャンプ → ピアシングタロン威力上昇", () => {
+  it("バフ未付与時は通常威力（200）で実行される", () => {
+    const piercingTalon = makeSkill({
+      id: "piercing-talon",
+      potency: 200,
+      conditionalPotencyBuffs: [{ buffId: "enhanced-piercing-talon", potency: 350 }],
+    });
+    const skillMap = new Map([[piercingTalon.id, piercingTalon]]);
+
+    const result = resolveTimeline(
+      [makeEntry("piercing-talon")],
+      skillMap,
+      [],
+      undefined,
+      [enhancedPiercingTalon],
+    );
+
+    expect(result.entries[0].comboErrors).toHaveLength(0);
+    expect(result.entries[0].resolvedPotency).toBe(200);
+  });
+
+  it("イルーシブジャンプ後のピアシングタロンは威力350になる", () => {
+    const elusiveJump = makeSkill({
+      id: "elusive-jump",
+      potency: 0,
+      type: "ogcd",
+      target: "self",
+      cooldown: 30,
+      buffApplications: ["enhanced-piercing-talon"],
+    });
+    const piercingTalon = makeSkill({
+      id: "piercing-talon",
+      potency: 200,
+      conditionalPotencyBuffs: [{ buffId: "enhanced-piercing-talon", potency: 350 }],
+    });
+    const skillMap = new Map([
+      [elusiveJump.id, elusiveJump],
+      [piercingTalon.id, piercingTalon],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("elusive-jump"), makeEntry("piercing-talon")],
+      skillMap,
+      [],
+      undefined,
+      [enhancedPiercingTalon],
+    );
+
+    expect(result.entries[0].comboErrors).toHaveLength(0);
+    expect(result.entries[1].comboErrors).toHaveLength(0);
+    expect(result.entries[1].resolvedPotency).toBe(350);
+  });
+
+  it("バフ消費後のピアシングタロンは再び通常威力に戻る", () => {
+    const elusiveJump = makeSkill({
+      id: "elusive-jump",
+      potency: 0,
+      type: "ogcd",
+      target: "self",
+      cooldown: 30,
+      buffApplications: ["enhanced-piercing-talon"],
+    });
+    const piercingTalon = makeSkill({
+      id: "piercing-talon",
+      potency: 200,
+      conditionalPotencyBuffs: [{ buffId: "enhanced-piercing-talon", potency: 350 }],
+    });
+    const skillMap = new Map([
+      [elusiveJump.id, elusiveJump],
+      [piercingTalon.id, piercingTalon],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("elusive-jump"),
+        makeEntry("piercing-talon"),
+        makeEntry("piercing-talon"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [enhancedPiercingTalon],
+    );
+
+    // 1発目は威力350（バフ消費）
+    expect(result.entries[1].resolvedPotency).toBe(350);
+    // 2発目は通常威力200（バフ無し）
+    expect(result.entries[2].resolvedPotency).toBe(200);
+  });
+
+  it("バフ効果時間（15秒）経過後は威力が元に戻る", () => {
+    const elusiveJump = makeSkill({
+      id: "elusive-jump",
+      potency: 0,
+      type: "ogcd",
+      target: "self",
+      cooldown: 30,
+      buffApplications: ["enhanced-piercing-talon"],
+    });
+    // 威力0・長いGCDで時間経過をシミュレート
+    const filler = makeSkill({
+      id: "filler",
+      potency: 0,
+      recastTime: 10,
+    });
+    const piercingTalon = makeSkill({
+      id: "piercing-talon",
+      potency: 200,
+      conditionalPotencyBuffs: [{ buffId: "enhanced-piercing-talon", potency: 350 }],
+    });
+    const skillMap = new Map([
+      [elusiveJump.id, elusiveJump],
+      [filler.id, filler],
+      [piercingTalon.id, piercingTalon],
+    ]);
+
+    // filler を2つ挟む → GCD20秒経過 → バフ切れ
+    const result = resolveTimeline(
+      [
+        makeEntry("elusive-jump"),
+        makeEntry("filler"),
+        makeEntry("filler"),
+        makeEntry("piercing-talon"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [enhancedPiercingTalon],
+    );
+
+    expect(result.entries[3].resolvedPotency).toBe(200);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -519,6 +519,20 @@ export function resolveTimeline(
       }
     }
 
+    // conditionalPotencyBuffs: バフがあれば威力を上書きしバフを消費（なければ通常威力、エラーにしない）
+    let conditionalPotencyOverride: number | undefined;
+    let conditionalMatchedBuffId: string | undefined;
+    if (skill.conditionalPotencyBuffs) {
+      for (const option of skill.conditionalPotencyBuffs) {
+        const activeBuff = currentActiveBuffs.find((ab) => ab.buffId === option.buffId);
+        if (activeBuff) {
+          conditionalMatchedBuffId = option.buffId;
+          conditionalPotencyOverride = option.potency;
+          break;
+        }
+      }
+    }
+
     // WSコンボ判定: comboFromが設定されているGCDスキルのコンボ成否を判定
     let wsComboError = false;
     if (skill.comboFrom && skill.type === "gcd") {
@@ -528,7 +542,7 @@ export function resolveTimeline(
     }
 
     // コンボ成否に基づく威力決定
-    let resolvedPotency = anyOfPotencyOverride ?? skill.potency;
+    let resolvedPotency = anyOfPotencyOverride ?? conditionalPotencyOverride ?? skill.potency;
     if (wsComboError && skill.nonComboPotency !== undefined) {
       resolvedPotency = skill.nonComboPotency;
     }
@@ -680,6 +694,15 @@ export function resolveTimeline(
       // buffConsumptionAnyOf: マッチしたバフを消費
       if (anyOfMatchedBuffId) {
         const activeBuff = currentActiveBuffs.find((ab) => ab.buffId === anyOfMatchedBuffId);
+        if (activeBuff) {
+          const idx = currentActiveBuffs.indexOf(activeBuff);
+          if (idx >= 0) currentActiveBuffs.splice(idx, 1);
+        }
+      }
+
+      // conditionalPotencyBuffs: マッチしたバフを消費
+      if (conditionalMatchedBuffId) {
+        const activeBuff = currentActiveBuffs.find((ab) => ab.buffId === conditionalMatchedBuffId);
         if (activeBuff) {
           const idx = currentActiveBuffs.indexOf(activeBuff);
           if (idx >= 0) currentActiveBuffs.splice(idx, 1);

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -105,6 +105,8 @@ export interface Skill {
   buffApplicationsByConsumedCount?: string[][];
   /** バフ消費のOR条件（いずれか1つを消費。potency指定時は威力を上書き、procRate+fallbackPotency指定時は期待値を計算） */
   buffConsumptionAnyOf?: { buffId: string; stacks: number; potency?: number; procRate?: number; fallbackPotency?: number }[];
+  /** 指定バフがアクティブなら威力を上書きしバフを消費する。バフ未付与時は通常威力で実行（エラーにならない） */
+  conditionalPotencyBuffs?: { buffId: string; potency: number }[];
   /** スキル使用に必要なバフID（未アクティブ時はエラー、威力を計上しない） */
   requiredBuff?: string;
   /** 自動変化条件（指定バフがアクティブ時に別スキルに変化。配列の場合は先頭から優先チェック） */


### PR DESCRIPTION
## 概要

竜騎士のイルーシブジャンプ使用後、次のピアシングタロンの威力が350に上昇するFF14の仕様を実装した。

## 変更点

- `Skill` インターフェースに `conditionalPotencyBuffs?: { buffId: string; potency: number }[]` を追加
  - 指定バフがアクティブなら威力を上書き＆消費、未付与時はエラーにせず通常威力
  - 既存の `buffConsumptionAnyOf` と異なり、バフ任意（なくてもエラーにならない）パターンを表現
- `drg-buffs.ts`: `enhanced-piercing-talon` バフを追加（duration 15s, acquiredLevel 76）
- `drg-skills.ts`:
  - `elusive-jump` に `buffApplications: ["enhanced-piercing-talon"]` を設定
  - `piercing-talon` に `conditionalPotencyBuffs: [{ buffId: "enhanced-piercing-talon", potency: 350 }]` を設定
- `resolve-timeline.ts`: バフチェック・威力上書き・バフ消費ロジックを追加
- Lv76 制御: バフの `acquiredLevel: 76` により `skill-level.ts` で Lv76 未満は `buffApplications` から除外される

## 仕様確認

| 項目 | 決定値 | 根拠 |
|------|--------|------|
| バフ効果時間 | 15秒 | FF14公式ジョブガイド・Web検索で確認 |
| 対象レベル | Lv76以上（Lance Mastery特性由来） | 基本威力200化と同じ特性と解釈 |
| バフ消費 | ピアシングタロン使用で消費、時間経過で失効 | FF14標準挙動 |

## テスト

新規テストファイル `src/client/logic/__tests__/drg-enhanced-piercing-talon.test.ts` で以下を検証:

- [x] バフ未付与時は威力200で実行される
- [x] イルーシブジャンプ後のピアシングタロンは威力350
- [x] バフ消費後、2発目のピアシングタロンは通常威力に戻る
- [x] バフ効果時間（15秒）経過後は威力が元に戻る

closes #133