### PR TITLE
fix: Playwright MCP の --browser chromium 廃止に追従し --executable-path へ移行 #181

### DIFF
--- a/.claude/rules/playwright-mcp.md
+++ b/.claude/rules/playwright-mcp.md
@@ -47,10 +47,10 @@ browser_take_screenshot                   # 必要なら画像も保存
 
 | 症状 | 原因 | 対処 |
 |------|------|------|
-| `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome` | `.mcp.json` の `--browser chromium` が欠落、またはセッションが古い設定で起動している | `.mcp.json` を確認 → Claude Code セッションを再起動 |
+| `Browser "chrome-for-testing" is not installed` | `.mcp.json` の `--executable-path` が欠落し、`@playwright/mcp@latest` が `chrome-for-testing` にフォールバックしている（旧 `--browser chromium` は廃止済み） | `.mcp.json` に `--executable-path /opt/pw-browsers/chromium-1194/chrome-linux/chrome` が入っているか確認 → Claude Code セッションを再起動 |
 | `InputValidationError` / ツールが呼べない | ToolSearch 未実行でスキーマが未ロード | `ToolSearch select:<tool_name>` で先にロード |
 | `browser_navigate` でタイムアウト／接続拒否 | Vite が起動していない・ポート違い | `npm run dev:client` のログで `http://localhost:5173/` を確認 |
-| Chromium 自体が無い | Dev Container 新規構築直後 | `npx playwright install chromium` を実行 |
+| `--executable-path` で指定したパスに Chromium が無い | `/opt/pw-browsers/chromium-1194` 未配備（新規 DevContainer 直後など） | 環境側で `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` のもと `npx playwright install chromium` を実行して `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` を用意 |
 | 一度使えていた `mcp__playwright__*` ツールが突然 `No matching deferred tools found` になる | セッション長時間放置で stdio サーバーが切断 | 下記「切断時の再接続手順」を参照 |
 
 ## 切断時の再接続手順（Claude 向け）
@@ -88,5 +88,6 @@ UI 検証を始めようとして切断を検知したら、**自己判断で復
 
 ## 参考
 
-- MCP 登録: リポジトリ直下 `.mcp.json`（`--browser chromium` 必須）
+- MCP 登録: リポジトリ直下 `.mcp.json`（`--executable-path /opt/pw-browsers/chromium-1194/chrome-linux/chrome` 必須。`@playwright/mcp@latest` では `--browser chromium` が廃止されているため `--executable-path` でプリインストール済み Chromium を直接指す）
+- 前提環境: `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` が設定され、同パス配下に Playwright 公式 Chromium（`chromium-1194/chrome-linux/chrome`）が配備されていること
 - 人間向けセットアップ: `CONTRIBUTING.md` 「MCP サーバー（Playwright による UI 視覚検証）」

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium"]
+      "args": ["-y", "@playwright/mcp@latest", "--executable-path", "/opt/pw-browsers/chromium-1194/chrome-linux/chrome"]
     },
     "brave-search": {
       "command": "npx",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,14 +169,31 @@ npm test
 
 ### 初回セットアップ
 
-Chromium バイナリをダウンロードしておきます（Playwright MCP の初回起動時に `npx` が自動で `@playwright/mcp` を取得するため、別途インストールは不要）。
+`@playwright/mcp@latest` は `--browser` 引数で `chrome | firefox | webkit | msedge` のみを受け付け、旧 `chromium` 指定は廃止されています。本プロジェクトの `.mcp.json` では `--executable-path` を使って、DevContainer にプリインストールされている Playwright 公式 Chromium を直接指す構成になっています。
+
+```jsonc
+// .mcp.json（抜粋）
+"args": [
+  "-y",
+  "@playwright/mcp@latest",
+  "--executable-path",
+  "/opt/pw-browsers/chromium-1194/chrome-linux/chrome"
+]
+```
+
+DevContainer 内では事前に以下が満たされている前提です：
+
+- 環境変数 `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` が設定されている
+- `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` が存在する（Playwright 公式 Chromium）
+
+上記が無い／バージョンが異なる環境では、以下のいずれかで配備します：
 
 ```bash
-# 開発コンテナ内で1回だけ実行
+# 開発コンテナ内で1回だけ実行（PLAYWRIGHT_BROWSERS_PATH 設定下で）
 npx playwright install chromium
 ```
 
-> Dev Container を新規ビルドした場合は再度実行が必要です。
+> Dev Container を新規ビルドした場合は再度実行が必要です。インストール後に `.mcp.json` の `--executable-path` が実在するバイナリを指しているかを確認してください（バージョンディレクトリ名が変わる場合があります）。
 
 ### 利用フロー
 
@@ -191,4 +208,8 @@ npx playwright install chromium
 
 ### 接続確認
 
-Claude Code セッションで `ToolSearch` に `playwright` や `browser_navigate` を投げて該当ツールが返ってくれば接続成功です。返ってこない場合は `.mcp.json` のパスと `@playwright/mcp` のインストール可否を確認してください。
+Claude Code セッションで `ToolSearch` に `playwright` や `browser_navigate` を投げて該当ツールが返ってくれば接続成功です。返ってこない場合は以下を確認してください：
+
+- `.mcp.json` の `--executable-path` が実在するバイナリを指しているか
+- `@playwright/mcp` が `npx` で取得可能か
+- `browser_navigate` 実行時に `Browser "chrome-for-testing" is not installed` が出る場合、`--executable-path` が効いていない（古い設定で MCP サーバーが起動している）可能性があるためセッション再起動を試みる


### PR DESCRIPTION
## 概要

`@playwright/mcp@latest` で `--browser chromium` が廃止され、内部的に `chrome-for-testing` にフォールバックした結果、`browser_navigate` が `Browser "chrome-for-testing" is not installed` で失敗していた問題を修正する。サンドボックス環境からは `cdn.playwright.dev` に到達できずインストールも不可のため、プリインストール済み Chromium を `--executable-path` で直接指す方式に切り替えた（Issue #181 案 A）。

closes #181

## 変更点

- **`.mcp.json`**: `--browser chromium` を削除し、`--executable-path /opt/pw-browsers/chromium-1194/chrome-linux/chrome` を追加
- **`.claude/rules/playwright-mcp.md`**:
  - トラブルシュート表を現行エラーメッセージ (`Browser "chrome-for-testing" is not installed`) に更新
  - 「参考」節に `--executable-path` 必須の旨と `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` 前提を追記
- **`CONTRIBUTING.md`**:
  - 「MCP サーバー（Playwright による UI 視覚検証）」セクションを `--executable-path` 前提に書き換え
  - 「接続確認」に `chrome-for-testing` エラーの判定パスを追加

## テスト

### 修正前の再現
- `mcp__playwright__browser_navigate about:blank` → `Error: Browser "chrome-for-testing" is not installed.` を確認

### 修正後（セッション再起動後の検証が必要）
本 PR の `.mcp.json` 変更は **MCP サーバーの再起動（= Claude Code セッション再起動）** で反映されるため、このセッション内での最終確認は不可。ユーザー側でマージ前／マージ後に以下の手順で動作確認をお願いします：

1. Claude Code セッションを再起動（CLI なら exit → 再入、Web なら新規セッション）
2. `npm run dev:client` 起動（任意のフロントエンド検証用）
3. Claude セッションで `ToolSearch` → `mcp__playwright__browser_navigate` をロード
4. `browser_navigate http://localhost:5173`（または `about:blank`）が成功し、`browser_snapshot` が取得できること

### 通常テスト
- [x] `npm test` — 73/73 passed（Vitest）

## 未確定事項（Issue #181 より引用）

`/opt/pw-browsers/chromium-1194` のパスが他開発者の DevContainer にも存在するか。存在しない場合は別 Issue で「環境ごとの Chromium 配備設計」として扱う（本 PR のスコープ外）。

https://claude.ai/code/session_01N5ETYTM9t9rSkGVk7RvPg4