### PR TITLE
fix: ブラックコメット使用時に色調反転バフを消費するよう修正 #154

### DIFF
--- a/src/client/data/pct-skills.ts
+++ b/src/client/data/pct-skills.ts
@@ -239,6 +239,7 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
       { resourceId: "black-paint", amount: -1 },
     ],
     requiredBuff: "color-inversion",
+    buffConsumptions: [{ buffId: "color-inversion", stacks: 1 }],
     traitPotencyOverrides: [
       { traitLevel: 94, potency: 940 },
     ],


### PR DESCRIPTION
## 概要

ピクトマンサーのブラックコメット（`comet-in-black`）使用時に色調反転（`color-inversion`）バフが消費・解除されず、BPが0になった後のホワイトホーリーが誤って `autoTransform` でブラックコメットに置き換わり威力計算対象外になるバグを修正した。

## 変更点

- `src/client/data/pct-skills.ts` の `comet-in-black` 定義に `buffConsumptions: [{ buffId: "color-inversion", stacks: 1 }]` を追加
  - これにより使用時に `color-inversion` バフが解除される
  - 既存の `requiredBuff: "color-inversion"` は維持

## テスト

- `npm test` 全46件 PASS（9 test files）
- `npx tsc --noEmit` 型チェック PASS
- 想定挙動（再現手順より）:
  1. サブトラクティブパレット → `color-inversion` 付与、BP 1
  2. ホワイトホーリー → ブラックコメットに置き換わり、威力940、BP 0、`color-inversion` 解除
  3. 2個目のホワイトホーリー → 通常のホワイトホーリー（威力570）として実行

closes #154

https://claude.ai/code/session_019AErEhDCvxzVCPPJgbwhdL