### PR TITLE
fix: スターダイバーのLv90威力を720に修正 #135

### DIFF
--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -468,7 +468,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "stardiver",
     name: "スターダイバー",
-    potency: 840,
+    potency: 720,
     type: "ogcd",
     target: "enemy",
     icon: stardiverIcon,
@@ -478,6 +478,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     acquiredLevel: 80,
     buffConsumptions: [{ buffId: "stardiver-ready", stacks: 1 }],
     buffApplications: ["starcross-ready"],
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 840 },
+    ],
   },
   {
     id: "starcross",


### PR DESCRIPTION
## 概要

竜騎士のスターダイバー（`stardiver`）の威力が公式ジョブガイドと不一致だった件を修正。Lv80〜Lv93 の基本威力を `720` に下方修正し、Lv94 の Melee Mastery（ランサーマスタリーIV相当）特性で `840` に上昇するよう `traitPotencyOverrides` を設定した。

## 変更点

- `src/client/data/drg-skills.ts` の `stardiver` 定義:
  - `potency: 840` → `potency: 720`（Lv80 習得時〜Lv93 の基本威力）
  - `traitPotencyOverrides: [{ traitLevel: 94, potency: 840 }]` を追加（Lv94 特性で 840 に強化）

## 根拠

- 公式ジョブガイド: https://jp.finalfantasyxiv.com/jobguide/dragoon/
- FFXIV Wiki: "Potency is 720 prior to learning the Melee Mastery trait."（Melee Mastery 習得レベル: 94）

## 設計判断

- 既存の同ファイル内パターン（`geirskogul`: base 260 / Lv90で280、`nastrond`: base 600 / Lv90で720、`vorpal-thrust`: base 250 / Lv76で280、`disembowel`: base 210 / Lv76で250）および #134（PR #138）で `heavens-thrust` に適用した「base=習得時値 / override=特性で強化」パターンを踏襲。
- `stardiver` は `acquiredLevel: 80` で Lv80 以前には存在しないため、base が低レベル値・override で強化される自然な表現になる。
- バフ連携（`stardiver-ready` 消費、`starcross-ready` 付与）、リキャスト、習得レベル等は変更していない。

## テスト

- [x] `npm test` — 36/36 passed（`drg-buff-conditions.test.ts` 含む既存テスト全通過）
- [x] `npx tsc --noEmit` — exit 0（型エラーなし）
- [x] `traitPotencyOverrides` の適用ロジック（`src/client/logic/skill-level.ts` の `applyTraitOverrides`）確認済み: Lv80〜Lv93で base の 720、Lv94〜Lv100で override の 840 が適用される

closes #135

---
_Generated by [Claude Code](https://claude.ai/code)_