### PR TITLE
fix: レインボードリップのリキャストを6秒に修正 #144

### DIFF
--- a/src/client/data/pct-skills.ts
+++ b/src/client/data/pct-skills.ts
@@ -271,7 +271,7 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
     type: "gcd",
     target: "enemy",
     icon: rainbowDripIcon,
-    recastTime: GCD_RECAST,
+    recastTime: 6,
     animationLock: DEFAULT_ANIMATION_LOCK,
     castTime: 4,
     acquiredLevel: 92,


### PR DESCRIPTION
## 概要

ピクトマンサーのレインボードリップ（`rainbow-drip`）のリキャストタイムが GCD 共通値（2.5秒）になっていたバグを、公式仕様の **6秒**（固有リキャスト）に修正する。

## 変更点

- `src/client/data/pct-skills.ts` — `rainbow-drip` の `recastTime` を `GCD_RECAST` から `6` に変更
- `castTime: 4` は正しい値のため変更なし

## テスト

- [x] `npm test` 全 36 テスト pass
- [x] `npx tsc --noEmit` 型エラーなし
- [x] `resolve-timeline.ts:374` で `gcdAvailableAt = startTime + recastTime` のフローを確認済み（次GCDが6秒後まで打てない挙動になる）
- [x] `rainbow-drip-ready` バフは `effects: []` のため、本修正で挙動回帰なし

closes #144