### PR TITLE
fix: ヘヴンスラストの威力をジョブガイド準拠に修正 #134

### DIFF
--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -290,7 +290,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "heavens-thrust",
     name: "ヘヴンスラスト",
-    potency: 460,
+    potency: 400,
     nonComboPotency: 160,
     comboFrom: ["vorpal-thrust", "lance-barrage"],
     type: "gcd",
@@ -300,6 +300,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 86,
     replacesSkillId: "full-thrust",
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 460 },
+    ],
   },
   {
     id: "chaotic-spring",


### PR DESCRIPTION
## 概要

竜騎士のヘヴンスラスト（`heavens-thrust`）のLv90時点のコンボ威力が `460` でハードコードされていたのを、公式ジョブガイド準拠の `400` に修正する。併せてLv94のランサーマスタリーIII特性による威力強化を `traitPotencyOverrides` で表現する。

## 変更点

- `src/client/data/drg-skills.ts`
  - `heavens-thrust.potency` を `460` → `400` に修正（Lv86〜Lv93のコンボ威力）
  - `traitPotencyOverrides: [{ traitLevel: 94, potency: 460 }]` を追加（Lv94のランサーマスタリーIII強化）

## レベル別威力

| レベル | コンボ威力 | 非コンボ威力 |
|--------|-----------|-------------|
| Lv86〜Lv93 | 400 | 160 |
| Lv94〜Lv100 | 460 | 160 |

## 設計判断

- Issue #93 の `drakesbane` 修正では「base potency = Lv94+値、overrideで低レベル値をダウングレード」パターンが採られていたが、`heavens-thrust` は `acquiredLevel: 86` で習得後しか表示されないため、`vorpal-thrust` / `disembowel` と同じ「base potency = 習得時値、overrideで特性強化」の自然な表現を採用した。どちらのパターンでも `getSkillsForLevel` の挙動は一致する。
- `nonComboPotency: 160` は公式ジョブガイドと一致しているため据え置き。
- 関連コンボスキル（`vorpal-thrust` / `lance-barrage` / `fang-and-claw` / `wheeling-thrust` / `drakesbane`）は既存値がジョブガイドと整合しているため変更しない。

## テスト

- npm registry へのアクセス制限によりローカルでの `npm install` / `vitest` 実行は不可。データ定義のみの変更であり、型・構造は既存パターン（`drakesbane` 等）に完全準拠。
- CI（GitHub Actions）で型チェック・テスト・ビルドが検証される想定。

closes #134