### PR TITLE
fix: ピクトマンサーWP表示を2行にしてアビリティ挟み込み時の重なりを解消 #146

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -996,10 +996,10 @@ export function Timeline({
                           title={group.resources.map((r) => `${r.name}: ${entry.resourceSnapshot[r.id] ?? 0}/${r.maxStacks}`).join(", ") + (hasError ? " (不足)" : "")}
                         >
                           <div style={styles.resourceDots}>
-                            {group.resources.flatMap((res) => {
+                            {group.resources.map((res) => {
                               const count = entry.resourceSnapshot[res.id] ?? 0;
                               if (res.maxStacks > 10) {
-                                return [(
+                                return (
                                   <div key={res.id} style={styles.resourceGauge}>
                                     <div
                                       style={{
@@ -1010,20 +1010,31 @@ export function Timeline({
                                     />
                                     <span style={styles.resourceGaugeLabel}>{count}</span>
                                   </div>
-                                )];
+                                );
                               }
-                              return Array.from({ length: res.maxStacks }, (_, i) => (
+                              const stacksPerRow = res.stacksPerRow ?? res.maxStacks;
+                              return (
                                 <div
-                                  key={`${res.id}-${i}`}
+                                  key={res.id}
                                   style={{
-                                    ...styles.resourceDot,
-                                    backgroundColor:
-                                      i < count
-                                        ? res.color
-                                        : "rgba(255,255,255,0.15)",
+                                    ...styles.resourceDotGrid,
+                                    gridTemplateColumns: `repeat(${stacksPerRow}, ${RESOURCE_DOT_SIZE}px)`,
                                   }}
-                                />
-                              ));
+                                >
+                                  {Array.from({ length: res.maxStacks }, (_, i) => (
+                                    <div
+                                      key={`${res.id}-${i}`}
+                                      style={{
+                                        ...styles.resourceDot,
+                                        backgroundColor:
+                                          i < count
+                                            ? res.color
+                                            : "rgba(255,255,255,0.15)",
+                                      }}
+                                    />
+                                  ))}
+                                </div>
+                              );
                             })}
                           </div>
                           {hasError && (
@@ -1541,6 +1552,11 @@ const styles: Record<string, React.CSSProperties> = {
   },
   resourceDots: {
     display: "flex",
+    alignItems: "center",
+    gap: "3px",
+  },
+  resourceDotGrid: {
+    display: "grid",
     gap: "3px",
   },
   resourceGauge: {

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -32,6 +32,7 @@ const LANE_LABEL_WIDTH = 52;
 
 /** リソースドットのサイズ（px） */
 const RESOURCE_DOT_SIZE = 10;
+const RESOURCE_DOT_GAP = 3;
 
 interface TimelineProps {
   skills: Skill[];
@@ -1013,12 +1014,13 @@ export function Timeline({
                                 );
                               }
                               const stacksPerRow = res.stacksPerRow ?? res.maxStacks;
+                              const gridWidth = stacksPerRow * RESOURCE_DOT_SIZE + (stacksPerRow - 1) * RESOURCE_DOT_GAP;
                               return (
                                 <div
                                   key={res.id}
                                   style={{
                                     ...styles.resourceDotGrid,
-                                    gridTemplateColumns: `repeat(${stacksPerRow}, ${RESOURCE_DOT_SIZE}px)`,
+                                    width: gridWidth,
                                   }}
                                 >
                                   {Array.from({ length: res.maxStacks }, (_, i) => (
@@ -1556,8 +1558,10 @@ const styles: Record<string, React.CSSProperties> = {
     gap: "3px",
   },
   resourceDotGrid: {
-    display: "grid",
-    gap: "3px",
+    display: "flex",
+    flexWrap: "wrap" as const,
+    justifyContent: "center",
+    gap: `${RESOURCE_DOT_GAP}px`,
   },
   resourceGauge: {
     position: "relative",

--- a/src/client/data/pct-resources.ts
+++ b/src/client/data/pct-resources.ts
@@ -24,6 +24,7 @@ export const PCT_RESOURCES: ResourceDefinition[] = [
     color: "#ffffff",
     acquiredLevel: 15,
     displayGroup: "paint",
+    stacksPerRow: 3,
   },
   {
     id: "black-paint",

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -153,6 +153,8 @@ export interface ResourceDefinition {
   acquiredLevel?: number;
   /** 表示グループ名（同じグループのリソースは1行にまとめて表示） */
   displayGroup?: string;
+  /** ドット1行あたりのスタック数（未設定の場合はmaxStacksを1行で表示。maxStacksがこの値を超える場合は複数行に折り返される） */
+  stacksPerRow?: number;
 }
 
 /** 特定時点のリソース状態 */


### PR DESCRIPTION
## 概要

ピクトマンサーのホワイトペイント（WP）はタイムライン上で横1行に5個のドットとして表示されていたが、GCD間にアビリティ（oGCD）を挟み込むと前後エントリが近接し、WPのドット表示が隣接エントリと重なって視認性が悪くなっていた。WPのドットを **3列×2行（3+2）** のグリッドレイアウトに変更し、横幅を抑えることで挟み込み時の重なりを解消する。

closes #146

## 変更点

- `src/client/types/skill.ts`: `ResourceDefinition` に optional `stacksPerRow?: number` フィールドを追加（ドット1行あたりのスタック数を指定）
- `src/client/data/pct-resources.ts`: WPに `stacksPerRow: 3` を設定
- `src/client/components/Timeline.tsx`:
  - ドット描画ロジックを、リソースごとに `display: grid` のコンテナで包む方式に変更。`gridTemplateColumns: repeat(stacksPerRow, DOT_SIZE)` で自動的に折り返される。`stacksPerRow` が未設定なら `maxStacks` を使うため、他リソースの1行表示は従来通り維持される
  - `resourceDots` に `alignItems: center` を追加し、2行化したWPの隣に並ぶ1行リソース（BP）がレーン中央で整列するようにした
  - `resourceDotGrid` スタイルを新設

## テスト

- [x] `npx tsc --noEmit` 通過
- [x] `npm test`（Vitest 36 tests）通過
- [x] Playwright でPCTタイムラインに GCD×5 + oGCD×2 を配置し、WPが3+2の2行で表示されることを確認
- [x] 同条件でBP（同一ペイントグループ・1スタック）が2行WPの右側に縦中央揃えで表示されることを確認
- [x] パレットゲージ（`maxStacks: 100` のゲージ表示）、キャンバス群（`displayGroup: canvas`）に回帰なし
- [x] 詩人ジョブに切り替えて他ジョブの表示に回帰がないことを確認
