### PR TITLE
fix: ピクトマンサーのペイントゲージをWP/BP共有5スロット制に修正 #149

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -122,20 +122,43 @@ export function Timeline({
 
   // リソースをdisplayGroupでグループ化（同じグループは1行にまとめる）
   const resourceGroups = useMemo(() => {
-    const groups: { key: string; label: string; resources: typeof resources }[] = [];
+    const groups: {
+      key: string;
+      label: string;
+      resources: typeof resources;
+      /** displayGroupPriority 昇順で並べたリソース（統合スロット描画時の充填順） */
+      sortedResources: typeof resources;
+      /** グループ合計の最大スタック数（統合スロット描画する場合のみ設定） */
+      groupMaxStacks?: number;
+      /** 統合スロット描画時の1行あたりドット数 */
+      stacksPerRow?: number;
+    }[] = [];
     const seen = new Set<string>();
     for (const res of resources) {
       if (res.displayGroup) {
         if (!seen.has(res.displayGroup)) {
           seen.add(res.displayGroup);
+          const groupResources = resources.filter((r) => r.displayGroup === res.displayGroup);
+          const groupMaxStacks = groupResources.find((r) => r.groupMaxStacks !== undefined)?.groupMaxStacks;
+          const sortedResources = groupMaxStacks !== undefined
+            ? [...groupResources].sort(
+                (a, b) => (a.displayGroupPriority ?? Number.MAX_SAFE_INTEGER) - (b.displayGroupPriority ?? Number.MAX_SAFE_INTEGER)
+              )
+            : groupResources;
+          const stacksPerRow = groupMaxStacks !== undefined
+            ? sortedResources.find((r) => r.stacksPerRow !== undefined)?.stacksPerRow
+            : undefined;
           groups.push({
             key: res.displayGroup,
             label: res.shortName,
-            resources: resources.filter((r) => r.displayGroup === res.displayGroup),
+            resources: groupResources,
+            sortedResources,
+            groupMaxStacks,
+            stacksPerRow,
           });
         }
       } else {
-        groups.push({ key: res.id, label: res.shortName, resources: [res] });
+        groups.push({ key: res.id, label: res.shortName, resources: [res], sortedResources: [res] });
       }
     }
     return groups;
@@ -994,10 +1017,42 @@ export function Timeline({
                             ...styles.resourceMarker,
                             left: entry.startTime * PX_PER_SEC,
                           }}
-                          title={group.resources.map((r) => `${r.name}: ${entry.resourceSnapshot[r.id] ?? 0}/${r.maxStacks}`).join(", ") + (hasError ? " (不足)" : "")}
+                          title={
+                            group.groupMaxStacks !== undefined
+                              ? group.resources.map((r) => `${r.name}: ${entry.resourceSnapshot[r.id] ?? 0}`).join(" / ") +
+                                ` (合計 ${group.resources.reduce((s, r) => s + (entry.resourceSnapshot[r.id] ?? 0), 0)}/${group.groupMaxStacks})` +
+                                (hasError ? " (不足)" : "")
+                              : group.resources.map((r) => `${r.name}: ${entry.resourceSnapshot[r.id] ?? 0}/${r.maxStacks}`).join(", ") +
+                                (hasError ? " (不足)" : "")
+                          }
                         >
                           <div style={styles.resourceDots}>
-                            {group.resources.map((res) => {
+                            {group.groupMaxStacks !== undefined ? (() => {
+                              // 統合スロット描画: displayGroupPriority 昇順でスロットを埋め、残りは空ドット
+                              const groupMax = group.groupMaxStacks;
+                              const slotColors: string[] = [];
+                              for (const res of group.sortedResources) {
+                                const count = entry.resourceSnapshot[res.id] ?? 0;
+                                for (let i = 0; i < count && slotColors.length < groupMax; i++) {
+                                  slotColors.push(res.color);
+                                }
+                              }
+                              while (slotColors.length < groupMax) {
+                                slotColors.push("rgba(255,255,255,0.15)");
+                              }
+                              const stacksPerRow = group.stacksPerRow ?? groupMax;
+                              const gridWidth = stacksPerRow * RESOURCE_DOT_SIZE + (stacksPerRow - 1) * RESOURCE_DOT_GAP;
+                              return (
+                                <div style={{ ...styles.resourceDotGrid, width: gridWidth }}>
+                                  {slotColors.map((color, i) => (
+                                    <div
+                                      key={i}
+                                      style={{ ...styles.resourceDot, backgroundColor: color }}
+                                    />
+                                  ))}
+                                </div>
+                              );
+                            })() : group.resources.map((res) => {
                               const count = entry.resourceSnapshot[res.id] ?? 0;
                               if (res.maxStacks > 10) {
                                 return (

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1646,6 +1646,8 @@ const styles: Record<string, React.CSSProperties> = {
     width: RESOURCE_DOT_SIZE,
     height: RESOURCE_DOT_SIZE,
     borderRadius: "50%",
+    // 背景色が濃いため、暗色リソース（BP 等）が空きスロットや背景と同化しないよう輪郭を付ける
+    boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.25)",
     transition: "background-color 0.2s",
   },
   resourceErrorMark: {

--- a/src/client/data/pct-buffs.ts
+++ b/src/client/data/pct-buffs.ts
@@ -53,6 +53,12 @@ export const PCT_BUFFS: BuffDefinition[] = [
     duration: 120,
     effects: [],
     color: "#546e7a",
+    // 色調反転は本来永続バフだが、本ツールは永続バフ未実装のため duration: 120 で近似している。
+    // バフ消失時に BP を WP に戻すことで、時間経過後もペイント枠が失われない状態を維持する。
+    onExpireResourceTransfer: {
+      fromResourceId: "black-paint",
+      toResourceId: "white-paint",
+    },
   },
 
   // ============================================================

--- a/src/client/data/pct-resources.ts
+++ b/src/client/data/pct-resources.ts
@@ -25,15 +25,19 @@ export const PCT_RESOURCES: ResourceDefinition[] = [
     acquiredLevel: 15,
     displayGroup: "paint",
     stacksPerRow: 3,
+    groupMaxStacks: 5,
+    displayGroupPriority: 2,
   },
   {
     id: "black-paint",
     name: "ブラックペイント",
     shortName: "BP",
-    maxStacks: 1,
+    maxStacks: 5,
     color: "#424242",
     acquiredLevel: 90,
     displayGroup: "paint",
+    groupMaxStacks: 5,
+    displayGroupPriority: 1,
   },
 
   // ============================================================

--- a/src/client/data/pct-resources.ts
+++ b/src/client/data/pct-resources.ts
@@ -33,8 +33,8 @@ export const PCT_RESOURCES: ResourceDefinition[] = [
     name: "ブラックペイント",
     shortName: "BP",
     maxStacks: 5,
-    // 空きスロット色 rgba(255,255,255,0.15) (≈ #333344) と区別するため、ほぼ純黒にする
-    color: "#1a1a1a",
+    // 「黒」よりも紫として認識される方が直感的なため、濃い紫にする
+    color: "#7b1fa2",
     acquiredLevel: 90,
     displayGroup: "paint",
     groupMaxStacks: 5,

--- a/src/client/data/pct-resources.ts
+++ b/src/client/data/pct-resources.ts
@@ -33,7 +33,8 @@ export const PCT_RESOURCES: ResourceDefinition[] = [
     name: "ブラックペイント",
     shortName: "BP",
     maxStacks: 5,
-    color: "#424242",
+    // 空きスロット色 rgba(255,255,255,0.15) (≈ #333344) と区別するため、ほぼ純黒にする
+    color: "#1a1a1a",
     acquiredLevel: 90,
     displayGroup: "paint",
     groupMaxStacks: 5,

--- a/src/client/logic/__tests__/pct-paint-group.test.ts
+++ b/src/client/logic/__tests__/pct-paint-group.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, ResourceDefinition, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string, uid?: string): TimelineEntry {
+  return { uid: uid ?? `${skillId}-${Math.random()}`, skillId };
+}
+
+const PAINT_RESOURCES: ResourceDefinition[] = [
+  {
+    id: "white-paint",
+    name: "WP",
+    shortName: "WP",
+    maxStacks: 5,
+    color: "#fff",
+    displayGroup: "paint",
+    groupMaxStacks: 5,
+    displayGroupPriority: 2,
+  },
+  {
+    id: "black-paint",
+    name: "BP",
+    shortName: "BP",
+    maxStacks: 5,
+    color: "#000",
+    displayGroup: "paint",
+    groupMaxStacks: 5,
+    displayGroupPriority: 1,
+  },
+];
+
+describe("ピクトマンサー ペイントゲージ（WP/BP 共有5スロット）", () => {
+  it("WP=5 時に BP+1 を試みても groupMaxStacks=5 により BP は 0 のまま（グループキャップ）", () => {
+    const fillWp = makeSkill({ id: "fill-wp", resourceChanges: [{ resourceId: "white-paint", amount: 5 }] });
+    const addBp = makeSkill({ id: "add-bp", resourceChanges: [{ resourceId: "black-paint", amount: 1 }] });
+
+    const skillMap = new Map([[fillWp.id, fillWp], [addBp.id, addBp]]);
+    const result = resolveTimeline(
+      [makeEntry("fill-wp"), makeEntry("add-bp"), makeEntry("add-bp")],
+      skillMap,
+      PAINT_RESOURCES
+    );
+
+    // add-bp 実行前: WP=5, BP=0
+    expect(result.entries[1].resourceSnapshot["white-paint"]).toBe(5);
+    expect(result.entries[1].resourceSnapshot["black-paint"]).toBe(0);
+    // 2 回目の add-bp 実行前: 1 回目の add-bp でキャップされたため、BP は 0 のまま
+    expect(result.entries[2].resourceSnapshot["white-paint"]).toBe(5);
+    expect(result.entries[2].resourceSnapshot["black-paint"]).toBe(0);
+  });
+
+  it("WP 3, BP 0 から +1 WP したら WP=4 になる（合計 4 <= 5）", () => {
+    const setup = makeSkill({ id: "setup", resourceChanges: [{ resourceId: "white-paint", amount: 3 }] });
+    const addWp = makeSkill({ id: "add-wp", resourceChanges: [{ resourceId: "white-paint", amount: 1 }] });
+    const skillMap = new Map([[setup.id, setup], [addWp.id, addWp]]);
+    const result = resolveTimeline(
+      [makeEntry("setup"), makeEntry("add-wp"), makeEntry("add-wp")],
+      skillMap,
+      PAINT_RESOURCES
+    );
+    // 2個目実行前: WP=3
+    expect(result.entries[1].resourceSnapshot["white-paint"]).toBe(3);
+    // 3個目実行前: WP=4 (add-wp 1 回で +1 されてキャップにひっかからない)
+    expect(result.entries[2].resourceSnapshot["white-paint"]).toBe(4);
+  });
+
+  it("サブトラクティブパレット的 WP→BP 転送（WP -1, BP +1）は合計を維持する", () => {
+    const setup = makeSkill({ id: "setup", resourceChanges: [{ resourceId: "white-paint", amount: 5 }] });
+    const subtract = makeSkill({
+      id: "subtract",
+      resourceChanges: [
+        { resourceId: "white-paint", amount: -1 },
+        { resourceId: "black-paint", amount: 1 },
+      ],
+    });
+    const skillMap = new Map([[setup.id, setup], [subtract.id, subtract]]);
+    const result = resolveTimeline(
+      [makeEntry("setup"), makeEntry("subtract"), makeEntry("subtract")],
+      skillMap,
+      PAINT_RESOURCES
+    );
+    // 1回目のsubtract後: WP=4, BP=1 (3番目実行前)
+    expect(result.entries[2].resourceSnapshot["white-paint"]).toBe(4);
+    expect(result.entries[2].resourceSnapshot["black-paint"]).toBe(1);
+  });
+
+  it("WP=0 で [{WP:-1},{BP:+1}] を実行すると resourceError で両方とも変化しない", () => {
+    const subtract = makeSkill({
+      id: "subtract",
+      resourceChanges: [
+        { resourceId: "white-paint", amount: -1 },
+        { resourceId: "black-paint", amount: 1 },
+      ],
+    });
+    const skillMap = new Map([[subtract.id, subtract]]);
+    const result = resolveTimeline([makeEntry("subtract"), makeEntry("subtract")], skillMap, PAINT_RESOURCES);
+
+    expect(result.entries[0].resourceErrors).toContain("white-paint");
+    // 1 回目がエラーなのでリソースは変化していないまま 2 回目の実行に到達する
+    expect(result.entries[1].resourceSnapshot["white-paint"]).toBe(0);
+    expect(result.entries[1].resourceSnapshot["black-paint"]).toBe(0);
+  });
+
+  it("resourceChanges の並び順に結果が依存しない（負→正の2パス適用）", () => {
+    const fillWp = makeSkill({ id: "fill-wp", resourceChanges: [{ resourceId: "white-paint", amount: 5 }] });
+    const normalOrder = makeSkill({
+      id: "normal",
+      resourceChanges: [
+        { resourceId: "white-paint", amount: -1 },
+        { resourceId: "black-paint", amount: 1 },
+      ],
+    });
+    const reversedOrder = makeSkill({
+      id: "reversed",
+      resourceChanges: [
+        { resourceId: "black-paint", amount: 1 },
+        { resourceId: "white-paint", amount: -1 },
+      ],
+    });
+    const skillMap = new Map([[fillWp.id, fillWp], [normalOrder.id, normalOrder], [reversedOrder.id, reversedOrder]]);
+
+    const r1 = resolveTimeline(
+      [makeEntry("fill-wp"), makeEntry("normal"), makeEntry("normal")],
+      skillMap,
+      PAINT_RESOURCES
+    );
+    const r2 = resolveTimeline(
+      [makeEntry("fill-wp"), makeEntry("reversed"), makeEntry("reversed")],
+      skillMap,
+      PAINT_RESOURCES
+    );
+    // 3 番目エントリ実行前の snapshot で比較（2 回適用後の状態）
+    expect(r1.entries[2].resourceSnapshot).toEqual(r2.entries[2].resourceSnapshot);
+  });
+
+  it("onExpireResourceTransfer: バフ消失時に BP を WP へ戻す", () => {
+    const grantBuff = makeSkill({
+      id: "grant",
+      type: "gcd",
+      resourceChanges: [
+        { resourceId: "white-paint", amount: 3 },
+        { resourceId: "black-paint", amount: 2 },
+      ],
+      buffApplications: ["test-inversion"],
+    });
+    // 十分な時間経過のため、GCDスキルを多数打つ
+    const idle = makeSkill({ id: "idle", type: "gcd", recastTime: 2.5 });
+    const check = makeSkill({ id: "check", type: "gcd", recastTime: 2.5 });
+    const skillMap = new Map([[grantBuff.id, grantBuff], [idle.id, idle], [check.id, check]]);
+
+    const buffs: BuffDefinition[] = [
+      {
+        id: "test-inversion",
+        name: "test-inversion",
+        shortName: "TI",
+        icon: "",
+        duration: 5, // 5秒で切れる
+        effects: [],
+        color: "#000",
+        onExpireResourceTransfer: {
+          fromResourceId: "black-paint",
+          toResourceId: "white-paint",
+        },
+      },
+    ];
+
+    // grant → idle x3（約7.5秒経過）→ check（バフ消失後）
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("idle"), makeEntry("idle"), makeEntry("idle"), makeEntry("check")],
+      skillMap,
+      PAINT_RESOURCES,
+      undefined,
+      buffs
+    );
+
+    const checkEntry = result.entries[4];
+    // バフが切れている時点のスナップショットでは、BP→WP が転送済みのはず
+    expect(checkEntry.resourceSnapshot["black-paint"]).toBe(0);
+    expect(checkEntry.resourceSnapshot["white-paint"]).toBe(5); // 3 + 2 = 5
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -304,6 +304,107 @@ function isInUntargetableWindow(
   return false;
 }
 
+/**
+ * 同一 displayGroup 内の他リソース合計を取得する（groupMaxStacks キャップ判定用）。
+ */
+function getGroupOtherSum(
+  resourceState: ResourceSnapshot,
+  def: ResourceDefinition,
+  resources: ResourceDefinition[]
+): number {
+  if (!def.displayGroup) return 0;
+  let sum = 0;
+  for (const r of resources) {
+    if (r.id === def.id) continue;
+    if (r.displayGroup === def.displayGroup) {
+      sum += resourceState[r.id] ?? 0;
+    }
+  }
+  return sum;
+}
+
+/**
+ * リソースに変動量を適用する。
+ * 個別の maxStacks に加え、displayGroup で groupMaxStacks が設定されていれば
+ * グループ合計も上限に収まるようキャップする。
+ */
+function applyResourceChange(
+  resourceState: ResourceSnapshot,
+  def: ResourceDefinition,
+  amount: number,
+  resources: ResourceDefinition[]
+): void {
+  const prev = resourceState[def.id] ?? 0;
+  let next = Math.max(0, Math.min(prev + amount, def.maxStacks));
+  if (def.groupMaxStacks !== undefined && amount > 0) {
+    const otherSum = getGroupOtherSum(resourceState, def, resources);
+    const groupRoom = Math.max(0, def.groupMaxStacks - otherSum);
+    next = Math.min(next, groupRoom);
+    // すでに groupRoom を超過していた既存値は減らさない（現状維持）
+    if (next < prev) next = prev;
+  }
+  resourceState[def.id] = next;
+}
+
+/**
+ * アクティブバフから期限切れのものを除去する。
+ * 消失対象バフに onExpireResourceTransfer が設定されていれば、
+ * from→to へリソースを移し替える（色調反転消失時に BP→WP 戻しなど）。
+ */
+function expireBuffs(
+  activeBuffs: ActiveBuff[],
+  currentTime: number,
+  buffDefMap: Map<string, BuffDefinition>,
+  resourceState: ResourceSnapshot,
+  resourceDefMap: Map<string, ResourceDefinition>,
+  resources: ResourceDefinition[]
+): void {
+  for (let i = activeBuffs.length - 1; i >= 0; i--) {
+    if (activeBuffs[i].endTime <= currentTime) {
+      const buffId = activeBuffs[i].buffId;
+      activeBuffs.splice(i, 1);
+      const def = buffDefMap.get(buffId);
+      if (!def?.onExpireResourceTransfer) continue;
+      const { fromResourceId, toResourceId } = def.onExpireResourceTransfer;
+      if (!resourceDefMap.has(fromResourceId)) continue;
+      const toDef = resourceDefMap.get(toResourceId);
+      if (!toDef) continue;
+      const amount = resourceState[fromResourceId] ?? 0;
+      if (amount <= 0) continue;
+      resourceState[fromResourceId] = 0;
+      applyResourceChange(resourceState, toDef, amount, resources);
+    }
+  }
+}
+
+/**
+ * resourceChanges を 2 パス（負→正）で適用することで、配列の並び順に結果が依存しないようにする。
+ * 例: WP=5 の状態で [{WP:-1}, {BP:+1}] と [{BP:+1}, {WP:-1}] は同じ結果（WP=4, BP=1）。
+ * 正変動を先に評価すると groupMaxStacks キャップで BP が詰まれず 0 のままになる問題を避ける。
+ */
+function applyResourceChanges(
+  resourceState: ResourceSnapshot,
+  changes: { resourceId: string; amount: number }[],
+  resourceDefMap: Map<string, ResourceDefinition>,
+  resources: ResourceDefinition[],
+  onApplied?: (def: ResourceDefinition) => void
+): void {
+  for (const change of changes) {
+    if (change.amount >= 0) continue;
+    const def = resourceDefMap.get(change.resourceId);
+    if (!def) continue;
+    applyResourceChange(resourceState, def, change.amount, resources);
+    onApplied?.(def);
+  }
+  for (const change of changes) {
+    if (change.amount < 0) continue;
+    const def = resourceDefMap.get(change.resourceId);
+    if (!def) continue;
+    applyResourceChange(resourceState, def, change.amount, resources);
+    onApplied?.(def);
+  }
+}
+
 export function resolveTimeline(
   entries: TimelineEntry[],
   skillMap: Map<string, Skill>,
@@ -357,12 +458,8 @@ export function resolveTimeline(
       startTime = Math.max(gcdAvailableAt, actionAvailableAt);
       startTime = Math.round(startTime * 1000) / 1000;
 
-      // 期限切れバフを除去
-      for (let i = currentActiveBuffs.length - 1; i >= 0; i--) {
-        if (currentActiveBuffs[i].endTime <= startTime) {
-          currentActiveBuffs.splice(i, 1);
-        }
-      }
+      // 期限切れバフを除去（onExpireResourceTransfer があればリソース移し替えも実施）
+      expireBuffs(currentActiveBuffs, startTime, buffDefMap, resourceState, resourceDefMap, resources);
 
       // 速度バフを適用してリキャスト・詠唱時間計算
       const speedMul = getSpeedMultiplier(currentActiveBuffs, buffDefMap);
@@ -378,12 +475,8 @@ export function resolveTimeline(
       startTime = actionAvailableAt;
       startTime = Math.round(startTime * 1000) / 1000;
 
-      // 期限切れバフを除去
-      for (let i = currentActiveBuffs.length - 1; i >= 0; i--) {
-        if (currentActiveBuffs[i].endTime <= startTime) {
-          currentActiveBuffs.splice(i, 1);
-        }
-      }
+      // 期限切れバフを除去（onExpireResourceTransfer があればリソース移し替えも実施）
+      expireBuffs(currentActiveBuffs, startTime, buffDefMap, resourceState, resourceDefMap, resources);
 
       actionAvailableAt = startTime + originalSkill.animationLock;
     }
@@ -615,47 +708,25 @@ export function resolveTimeline(
     const dhRateBonusBeforeApply = guaranteedDhBeforeApply ? 1 : baseDhRateBonus;
 
     if (!hasError) {
+      const onResourceApplied = (def: ResourceDefinition) => {
+        // リソースが最大未満になったら自動生成タイマーを開始
+        if (
+          def.autoGenerateInterval &&
+          resourceState[def.id] < def.maxStacks &&
+          autoGenTimers[def.id].startedAt === null
+        ) {
+          autoGenTimers[def.id].startedAt = startTime;
+        }
+      };
+
       // リソース変動を適用
       if (skill.resourceChanges) {
-        for (const change of skill.resourceChanges) {
-          const def = resourceDefMap.get(change.resourceId);
-          if (!def) continue;
-          const prevValue = resourceState[change.resourceId];
-          resourceState[change.resourceId] = Math.max(
-            0,
-            Math.min(prevValue + change.amount, def.maxStacks)
-          );
-
-          // リソースが最大未満になったら自動生成タイマーを開始
-          if (
-            def.autoGenerateInterval &&
-            resourceState[change.resourceId] < def.maxStacks &&
-            autoGenTimers[change.resourceId].startedAt === null
-          ) {
-            autoGenTimers[change.resourceId].startedAt = startTime;
-          }
-        }
+        applyResourceChanges(resourceState, skill.resourceChanges, resourceDefMap, resources, onResourceApplied);
       }
 
       // コンボ成立時のみのリソース変動を適用
       if (!wsComboError && skill.comboResourceChanges) {
-        for (const change of skill.comboResourceChanges) {
-          const def = resourceDefMap.get(change.resourceId);
-          if (!def) continue;
-          const prevValue = resourceState[change.resourceId];
-          resourceState[change.resourceId] = Math.max(
-            0,
-            Math.min(prevValue + change.amount, def.maxStacks)
-          );
-
-          if (
-            def.autoGenerateInterval &&
-            resourceState[change.resourceId] < def.maxStacks &&
-            autoGenTimers[change.resourceId].startedAt === null
-          ) {
-            autoGenTimers[change.resourceId].startedAt = startTime;
-          }
-        }
+        applyResourceChanges(resourceState, skill.comboResourceChanges, resourceDefMap, resources, onResourceApplied);
       }
 
       // consumeAllOfResource: 指定リソースを全消費（resourceChangesの消費を上書き）
@@ -1090,14 +1161,7 @@ export function getFinalResourceState(
   if (!hasError && skill) {
     if (skill.resourceChanges) {
       const resourceDefMap = new Map(resources.map((r) => [r.id, r]));
-      for (const change of skill.resourceChanges) {
-        const def = resourceDefMap.get(change.resourceId);
-        if (!def) continue;
-        state[change.resourceId] = Math.max(
-          0,
-          Math.min(state[change.resourceId] + change.amount, def.maxStacks)
-        );
-      }
+      applyResourceChanges(state, skill.resourceChanges, resourceDefMap, resources);
     }
     if (skill.consumeAllOfResource) {
       state[skill.consumeAllOfResource] = 0;

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -155,6 +155,10 @@ export interface ResourceDefinition {
   displayGroup?: string;
   /** ドット1行あたりのスタック数（未設定の場合はmaxStacksを1行で表示。maxStacksがこの値を超える場合は複数行に折り返される） */
   stacksPerRow?: number;
+  /** displayGroup内のリソース合計スタック数の上限（同グループ内で合計がこの値を超えないようキャップ） */
+  groupMaxStacks?: number;
+  /** 同一displayGroup内でドット表示時の描画優先順位（昇順）。小さいほどスロットの先頭に埋められる */
+  displayGroupPriority?: number;
 }
 
 /** 特定時点のリソース状態 */
@@ -222,6 +226,11 @@ export interface BuffDefinition {
   acquiredLevel?: number;
   /** 排他グループ名（同グループのバフは1つだけアクティブ。新規適用時に既存を解除） */
   exclusiveGroup?: string;
+  /** バフ消失時にリソースを別リソースへ移し替える（例: 色調反転消失時にBP→WP） */
+  onExpireResourceTransfer?: {
+    fromResourceId: string;
+    toResourceId: string;
+  };
 }
 
 /** タイムライン上のアクティブなバフ */


### PR DESCRIPTION
## 概要

ピクトマンサーのペイントゲージを FF14 実機仕様に合わせ、ホワイトペイント（WP）とブラックペイント（BP）を独立した 5+1 リソースではなく、**合計 5 スロット共有の枠**として管理するよう修正する。タイムライン表示も 5 個固定ドットで WP/BP を色分け表示する。

closes #149

## 変更点

### 型定義・モデル拡張

- `ResourceDefinition` に以下を追加:
  - `groupMaxStacks?: number` — 同一 `displayGroup` 内リソース合計の上限
  - `displayGroupPriority?: number` — 統合スロット表示時の充填順（昇順）
- `BuffDefinition` に `onExpireResourceTransfer?: { fromResourceId; toResourceId }` を追加し、バフ消失時にリソースを別リソースへ移し替えられるようにした

### PCT リソース・バフ定義

- `white-paint` / `black-paint` を `groupMaxStacks: 5` で共有化、優先度で BP→WP の順にドット充填
  - `black-paint` の個別 `maxStacks` を 1 → 5 に引き上げ（実際の上限はグループ合計で制御）
- `color-inversion` バフに `onExpireResourceTransfer: { from: "black-paint", to: "white-paint" }` を追加
  - 色調反転は本来永続バフだが、本ツールは永続バフ未実装のため duration: 120 で近似。消失時に BP→WP を戻すことでペイント枠が失われないようにする

### ロジック (resolve-timeline.ts)

- `applyResourceChange` ヘルパーで個別 `maxStacks` と `groupMaxStacks` の両方をキャップ
- `expireBuffs` ヘルパーでバフ期限切れ処理を一元化し、`onExpireResourceTransfer` を汎用的に処理
- `applyResourceChanges` ヘルパーで resourceChanges を **負 → 正の 2 パス適用** にすることで、スキル定義内の変動順序に結果が依存しないようにした

### UI (Timeline.tsx)

- `resourceGroups` に `sortedResources` / `groupMaxStacks` / `stacksPerRow` を持たせ、統合スロット描画をサポート
- `groupMaxStacks` 設定時は 1 つの統合ドットグリッドを描画し、`displayGroupPriority` 順でドット色を決定
- ペイント枠は常に 5 個固定ドット（6 個ではない）で表示され、BP=暗色、WP=白で色分けされる
- ツールチップも合計表示に対応（例: `ホワイトペイント: 3 / ブラックペイント: 2 (合計 5/5)`）

### テスト

- `src/client/logic/__tests__/pct-paint-group.test.ts` を追加（6 ケース）
  - groupMaxStacks によるキャップ（WP=5 で BP+1 が効かない）
  - 通常の加算が合計範囲内で動作
  - WP→BP 転送（サブトラクティブパレット相当）
  - WP=0 での WP-1,BP+1 が resourceError で両方変化しない
  - resourceChanges 並び順に非依存（2 パス適用の回帰防止）
  - onExpireResourceTransfer によるバフ消失時 BP→WP 戻し

## テスト

- [x] 型チェック: `npx tsc --noEmit` エラーなし
- [x] テスト: `npm test` 全 42 件パス（8 ファイル / +6 新規ケース）
- [x] ビルド: `npx vite build` 成功
- [x] コードレビュー (code-reviewer) 指摘 3 件に対応済み
  - resourceChanges の並び順依存 → 2 パス適用で解消
  - `expireBuffs` での `fromResourceId` 検証漏れ → `resourceDefMap.has` を追加
  - テストカバレッジ不足 → 追加テスト 2 件で補強

## 未確認

- Playwright による UI 視覚確認はブラウザダウンロード失敗（503）のため未実施。マージ前に手動で `npm run dev:client` で実機確認推奨