### PR TITLE
fix: 天竜点睛のLv90威力を420に修正 #136

### DIFF
--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -534,7 +534,7 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
   {
     id: "wyrmwind-thrust",
     name: "天竜点睛",
-    potency: 440,
+    potency: 420,
     type: "ogcd",
     target: "enemy",
     icon: wyrmwindThrustIcon,
@@ -544,6 +544,9 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     acquiredLevel: 90,
     resourceChanges: [
       { resourceId: "firstminds-focus", amount: -2 },
+    ],
+    traitPotencyOverrides: [
+      { traitLevel: 94, potency: 440 },
     ],
   },
 


### PR DESCRIPTION
## 概要

竜騎士「天竜点睛」（`wyrmwind-thrust`）のLv90威力が `440` で定義されていたが、公式ジョブガイド準拠の正しい値 `420` に修正する。Lv94特性でLv94以降の威力が `440` に戻るよう `traitPotencyOverrides` を追加。

## 変更点

- `src/client/data/drg-skills.ts`
  - `wyrmwind-thrust.potency`: `440` → `420`（Lv90基本威力、公式ジョブガイド準拠）
  - `traitPotencyOverrides` を追加: `{ traitLevel: 94, potency: 440 }`

## テスト

- `npm test` → 7 files / 36 tests passed
- 威力以外（リキャスト `10s`、`firstminds-focus -2`、アニメーションロック、習得レベル `90`）は変更していない

## 参考

先行する類似修正（#134 ヘヴンスラスト、#135 スターダイバー）と同じパターンで、Lv90/86/80の基本威力を下げた上でLv94特性で元の値に戻す構造を踏襲。

closes #136