### PR TITLE
feat: タイムライン内スキルのD&D並び替えと削除ドロップエリアを追加 #164

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -125,6 +125,22 @@ export function App() {
     setEntries((prev) => prev.filter((e) => e.uid !== uid));
   }, []);
 
+  const handleMoveEntry = useCallback((uid: string, insertBeforeUid?: string) => {
+    if (insertBeforeUid === uid) return;
+    setEntries((prev) => {
+      const fromIdx = prev.findIndex((e) => e.uid === uid);
+      if (fromIdx < 0) return prev;
+      const entry = prev[fromIdx];
+      const without = [...prev.slice(0, fromIdx), ...prev.slice(fromIdx + 1)];
+      if (insertBeforeUid) {
+        const toIdx = without.findIndex((e) => e.uid === insertBeforeUid);
+        if (toIdx < 0) return prev;
+        return [...without.slice(0, toIdx), entry, ...without.slice(toIdx)];
+      }
+      return [...without, entry];
+    });
+  }, []);
+
   // per-entryのクリティカル率ボーナスを考慮した合計期待威力
   const { totalExpectedPotency, dotExpectedPotency } = useMemo(() => {
     const directExpected = resolvedEntries.reduce((sum, entry) => {
@@ -190,6 +206,7 @@ export function App() {
           resolvedEntries={resolvedEntries}
           onAddEntry={handleAddEntry}
           onRemoveEntry={handleRemoveEntry}
+          onMoveEntry={handleMoveEntry}
           resources={levelResources}
           buffs={levelBuffs}
           totalExpectedPotency={totalExpectedPotency}

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -41,6 +41,7 @@ interface TimelineProps {
   resolvedEntries: ResolvedTimelineEntry[];
   onAddEntry: (skillId: string, insertBeforeUid?: string) => void;
   onRemoveEntry: (uid: string) => void;
+  onMoveEntry: (uid: string, insertBeforeUid?: string) => void;
   resources: ResourceDefinition[];
   buffs: BuffDefinition[];
   totalExpectedPotency: number;
@@ -101,6 +102,7 @@ export function Timeline({
   resolvedEntries,
   onAddEntry,
   onRemoveEntry,
+  onMoveEntry,
   resources,
   buffs,
   totalExpectedPotency,
@@ -119,6 +121,10 @@ export function Timeline({
   const [dragOver, setDragOver] = useState(false);
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
   const [dragType, setDragType] = useState<"gcd" | "ogcd" | null>(null);
+  /** タイムライン内ドラッグ中のエントリUID（null = パレットドラッグ中 or 非ドラッグ） */
+  const [draggingEntryUid, setDraggingEntryUid] = useState<string | null>(null);
+  /** 削除ドロップエリア上にカーソルがあるか */
+  const [overDeleteZone, setOverDeleteZone] = useState(false);
   const [showResources, setShowResources] = useState(true);
 
   // リソースをdisplayGroupでグループ化（同じグループは1行にまとめる）
@@ -176,14 +182,6 @@ export function Timeline({
   const dragRafRef = useRef<number | null>(null);
   /** dragenter/dragleaveの子要素間移動を無視するためのカウンター */
   const dragEnterCountRef = useRef(0);
-
-  const handleRemoveEntry = useCallback(
-    (uid: string) => {
-      shouldAutoScrollRef.current = false;
-      onRemoveEntry(uid);
-    },
-    [onRemoveEntry]
-  );
 
   // パレット用のスキルマップ（ドラッグ判定用）
   const paletteSkillMap = useMemo(
@@ -383,6 +381,67 @@ export function Timeline({
     return e.dataTransfer.types.includes("application/skill-type-gcd") ? "gcd" : "ogcd";
   }, []);
 
+  /** ドラッグ元を検出（タイムライン内エントリのD&D か、パレットからの新規追加か） */
+  const detectDragSource = useCallback((e: React.DragEvent): "timeline" | "palette" => {
+    return e.dataTransfer.types.includes("application/timeline-entry-uid") ? "timeline" : "palette";
+  }, []);
+
+  const handleEntryDragStart = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, entry: { uid: string; skillId: string }, skill: Skill) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("application/timeline-entry-uid", entry.uid);
+      e.dataTransfer.setData("application/skill-id", entry.skillId);
+      e.dataTransfer.setData(`application/skill-type-${skill.type}`, "1");
+      setDraggingEntryUid(entry.uid);
+    },
+    []
+  );
+
+  const handleEntryDragEnd = useCallback(() => {
+    setDraggingEntryUid(null);
+    setOverDeleteZone(false);
+    setInsertIndex(null);
+    setDragType(null);
+    dragEnterCountRef.current = 0;
+    if (dragRafRef.current !== null) {
+      cancelAnimationFrame(dragRafRef.current);
+      dragRafRef.current = null;
+    }
+  }, []);
+
+  const handleDeleteZoneDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    if (!e.dataTransfer.types.includes("application/timeline-entry-uid")) return;
+    setOverDeleteZone(true);
+  }, []);
+
+  const handleDeleteZoneDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("application/timeline-entry-uid")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const handleDeleteZoneDragLeave = useCallback(() => {
+    setOverDeleteZone(false);
+  }, []);
+
+  const handleDeleteZoneDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const uid = e.dataTransfer.getData("application/timeline-entry-uid");
+      setOverDeleteZone(false);
+      setDraggingEntryUid(null);
+      setInsertIndex(null);
+      setDragType(null);
+      if (uid) {
+        shouldAutoScrollRef.current = false;
+        onRemoveEntry(uid);
+      }
+    },
+    [onRemoveEntry]
+  );
+
   /** GCDエントリのみをフィルタ */
   const gcdResolvedEntries = useMemo(
     () => resolvedEntries.filter((entry) => {
@@ -488,31 +547,51 @@ export function Timeline({
       e.preventDefault();
       setDragOver(false);
 
+      const source = detectDragSource(e);
       const skillId = e.dataTransfer.getData("application/skill-id");
       if (!skillId) {
         setInsertIndex(null);
         setDragType(null);
+        setDraggingEntryUid(null);
         return;
       }
 
-      if (scrollRef.current && resolvedEntries.length > 0) {
-        const rect = scrollRef.current.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-        const skill = skillMap.get(skillId);
-        const type: "gcd" | "ogcd" = skill?.type === "gcd" ? "gcd" : "ogcd";
-        const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
-        const isInsertMiddle = idx < resolvedEntries.length;
-        if (isInsertMiddle) {
-          shouldAutoScrollRef.current = false;
+      const skill = skillMap.get(skillId);
+      const type: "gcd" | "ogcd" = skill?.type === "gcd" ? "gcd" : "ogcd";
+
+      if (source === "timeline") {
+        const movingUid = e.dataTransfer.getData("application/timeline-entry-uid");
+        if (movingUid && scrollRef.current && resolvedEntries.length > 0) {
+          const rect = scrollRef.current.getBoundingClientRect();
+          const mouseX = e.clientX - rect.left;
+          const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
+          const targetEntry = idx < resolvedEntries.length ? resolvedEntries[idx] : undefined;
+          // 同位置（直後のエントリが自分自身）へのドロップは no-op
+          if (!targetEntry || targetEntry.uid !== movingUid) {
+            shouldAutoScrollRef.current = false;
+            onMoveEntry(movingUid, targetEntry?.uid);
+          }
         }
-        onAddEntry(skillId, isInsertMiddle ? resolvedEntries[idx].uid : undefined);
       } else {
-        onAddEntry(skillId);
+        if (scrollRef.current && resolvedEntries.length > 0) {
+          const rect = scrollRef.current.getBoundingClientRect();
+          const mouseX = e.clientX - rect.left;
+          const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
+          const isInsertMiddle = idx < resolvedEntries.length;
+          if (isInsertMiddle) {
+            shouldAutoScrollRef.current = false;
+          }
+          onAddEntry(skillId, isInsertMiddle ? resolvedEntries[idx].uid : undefined);
+        } else {
+          onAddEntry(skillId);
+        }
       }
+
       setInsertIndex(null);
       setDragType(null);
+      setDraggingEntryUid(null);
     },
-    [onAddEntry, resolvedEntries, skillMap, calcCombinedInsertIndex]
+    [onAddEntry, onMoveEntry, resolvedEntries, skillMap, calcCombinedInsertIndex, detectDragSource]
   );
 
   /**
@@ -879,14 +958,18 @@ export function Timeline({
                             ...styles.skillIcon,
                             ...(hasError ? styles.skillIconError : {}),
                             ...(entry.wsComboError ? styles.skillIconComboWarning : {}),
+                            ...(draggingEntryUid === entry.uid ? styles.skillIconDragging : {}),
                           }}
                           title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
-                          onClick={() => handleRemoveEntry(entry.uid)}
+                          draggable
+                          onDragStart={(e) => handleEntryDragStart(e, entry, entry.skill)}
+                          onDragEnd={handleEntryDragEnd}
                         >
                           <img
                             src={entry.displaySkill.icon}
                             alt={entry.displaySkill.name}
                             style={styles.iconImage}
+                            draggable={false}
                           />
                         </div>
                         <div style={{
@@ -926,14 +1009,18 @@ export function Timeline({
                           style={{
                             ...styles.ogcdIcon,
                             ...(hasError ? styles.ogcdIconError : {}),
+                            ...(draggingEntryUid === entry.uid ? styles.ogcdIconDragging : {}),
                           }}
                           title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
-                          onClick={() => handleRemoveEntry(entry.uid)}
+                          draggable
+                          onDragStart={(e) => handleEntryDragStart(e, entry, entry.skill)}
+                          onDragEnd={handleEntryDragEnd}
                         >
                           <img
                             src={entry.displaySkill.icon}
                             alt={entry.displaySkill.name}
                             style={styles.iconImage}
+                            draggable={false}
                           />
                         </div>
                         <div style={styles.skillPotency}>
@@ -1307,7 +1394,25 @@ export function Timeline({
         )}
       </div>
 
-      <div style={styles.hint}>クリックでスキルを削除</div>
+      <div style={styles.hint}>
+        タイムライン上のスキルをドラッグで並び替え／画面下部のエリアにドロップで削除
+      </div>
+
+      {draggingEntryUid !== null && (
+        <div
+          style={{
+            ...styles.deleteDropZone,
+            ...(overDeleteZone ? styles.deleteDropZoneActive : {}),
+          }}
+          onDragEnter={handleDeleteZoneDragEnter}
+          onDragOver={handleDeleteZoneDragOver}
+          onDragLeave={handleDeleteZoneDragLeave}
+          onDrop={handleDeleteZoneDrop}
+        >
+          <div style={styles.deleteDropZoneIcon} aria-hidden>×</div>
+          <div style={styles.deleteDropZoneLabel}>ここにドロップして削除</div>
+        </div>
+      )}
     </div>
   );
 }
@@ -1476,7 +1581,7 @@ const styles: Record<string, React.CSSProperties> = {
     height: ICON_SIZE,
     borderRadius: "6px",
     overflow: "hidden",
-    cursor: "pointer",
+    cursor: "grab",
     border: "1px solid rgba(255,255,255,0.2)",
     marginTop: "8px",
     flexShrink: 0,
@@ -1490,6 +1595,9 @@ const styles: Record<string, React.CSSProperties> = {
     border: "2px solid #ff9800",
     boxShadow: "0 0 8px rgba(255, 152, 0, 0.6)",
   },
+  skillIconDragging: {
+    opacity: 0.3,
+  },
   ogcdBlock: {
     position: "absolute",
     top: "8px",
@@ -1502,7 +1610,7 @@ const styles: Record<string, React.CSSProperties> = {
     height: ICON_SIZE - 4,
     borderRadius: "50%",
     overflow: "hidden",
-    cursor: "pointer",
+    cursor: "grab",
     border: "1px solid rgba(255,255,255,0.2)",
     flexShrink: 0,
     transition: "opacity 0.15s",
@@ -1510,6 +1618,9 @@ const styles: Record<string, React.CSSProperties> = {
   ogcdIconError: {
     border: "2px solid #ef5350",
     boxShadow: "0 0 8px rgba(239, 83, 80, 0.6)",
+  },
+  ogcdIconDragging: {
+    opacity: 0.3,
   },
   iconImage: {
     width: "100%",
@@ -1845,6 +1956,46 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "12px",
     color: "#555",
     textAlign: "center" as const,
+  },
+  deleteDropZone: {
+    position: "fixed" as const,
+    bottom: 32,
+    left: "50%",
+    transform: "translateX(-50%)",
+    minWidth: 260,
+    padding: "14px 28px",
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: "rgba(211, 47, 47, 0.85)",
+    color: "#fff",
+    border: "2px dashed rgba(255, 255, 255, 0.5)",
+    borderRadius: 12,
+    boxShadow: "0 6px 24px rgba(0, 0, 0, 0.5)",
+    fontSize: 14,
+    fontWeight: "bold" as const,
+    zIndex: 1000,
+    userSelect: "none" as const,
+    transition: "transform 0.15s, background-color 0.15s, border-color 0.15s",
+  },
+  deleteDropZoneActive: {
+    backgroundColor: "rgba(211, 47, 47, 1)",
+    borderColor: "rgba(255, 255, 255, 0.95)",
+    transform: "translateX(-50%) scale(1.06)",
+  },
+  deleteDropZoneIcon: {
+    width: 28,
+    height: 28,
+    borderRadius: "50%",
+    backgroundColor: "rgba(255, 255, 255, 0.18)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 20,
+    lineHeight: 1,
+  },
+  deleteDropZoneLabel: {
+    whiteSpace: "nowrap" as const,
   },
   // ボス離脱エディタ
   untargetableEditor: {


### PR DESCRIPTION
## 概要

タイムライン上のスキルをドラッグ＆ドロップで並び替えできるようにした。さらに、クリック削除とドラッグ操作の競合を避けるため、ドラッグ中のみ画面下部に削除ドロップエリアを表示し、そこへドロップすることで削除できるよう変更した。

closes #164

## 変更点

### 並び替え（方針A: `onMoveEntry` 追加）
- `App.tsx` に `handleMoveEntry(uid, insertBeforeUid?)` を追加。既存エントリを immutable に並び替え、uid を保持したまま `setEntries` を呼ぶ
- `Timeline.tsx` の props に `onMoveEntry` を追加
- GCD/oGCD の各スキルアイコンに `draggable={true}` と `onDragStart`/`onDragEnd` ハンドラを付与
- ドラッグ開始時の `dataTransfer` に以下をセット:
  - `application/timeline-entry-uid` = エントリの uid（並び替えソース識別用・新規）
  - `application/skill-id` = スキルID（既存）
  - `application/skill-type-{gcd|ogcd}` = "1"（既存の挿入位置計算用）
- `detectDragSource(e)` で `application/timeline-entry-uid` の有無を判定し、`handleDrop` を「パレット追加」と「タイムライン並び替え」に分岐
- 同位置ドロップ（`insertBeforeUid === uid`）は no-op
- GCD/oGCD 制限は既存の `calcCombinedInsertIndex` が type 別にインデックスを算出するため、自然に成立（GCD は GCD 境界、oGCD はアニメロック幅基準）

### 削除ドロップエリア
- `draggingEntryUid !== null` のときのみ `position: fixed` で画面下部中央に表示
- 自前の `onDragEnter/Over/Leave/Drop` を持ち、`application/timeline-entry-uid` がある場合のみ反応
- ドロップ時は `onRemoveEntry(uid)` を呼ぶ
- ホバー中は背景色を濃く＆拡大して視覚フィードバック
- ドラッグ終了（`dragend`）で自動的に非表示

### クリック削除の廃止
- GCD/oGCD アイコンの `onClick={() => handleRemoveEntry(...)}` を削除
- `cursor` を `"pointer"` → `"grab"` に変更（ドラッグ主体の操作を示唆）
- ヒントテキストを「クリックでスキルを削除」→「タイムライン上のスキルをドラッグで並び替え／画面下部のエリアにドロップで削除」に更新

### ドラッグ中のビジュアル
- ドラッグ中の元エントリは `opacity: 0.3` に半透明化（`skillIconDragging` / `ogcdIconDragging` スタイル）

## テスト

### 自動
- `npx tsc --noEmit`: エラーなし
- `npm test`: 62/62 passed（resolveTimeline 回帰テスト通過）

### 手動（Playwright MCP + browser_evaluate で HTML5 DnD を直接発火）
- [x] パレットからのドラッグで新規追加が動作する（グレアガ / ホーリガ / ディア を追加）
- [x] タイムラインエントリが `draggable="true"` になっている
- [x] ディアを先頭にドラッグすると順序が `ディア(0s) → グレアガ(2.5s) → ホーリガ(5s)` に入れ替わる
- [x] 並び替え後にタイムラインの時刻・威力が正しく再計算される（uid は保持）
- [x] ドラッグ中に元エントリが opacity 0.3 に変化する
- [x] ドラッグ中のみ画面下部に削除ドロップエリアが表示される
- [x] 削除エリアへのドロップでそのエントリのみが削除される（他は維持）
- [x] ドロップ後に削除エリアは自動で非表示になる

### レビュー推奨の追加手動チェック項目
- [ ] ブラウザでの実ドラッグ操作（マウス）で同様に動作するか（Playwright は HTML5 DnD を合成イベントで検証しているため、実操作でゴースト画像・カーソル変化等を確認）
- [ ] GCD を oGCD レーンに向けてドラッグしても、挿入位置が正しく GCD 境界になる
- [ ] oGCD の GCD リキャスト中への weaving 位置挿入が従来通り動作する
- [ ] ESC キャンセルで状態がクリアされる
- [ ] 長時間操作しても Chrome がクラッシュしない（#88 対策の継続）

https://claude.ai/code/session_01RmZ8RNPpb6CozT1pccBMjE