### PR TITLE
fix: castTime > recast の GCD スキルで詠唱バーが途中で切れる問題を修正 #170

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -915,17 +915,23 @@ export function Timeline({
                         : null
                     );
                     const isAutoTransformed = entry.resolvedSkillId !== entry.skillId;
+                    // castTime > recast の場合は次 GCD が打てるのは castTime 後（resolve-timeline.ts と整合）。
+                    // skillBlock の幅を max(castTime, recast) に拡張し、各バーを blockDuration 基準で割合計算する。
+                    const blockDuration = Math.max(castTime, recast);
                     return (
                       <div
                         key={entry.uid}
                         style={{
                           ...styles.skillBlock,
                           left: entry.startTime * PX_PER_SEC,
-                          width: recast * PX_PER_SEC,
+                          width: blockDuration * PX_PER_SEC,
                         }}
                       >
                         <div
-                          style={styles.recastBar}
+                          style={{
+                            ...styles.recastBar,
+                            width: (recast / blockDuration) * 100 + "%",
+                          }}
                           title={`リキャスト: ${recast}s`}
                         />
                         {castTime > 0 && (
@@ -936,7 +942,7 @@ export function Timeline({
                             <div
                               style={{
                                 ...styles.castTimeFill,
-                                width: (castTime / recast) * 100 + "%",
+                                width: (castTime / blockDuration) * 100 + "%",
                               }}
                             />
                           </div>
@@ -949,7 +955,7 @@ export function Timeline({
                             style={{
                               ...styles.animLockFill,
                               width:
-                                (entry.skill.animationLock / recast) * 100 + "%",
+                                (entry.skill.animationLock / blockDuration) * 100 + "%",
                             }}
                           />
                         </div>
@@ -1543,7 +1549,6 @@ const styles: Record<string, React.CSSProperties> = {
     position: "absolute",
     top: 0,
     left: 0,
-    right: 0,
     height: "4px",
     backgroundColor: "rgba(100, 149, 237, 0.3)",
     borderRadius: "2px",


### PR DESCRIPTION
## 概要

BLM のファイガ (`fire-3`, castTime: 3.5s) のようにスキルの詠唱時間が GCD リキャスト (2.5s) を超える場合に、Timeline.tsx の詠唱バーが recast 幅で切り落とされていた UI バグを修正する。

## 変更点

`src/client/components/Timeline.tsx`:

- GCD 行の `skillBlock` 幅を `recast * PX_PER_SEC` から `Math.max(castTime, recast) * PX_PER_SEC` に変更。次 GCD 開始時刻 `actionAvailableAt = startTime + max(castTime, animationLock)` (resolve-timeline.ts) と視覚的に整合させる
- `blockDuration = Math.max(castTime, recast)` を導入し、`recastBar` / `castTimeFill` / `animLockFill` の幅分母を統一
  - `recastBar`: `width: (recast / blockDuration) * 100%` — 詠唱支配スキルでは 2.5s 相当で止める
  - `castTimeFill`: `width: (castTime / blockDuration) * 100%` — fire-3 で 100% (= 3.5s 相当) に
  - `animLockFill`: `width: (animationLock / blockDuration) * 100%`
- `styles.recastBar` から `right: 0` を削除（呼び出し側で常に `width` を明示指定するため）

`castTime ≤ recast` の既存ケースは `blockDuration === recast` となり、各バーの計算式は変更前と数学的に等価（回帰なし）。

## テスト

- TypeScript 型チェック: 通過
- Vitest 73/73 テスト通過
- Playwright による実機検証:
  - **BLM ファイガ** (castTime 3.5s / recast 2.5s): skillBlock 280px (=3.5s×80) / recastBar 200px (2.5s相当) / castTimeFill 280px (3.5s相当, 100%) / animLockFill 52px (0.65s) — 詠唱バーが実詠唱時間分の長さで表示されることを確認
  - **WHM グレアガ** (castTime 1.5s / recast 2.5s): skillBlock 200px (=2.5s×80) / recastBar 200px (100%) / castTimeFill 120px (60%, 1.5s相当) / animLockFill 52px — 既存の描画と完全一致で回帰なし

closes #170