### PR TITLE
fix: サブトラReady付与中はサブトラクティブパレットのPG消費をスキップ #150

### DIFF
--- a/src/client/data/pct-skills.ts
+++ b/src/client/data/pct-skills.ts
@@ -494,6 +494,8 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
       { resourceId: "white-paint", amount: -1 },
       { resourceId: "black-paint", amount: 1 },
     ],
+    // subtractive-ready バフ中はパレットゲージ50消費をスキップしバフを優先消費（イマジンスカイ後の発動条件緩和）
+    buffSkippableResource: { buffId: "subtractive-ready", resourceId: "palette-gauge" },
     buffApplications: ["subtractive-palette", "color-inversion"],
   },
 

--- a/src/client/logic/__tests__/pct-subtractive-ready.test.ts
+++ b/src/client/logic/__tests__/pct-subtractive-ready.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type {
+  Skill,
+  TimelineEntry,
+  ResourceDefinition,
+  BuffDefinition,
+} from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: "",
+    recastTime: 0.65,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string, uid?: string): TimelineEntry {
+  return { uid: uid ?? `${skillId}-${Math.random()}`, skillId };
+}
+
+const PCT_RESOURCES: ResourceDefinition[] = [
+  {
+    id: "palette-gauge",
+    name: "PG",
+    shortName: "PG",
+    maxStacks: 100,
+    color: "#eee",
+  },
+  {
+    id: "white-paint",
+    name: "WP",
+    shortName: "WP",
+    maxStacks: 5,
+    color: "#fff",
+    displayGroup: "paint",
+    groupMaxStacks: 5,
+    displayGroupPriority: 2,
+  },
+  {
+    id: "black-paint",
+    name: "BP",
+    shortName: "BP",
+    maxStacks: 5,
+    color: "#000",
+    displayGroup: "paint",
+    groupMaxStacks: 5,
+    displayGroupPriority: 1,
+  },
+];
+
+const SUBTRACTIVE_READY_BUFF: BuffDefinition = {
+  id: "subtractive-ready",
+  name: "サブトラクティブパレット実行可",
+  shortName: "SR",
+  icon: "",
+  duration: 30,
+  effects: [],
+  color: "#90a4ae",
+};
+
+/** サブトラクティブパレットを模したスキル */
+const SUBTRACTIVE_PALETTE = makeSkill({
+  id: "subtractive-palette",
+  resourceChanges: [
+    { resourceId: "palette-gauge", amount: -50 },
+    { resourceId: "white-paint", amount: -1 },
+    { resourceId: "black-paint", amount: 1 },
+  ],
+  buffSkippableResource: { buffId: "subtractive-ready", resourceId: "palette-gauge" },
+});
+
+/** subtractive-ready を付与するスキル（イマジンスカイ相当） */
+const GRANT_READY = makeSkill({
+  id: "grant-ready",
+  buffApplications: ["subtractive-ready"],
+});
+
+/** WPを補充するスキル（セットアップ用） */
+const FILL_WP = makeSkill({ id: "fill-wp", resourceChanges: [{ resourceId: "white-paint", amount: 5 }] });
+
+/** PGを補充するスキル（セットアップ用） */
+const FILL_PG = makeSkill({ id: "fill-pg", resourceChanges: [{ resourceId: "palette-gauge", amount: 50 }] });
+
+describe("サブトラReady によるサブトラクティブパレット発動条件緩和", () => {
+  it("subtractive-ready なし・PG50未満 → resourceError（従来動作）", () => {
+    const skillMap = new Map([
+      [SUBTRACTIVE_PALETTE.id, SUBTRACTIVE_PALETTE],
+      [FILL_WP.id, FILL_WP],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("fill-wp"), makeEntry("subtractive-palette")],
+      skillMap,
+      PCT_RESOURCES,
+      undefined,
+      [SUBTRACTIVE_READY_BUFF]
+    );
+
+    expect(result.entries[1].resourceErrors).toContain("palette-gauge");
+  });
+
+  it("subtractive-ready なし・PG50以上 → 正常実行（PG=-50, WP=-1, BP=+1）", () => {
+    const skillMap = new Map([
+      [SUBTRACTIVE_PALETTE.id, SUBTRACTIVE_PALETTE],
+      [FILL_WP.id, FILL_WP],
+      [FILL_PG.id, FILL_PG],
+      [makeSkill({ id: "noop" }).id, makeSkill({ id: "noop" })],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("fill-wp"), makeEntry("fill-pg"), makeEntry("subtractive-palette"), makeEntry("noop")],
+      skillMap,
+      PCT_RESOURCES,
+      undefined,
+      [SUBTRACTIVE_READY_BUFF]
+    );
+
+    expect(result.entries[2].resourceErrors).toEqual([]);
+    // 直後のエントリのスナップショットで検証: PG=0, WP=4, BP=1
+    const after = result.entries[3].resourceSnapshot;
+    expect(after["palette-gauge"]).toBe(0);
+    expect(after["white-paint"]).toBe(4);
+    expect(after["black-paint"]).toBe(1);
+  });
+
+  it("subtractive-ready あり・PG0 → エラーなしで実行・バフ消費・WP→BP変換は維持", () => {
+    const skillMap = new Map([
+      [SUBTRACTIVE_PALETTE.id, SUBTRACTIVE_PALETTE],
+      [FILL_WP.id, FILL_WP],
+      [GRANT_READY.id, GRANT_READY],
+      [makeSkill({ id: "noop" }).id, makeSkill({ id: "noop" })],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("fill-wp"),
+        makeEntry("grant-ready"),
+        makeEntry("subtractive-palette"),
+        makeEntry("noop"),
+      ],
+      skillMap,
+      PCT_RESOURCES,
+      undefined,
+      [SUBTRACTIVE_READY_BUFF]
+    );
+
+    // エラーなし
+    expect(result.entries[2].resourceErrors).toEqual([]);
+    // 実行後スナップショット: PG温存（=0のまま）・WP=4・BP=1
+    const after = result.entries[3].resourceSnapshot;
+    expect(after["palette-gauge"]).toBe(0);
+    expect(after["white-paint"]).toBe(4);
+    expect(after["black-paint"]).toBe(1);
+    // バフは消費済（次エントリ時点で無い）
+    expect(
+      result.entries[3].activeBuffs.some((b) => b.buffId === "subtractive-ready")
+    ).toBe(false);
+  });
+
+  it("subtractive-ready あり・PG50以上 → バフ優先消費・PGは温存（Ready優先仕様）", () => {
+    const skillMap = new Map([
+      [SUBTRACTIVE_PALETTE.id, SUBTRACTIVE_PALETTE],
+      [FILL_WP.id, FILL_WP],
+      [FILL_PG.id, FILL_PG],
+      [GRANT_READY.id, GRANT_READY],
+      [makeSkill({ id: "noop" }).id, makeSkill({ id: "noop" })],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("fill-wp"),
+        makeEntry("fill-pg"),
+        makeEntry("grant-ready"),
+        makeEntry("subtractive-palette"),
+        makeEntry("noop"),
+      ],
+      skillMap,
+      PCT_RESOURCES,
+      undefined,
+      [SUBTRACTIVE_READY_BUFF]
+    );
+
+    expect(result.entries[3].resourceErrors).toEqual([]);
+    const after = result.entries[4].resourceSnapshot;
+    // PGは温存される（=50のまま）
+    expect(after["palette-gauge"]).toBe(50);
+    // WP→BP変換は実行
+    expect(after["white-paint"]).toBe(4);
+    expect(after["black-paint"]).toBe(1);
+    // バフ消費
+    expect(
+      result.entries[4].activeBuffs.some((b) => b.buffId === "subtractive-ready")
+    ).toBe(false);
+  });
+
+  it("subtractive-ready あり・WP0 → WP不足のエラーは依然として発生する（バフはPGのみをスキップ）", () => {
+    const skillMap = new Map([
+      [SUBTRACTIVE_PALETTE.id, SUBTRACTIVE_PALETTE],
+      [GRANT_READY.id, GRANT_READY],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant-ready"), makeEntry("subtractive-palette")],
+      skillMap,
+      PCT_RESOURCES,
+      undefined,
+      [SUBTRACTIVE_READY_BUFF]
+    );
+
+    // palette-gauge はスキップされるが white-paint は不足エラーとなる
+    expect(result.entries[1].resourceErrors).toContain("white-paint");
+    expect(result.entries[1].resourceErrors).not.toContain("palette-gauge");
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -550,11 +550,24 @@ export function resolveTimeline(
     // スキル実行前のリソーススナップショット
     const snapshot: ResourceSnapshot = { ...resourceState };
 
+    // buffSkippableResource: 指定バフがアクティブなら resourceChanges の該当リソース消費をスキップ
+    // （バフ優先消費。下の resourceChanges 適用時・バフ消費時にも参照される）
+    let skippedResourceId: string | null = null;
+    if (skill.buffSkippableResource) {
+      const hasBuff = currentActiveBuffs.some(
+        (ab) => ab.buffId === skill.buffSkippableResource!.buffId
+      );
+      if (hasBuff) {
+        skippedResourceId = skill.buffSkippableResource.resourceId;
+      }
+    }
+
     // リソース不足チェック
     const resourceErrors: string[] = [];
     if (skill.resourceChanges) {
       for (const change of skill.resourceChanges) {
         if (change.amount < 0) {
+          if (skippedResourceId !== null && change.resourceId === skippedResourceId) continue;
           const required = Math.abs(change.amount);
           if (resourceState[change.resourceId] < required) {
             resourceErrors.push(change.resourceId);
@@ -728,9 +741,29 @@ export function resolveTimeline(
         }
       };
 
-      // リソース変動を適用
+      // リソース変動を適用（buffSkippableResource でスキップ対象になった負の変動は除外）
       if (skill.resourceChanges) {
-        applyResourceChanges(resourceState, skill.resourceChanges, resourceDefMap, resources, onResourceApplied);
+        const changes = skippedResourceId !== null
+          ? skill.resourceChanges.filter(
+              (c) => !(c.resourceId === skippedResourceId && c.amount < 0)
+            )
+          : skill.resourceChanges;
+        applyResourceChanges(resourceState, changes, resourceDefMap, resources, onResourceApplied);
+      }
+
+      // buffSkippableResource: リソース消費をスキップした分、バフを1スタック消費
+      if (skippedResourceId !== null && skill.buffSkippableResource) {
+        const buffId = skill.buffSkippableResource.buffId;
+        const idx = currentActiveBuffs.findIndex((ab) => ab.buffId === buffId);
+        if (idx >= 0) {
+          const ab = currentActiveBuffs[idx];
+          if (ab.stacks !== undefined) {
+            ab.stacks = Math.max(0, ab.stacks - 1);
+            if (ab.stacks === 0) currentActiveBuffs.splice(idx, 1);
+          } else {
+            currentActiveBuffs.splice(idx, 1);
+          }
+        }
       }
 
       // コンボ成立時のみのリソース変動を適用

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -105,6 +105,8 @@ export interface Skill {
   buffApplicationsByConsumedCount?: string[][];
   /** バフ消費のOR条件（いずれか1つを消費。potency指定時は威力を上書き、procRate+fallbackPotency指定時は期待値を計算） */
   buffConsumptionAnyOf?: { buffId: string; stacks: number; potency?: number; procRate?: number; fallbackPotency?: number }[];
+  /** 指定バフがアクティブな場合、resourceChangesの特定リソース消費をスキップしバフを1スタック消費する（バフ優先消費） */
+  buffSkippableResource?: { buffId: string; resourceId: string };
   /** 指定バフがアクティブなら威力を上書きしバフを消費する。バフ未付与時は通常威力で実行（エラーにならない） */
   conditionalPotencyBuffs?: { buffId: string; potency: number }[];
   /** スキル使用に必要なバフID（未アクティブ時はエラー、威力を計上しない） */


### PR DESCRIPTION
## 概要

ピクトマンサーのサブトラクティブパレットは、通常パレットゲージ50消費を要求するが、イマジンスカイで付与される `subtractive-ready` バフがあるときはパレットゲージ不足でも使用可能（発動条件緩和）。現状はバフ有無にかかわらず常にPG消費を要求していたため、イマジンスカイ直後にパレットゲージ不足エラーが誤って表示されていた問題を修正。

## 変更点

### `src/client/types/skill.ts`
- `Skill` に `buffSkippableResource?: { buffId: string; resourceId: string }` フィールドを追加
  - 指定バフがアクティブな場合、`resourceChanges` の該当リソースの消費をスキップしてバフを1スタック消費する汎用機構

### `src/client/logic/resolve-timeline.ts`
- スキル解決時に `buffSkippableResource` を判定：
  - バフがアクティブ → 該当リソースの不足チェックをスキップ / 負のリソース変動をスキップ / バフを1スタック消費
  - バフが無い → 従来通りリソース消費
- WP→BP などの他のリソース変動はそのまま適用（消費スキップは指定 `resourceId` の負変動のみ）

### `src/client/data/pct-skills.ts`
- サブトラクティブパレットに `buffSkippableResource: { buffId: "subtractive-ready", resourceId: "palette-gauge" }` を追加

## 設計判断

FF14実機仕様に準拠し「Ready バフ優先消費・パレットゲージ温存」を採用。WP→BP 変換は維持。類似の #110（乱れ撃ちによるホークアイ不要化）はバフ同士の代替で `buffConsumptionAnyOf` を利用したが、本件はバフ→リソースの代替のため新フィールド `buffSkippableResource` を追加。

## テスト

`src/client/logic/__tests__/pct-subtractive-ready.test.ts` を追加。以下を検証：
- subtractive-ready なし・PG不足 → `resourceError`（従来通り）
- subtractive-ready なし・PG十分 → 正常実行（PG-50, WP-1, BP+1）
- subtractive-ready あり・PG0 → エラーなし・バフ消費・WP→BP維持
- subtractive-ready あり・PG十分 → バフ優先消費しPG温存
- subtractive-ready あり・WP不足 → WP不足は引き続きエラー（PG消費のみスキップ）

検証結果:
- `npx vitest run`: 全10ファイル / 51テスト パス
- `npx tsc --noEmit`: 型エラーなし
- `npx vite build`: ビルド成功

closes #150