### PR TITLE
fix: バフスパン描画が自然失効時刻を超えて延びるバグを修正 #159

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow, PpsRange } from "../types/skill";
 import { calcGcd, calcExpectedMultiplier } from "../logic/stat-calc";
+import { computeBuffTimespans } from "../logic/buff-timespans";
 import "./timeline.css";
 
 /** 1秒あたりのピクセル数 */
@@ -545,69 +546,11 @@ export function Timeline({
   // ドラッグオーバー時のstickyラベル背景色（ドロップゾーンの黄色みと視覚的に一致させる）
   const labelBg = dragOver ? "#1b1921" : "#0f0f23";
 
-  // タイムライン上の全バフ期間を収集（重複排除）
-  // スタック付きバフの場合、スタックが0になった時点でバフ終了とみなす
-  const buffTimespans = useMemo(() => {
-    const spans: Map<string, ActiveBuff[]> = new Map();
-    const stackableBuffIds = new Set(buffs.filter((b) => b.maxStacks).map((b) => b.id));
-    // 全バフを早期終了チェック対象（スタック消費、排他グループ、buffConsumptions等）
-    const allBuffIds = new Set(buffs.map((b) => b.id));
-    const earlyTerminationBuffIds = allBuffIds;
-
-    for (const entry of resolvedEntries) {
-      for (const ab of entry.activeBuffs) {
-        if (!spans.has(ab.buffId)) {
-          spans.set(ab.buffId, []);
-        }
-        const list = spans.get(ab.buffId)!;
-
-        if (stackableBuffIds.has(ab.buffId)) {
-          // スタック付きバフ: 同じ開始時刻のものは更新しない（初回のみ追加）
-          if (!list.some((s) => s.startTime === ab.startTime)) {
-            list.push({ ...ab });
-          }
-        } else {
-          // 通常バフ: 同じ開始・終了時刻のものは重複追加しない
-          if (!list.some((s) => s.startTime === ab.startTime && s.endTime === ab.endTime)) {
-            list.push(ab);
-          }
-        }
-      }
-    }
-
-    // スタック消費 or 排他グループ解除によるバフの実際の終了時刻を算出
-    for (const [buffId, spanList] of spans) {
-      if (!earlyTerminationBuffIds.has(buffId)) continue;
-      for (const span of spanList) {
-        let lastSeenTime = span.startTime;
-        for (const entry of resolvedEntries) {
-          const match = entry.activeBuffs.find(
-            (ab) => ab.buffId === buffId && ab.startTime === span.startTime
-          );
-          if (match) {
-            lastSeenTime = entry.startTime;
-          }
-        }
-        // スタック消費で終了した場合、最後に確認されたエントリの時刻を終了時刻とする
-        if (lastSeenTime < span.endTime) {
-          // 次のエントリでバフが消えたか確認
-          const allTimes = resolvedEntries.map((e) => e.startTime).sort((a, b) => a - b);
-          const nextTimeIdx = allTimes.findIndex((t) => t > lastSeenTime);
-          if (nextTimeIdx >= 0) {
-            const nextEntry = resolvedEntries.find((e) => e.startTime === allTimes[nextTimeIdx]);
-            const stillActive = nextEntry?.activeBuffs.some(
-              (ab) => ab.buffId === buffId && ab.startTime === span.startTime
-            );
-            if (!stillActive) {
-              span.endTime = allTimes[nextTimeIdx];
-            }
-          }
-        }
-      }
-    }
-
-    return spans;
-  }, [resolvedEntries, buffs]);
+  // タイムライン上の全バフ期間を収集（重複排除）。消費・排他解除時は実際に消えた時刻へクランプする
+  const buffTimespans = useMemo(
+    () => computeBuffTimespans(resolvedEntries, buffs),
+    [resolvedEntries, buffs],
+  );
 
   // リソースエラーまたはコンボエラーがあるエントリのUIDセット
   const entriesWithErrors = useMemo(() => {

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { computeBuffTimespans } from "../buff-timespans";
+import type { ActiveBuff, BuffDefinition, ResolvedTimelineEntry } from "../../types/skill";
+
+const buff30s: BuffDefinition = {
+  id: "test-buff",
+  name: "テストバフ",
+  shortName: "TB",
+  icon: "",
+  duration: 30,
+  effects: [],
+  color: "#ff0000",
+};
+
+function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimelineEntry {
+  return {
+    uid: `e-${startTime}`,
+    skillId: "dummy",
+    resolvedSkillId: "dummy",
+    resolvedPotency: 0,
+    startTime,
+    resourceSnapshot: {},
+    resourceErrors: [],
+    comboErrors: [],
+    untargetableError: false,
+    recastError: false,
+    wsComboError: false,
+    activeBuffs,
+    buffMultiplier: 1,
+    critRateBonus: 0,
+    dhRateBonus: 0,
+  };
+}
+
+describe("computeBuffTimespans", () => {
+  it("バフ消費前に自然失効ポイントを跨ぐエントリ間ギャップがあってもスパンが30秒を超えない（#159）", () => {
+    // aetherhues-3 が t=0 に付与され本来 t=30 で自然失効。
+    // t=10 までアクティブ、次のエントリが t=32（自然失効後）でバフが消えている場合、
+    // 修正前は span.endTime = 32 となりバーが30秒を超えて描画されていた。
+    const ab: ActiveBuff = { buffId: "test-buff", startTime: 0, endTime: 30 };
+    const entries: ResolvedTimelineEntry[] = [
+      makeEntry(0, [ab]),
+      makeEntry(10, [ab]),
+      makeEntry(32, []),
+    ];
+
+    const spans = computeBuffTimespans(entries, [buff30s]);
+    const list = spans.get("test-buff")!;
+
+    expect(list).toHaveLength(1);
+    expect(list[0].endTime).toBe(30);
+  });
+
+  it("バフ消費が自然失効より前なら、スパンは消費エントリ時刻まで詰められる", () => {
+    const ab: ActiveBuff = { buffId: "test-buff", startTime: 0, endTime: 30 };
+    const entries: ResolvedTimelineEntry[] = [
+      makeEntry(0, [ab]),
+      makeEntry(5, [ab]),
+      makeEntry(10, []),
+    ];
+
+    const spans = computeBuffTimespans(entries, [buff30s]);
+    const list = spans.get("test-buff")!;
+
+    expect(list).toHaveLength(1);
+    expect(list[0].endTime).toBe(10);
+  });
+
+  it("バフがリフレッシュされると startTime 別に独立したスパンとして扱う", () => {
+    const first: ActiveBuff = { buffId: "test-buff", startTime: 0, endTime: 30 };
+    const refreshed: ActiveBuff = { buffId: "test-buff", startTime: 20, endTime: 50 };
+    const entries: ResolvedTimelineEntry[] = [
+      makeEntry(0, [first]),
+      makeEntry(10, [first]),
+      makeEntry(20, [refreshed]),
+      makeEntry(45, [refreshed]),
+      makeEntry(55, []),
+    ];
+
+    const spans = computeBuffTimespans(entries, [buff30s]);
+    const list = spans.get("test-buff")!;
+
+    expect(list).toHaveLength(2);
+    const oldSpan = list.find((s) => s.startTime === 0)!;
+    const newSpan = list.find((s) => s.startTime === 20)!;
+    // 旧スパンはリフレッシュ時刻（20）で閉じる
+    expect(oldSpan.endTime).toBe(20);
+    // 新スパンは自然失効まで保持（次のエントリ 55 に延長されない）
+    expect(newSpan.endTime).toBe(50);
+  });
+
+  it("スパン調整は resolver スナップショットの ActiveBuff を副作用的に書き換えない", () => {
+    const ab: ActiveBuff = { buffId: "test-buff", startTime: 0, endTime: 30 };
+    const entries: ResolvedTimelineEntry[] = [
+      makeEntry(0, [ab]),
+      makeEntry(5, [ab]),
+      makeEntry(10, []),
+    ];
+
+    computeBuffTimespans(entries, [buff30s]);
+
+    expect(ab.endTime).toBe(30);
+  });
+
+  it("最後のエントリまでアクティブなバフは自然失効時刻を維持する", () => {
+    const ab: ActiveBuff = { buffId: "test-buff", startTime: 0, endTime: 30 };
+    const entries: ResolvedTimelineEntry[] = [
+      makeEntry(0, [ab]),
+      makeEntry(10, [ab]),
+      makeEntry(20, [ab]),
+    ];
+
+    const spans = computeBuffTimespans(entries, [buff30s]);
+    const list = spans.get("test-buff")!;
+
+    expect(list[0].endTime).toBe(30);
+  });
+});

--- a/src/client/logic/buff-timespans.ts
+++ b/src/client/logic/buff-timespans.ts
@@ -1,0 +1,74 @@
+import type { ActiveBuff, BuffDefinition, ResolvedTimelineEntry } from "../types/skill";
+
+/**
+ * タイムライン上のバフ表示スパンを算出する。
+ *
+ * 各 `ResolvedTimelineEntry.activeBuffs` のスナップショットから、`(buffId, startTime)` ごとに
+ * 1本のスパンを構築する。スタック消費・排他解除・消費スキルなどにより自然終了時刻より早く
+ * バフが消えた場合は、実際に消えたエントリの時刻まで `endTime` を詰める（クランプ）。
+ *
+ * 注意: この処理は表示用であり、ダメージ計算側の `ActiveBuff.endTime` をそのまま使うと
+ * バフ消費後もスパンが `startTime + duration` まで描画されてしまう。
+ */
+export function computeBuffTimespans(
+  resolvedEntries: ResolvedTimelineEntry[],
+  buffs: BuffDefinition[],
+): Map<string, ActiveBuff[]> {
+  const spans: Map<string, ActiveBuff[]> = new Map();
+  const stackableBuffIds = new Set(buffs.filter((b) => b.maxStacks).map((b) => b.id));
+
+  for (const entry of resolvedEntries) {
+    for (const ab of entry.activeBuffs) {
+      if (!spans.has(ab.buffId)) {
+        spans.set(ab.buffId, []);
+      }
+      const list = spans.get(ab.buffId)!;
+
+      if (stackableBuffIds.has(ab.buffId)) {
+        if (!list.some((s) => s.startTime === ab.startTime)) {
+          list.push({ ...ab });
+        }
+      } else {
+        if (!list.some((s) => s.startTime === ab.startTime && s.endTime === ab.endTime)) {
+          // resolver 側のスナップショット参照をそのまま保持するとスパン調整が副作用になるので clone
+          list.push({ ...ab });
+        }
+      }
+    }
+  }
+
+  const allTimes = resolvedEntries.map((e) => e.startTime).sort((a, b) => a - b);
+
+  // スタック消費・排他解除・消費スキルによる実際の終了時刻へスパンを詰める
+  for (const spanList of spans.values()) {
+    for (const span of spanList) {
+      let lastSeenTime = span.startTime;
+      for (const entry of resolvedEntries) {
+        const match = entry.activeBuffs.find(
+          (ab) => ab.buffId === span.buffId && ab.startTime === span.startTime,
+        );
+        if (match) {
+          lastSeenTime = entry.startTime;
+        }
+      }
+      if (lastSeenTime >= span.endTime) continue;
+
+      const nextTimeIdx = allTimes.findIndex((t) => t > lastSeenTime);
+      if (nextTimeIdx < 0) continue;
+
+      const nextTime = allTimes[nextTimeIdx];
+      const nextEntry = resolvedEntries.find((e) => e.startTime === nextTime);
+      const stillActive = nextEntry?.activeBuffs.some(
+        (ab) => ab.buffId === span.buffId && ab.startTime === span.startTime,
+      );
+      if (stillActive) continue;
+
+      // クランプ: 次のエントリ時刻が自然終了時刻より後ろにある場合でも、スパンを延長しない。
+      // これをしないと、バフ消費前に自然失効ポイントを跨ぐエントリ間ギャップがあると
+      // スパンが `startTime + duration` を超えて描画される（#159）。
+      span.endTime = Math.min(span.endTime, nextTime);
+    }
+  }
+
+  return spans;
+}


### PR DESCRIPTION
## 概要

`Timeline.tsx` の `buffTimespans` で、バフ消費前のエントリ間ギャップが自然失効時刻を跨ぐと、スパン終了時刻が逆方向に延長され、`aetherhues-3`（色魔法3実行可）などのバフバーが本来の30秒を超えて描画されていた問題（#159）を修正する。

## 根本原因

`Timeline.tsx` 旧実装 L592-605 の早期終了ロジック:

```ts
if (lastSeenTime < span.endTime) {
  const nextTimeIdx = allTimes.findIndex((t) => t > lastSeenTime);
  if (nextTimeIdx >= 0) {
    const nextEntry = ...;
    const stillActive = ...;
    if (!stillActive) {
      span.endTime = allTimes[nextTimeIdx]; // ← 無条件代入
    }
  }
}
```

`span.endTime` を「次のエントリ時刻」へ**無条件に**代入していたため、`lastSeenTime`（バフが最後に残っていたエントリ時刻）と次エントリの間で自然失効時刻を跨ぐと、スパンが縮むどころか延びていた。

例: `aetherhues-3` が `t=0` に付与され `endTime=30`、`t=10` までアクティブ、その後 `t=32` のエントリでバフが消えている場合、修正前は `span.endTime = 32` となりバーが30秒を超えて表示されていた。

## 変更点

- `src/client/logic/buff-timespans.ts` を新規追加し、`buffTimespans` ロジックを純粋関数 `computeBuffTimespans` として抽出（ユニットテスト可能化）
- スパン延長を防ぐため `span.endTime = Math.min(span.endTime, nextTime)` でクランプ
- 通常バフ系のスパン収集時に `ActiveBuff` 参照をそのまま push していたのを `{ ...ab }` で clone し、`resolver` スナップショットへの副作用書き換えを排除
- `src/client/components/Timeline.tsx` の useMemo を `computeBuffTimespans` の呼び出しだけに簡略化
- `src/client/logic/__tests__/buff-timespans.test.ts` に回帰テストを追加

## テスト

- `npm test` — 全 12 ファイル / 62 テスト PASS（新規 5 テストを含む）
- `npx tsc --noEmit` — 型エラーなし
- 回帰テストで以下をカバー:
  - #159 再現ケース（自然失効点を跨ぐギャップでもスパンが30秒を超えない）
  - 自然失効前のバフ消費による正常なスパン短縮
  - リフレッシュ時の独立スパン扱いと新スパン延長防止
  - `resolver` スナップショットへの副作用不在
  - 最終エントリまでアクティブなバフの自然失効時刻維持

closes #159