### PR TITLE
feat: Playwright MCP を .mcp.json に登録し UI 視覚検証を可能化 #139

### DIFF
--- a/.claude/rules/tech-stack.md
+++ b/.claude/rules/tech-stack.md
@@ -15,6 +15,7 @@
 | CI | GitHub Actions | `.github/workflows/ci.yml`（型チェック・テスト・ビルド検証） |
 | テスト配信 | Cloudflare Pages（Git連携） | Pages 自身が repo を監視しフロントエンドを自動ビルド＆配信（プロジェクト名: `ff14-rotation-calc`、トークン不要） |
 | 本番デプロイ | pm2 or systemd + Nginx | オンプレUbuntu + Cloudflare（CDN/DNS層） |
+| UI視覚検証 | Playwright MCP (`@playwright/mcp`) | Claude Code セッションから `browser_navigate` 等でフロントエンド操作・スクリーンショット取得（リポジトリ直下 `.mcp.json` に登録） |
 
 ## 開発環境
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,4 +155,38 @@ npm test
 └── skills/      # スラッシュ起動可能なスキル（/issue-start, /dev-plan）
 ```
 
+加えて、リポジトリ直下の `.mcp.json` に Claude Code が読み込む MCP サーバー（Playwright 等）を定義しています。
+
 詳細は `CLAUDE.md` を参照してください。
+
+---
+
+## MCP サーバー（Playwright による UI 視覚検証）
+
+リポジトリルートの `.mcp.json` に Playwright MCP (`@playwright/mcp`) を登録しており、Claude Code セッションから `browser_navigate` / `browser_snapshot` / `browser_click` 等のツールでフロントエンドの UI を操作・キャプチャできます。
+
+### 初回セットアップ
+
+Chromium バイナリをダウンロードしておきます（Playwright MCP の初回起動時に `npx` が自動で `@playwright/mcp` を取得するため、別途インストールは不要）。
+
+```bash
+# 開発コンテナ内で1回だけ実行
+npx playwright install chromium
+```
+
+> Dev Container を新規ビルドした場合は再度実行が必要です。
+
+### 利用フロー
+
+1. 別ターミナルでフロントエンドを起動：
+   ```bash
+   npm run dev:client
+   ```
+2. Claude Code セッションから MCP ツールを呼び出す（例）：
+   - `browser_navigate` で `http://localhost:5173` を開く
+   - `browser_snapshot` でアクセシビリティツリー／スクリーンショットを取得
+   - `browser_click` でスキルボタン等を操作
+
+### 接続確認
+
+Claude Code セッションで `ToolSearch` に `playwright` や `browser_navigate` を投げて該当ツールが返ってくれば接続成功です。返ってこない場合は `.mcp.json` のパスと `@playwright/mcp` のインストール可否を確認してください。


### PR DESCRIPTION
## 概要

Claude Code セッションから `browser_navigate` / `browser_snapshot` 等でフロントエンド UI を操作・キャプチャできるように、リポジトリ直下に `.mcp.json` を追加し Playwright MCP (`@playwright/mcp`) を登録した。

## 変更点

- **`.mcp.json`**（新規）: `@playwright/mcp@latest` を `npx -y` で起動する MCP サーバー定義。`mcpServers.playwright.command=npx` / `args=["-y","@playwright/mcp@latest"]` の最小構成。
- **`CONTRIBUTING.md`**: 「MCP サーバー（Playwright による UI 視覚検証）」セクションを追加。初回セットアップ手順（`npx playwright install chromium`）、`npm run dev:client` 連携フロー、接続確認方法を記載。`.claude/` ツリー図の下に `.mcp.json` の位置も追記。
- **`.claude/rules/tech-stack.md`**: 技術スタック表に「UI視覚検証: Playwright MCP」レイヤーを追加。

## テスト

- [x] `.mcp.json` の JSON 構造を `node` で検証（`mcpServers.playwright` が期待どおりパースされる）
- [x] code-reviewer によるレビューで構造破綻（ツリー図のインデント）を修正
- [ ] **ユーザー側で確認が必要**: Claude Code を再起動し、`ToolSearch` で `browser_navigate` 等の Playwright MCP ツールが取得できること
- [ ] **ユーザー側で確認が必要**: `npm run dev:client` 起動後、`browser_navigate http://localhost:5173` でスクリーンショット取得に成功すること
- [ ] Dev Container 初回構築時の Chromium 配備が `npx playwright install chromium` で足りるか（Issue #139「未確定事項」→ 実運用で検証）

## 備考

Issue #139 の「やらないこと」に従い、自動テストスイートや視覚回帰 CI は別 Issue で扱う。

closes #139