### PR TITLE
fix: タイムライン内D&D並び替えの挿入位置・no-opバグを修正 #172

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -262,36 +262,53 @@ export function Timeline({
   }
 
   /**
-   * 各エントリ処理後のタイムライン状態（gcdAvailableAt, actionAvailableAt）を事前計算。
+   * 挿入位置計算用の resolvedEntries。
+   * タイムライン内D&D中はドラッグ中のエントリを除外し、ドロップ後の並びを基準にする。
+   * これにより挿入インジケーターと実際のドロップ結果が一致する。
+   */
+  const insertionResolvedEntries = useMemo(
+    () => (draggingEntryUid !== null
+      ? resolvedEntries.filter((e) => e.uid !== draggingEntryUid)
+      : resolvedEntries),
+    [resolvedEntries, draggingEntryUid]
+  );
+
+  /**
+   * 挿入位置計算用: insertionResolvedEntries の各エントリ処理後の状態を事前計算。
    * 挿入インジケーターの正確な位置算出に使用する。
+   * ドラッグ中エントリを除外した並びで startTime を再計算するため、
+   * resolveTimeline と同じタイミング規則（GCD: max(gcdAvailable, actionAvailable), oGCD: actionAvailable）を適用。
    * states[i] = entry[i]処理後の状態。挿入位置idxの開始時刻算出にはstates[idx-1]を参照。
    */
-  const timelineStateAtIndex = useMemo(() => {
+  const insertionTimelineStateAtIndex = useMemo(() => {
     const states: TimelineState[] = [];
     let gcdAvailableAt = 0;
     let actionAvailableAt = 0;
 
-    for (const entry of resolvedEntries) {
+    for (const entry of insertionResolvedEntries) {
       const skill = skillMap.get(entry.skillId);
       if (!skill) {
         states.push({ gcdAvailableAt, actionAvailableAt });
         continue;
       }
 
+      let startTime: number;
       if (skill.type === "gcd") {
+        startTime = Math.max(gcdAvailableAt, actionAvailableAt);
         const recast = getEntryRecastTime(skill, entry.activeBuffs);
         const castTime = getEntryCastTime(skill, entry.activeBuffs);
-        gcdAvailableAt = entry.startTime + recast;
-        actionAvailableAt = entry.startTime + Math.max(castTime, skill.animationLock);
+        gcdAvailableAt = startTime + recast;
+        actionAvailableAt = startTime + Math.max(castTime, skill.animationLock);
       } else {
-        actionAvailableAt = entry.startTime + skill.animationLock;
+        startTime = actionAvailableAt;
+        actionAvailableAt = startTime + skill.animationLock;
       }
 
       states.push({ gcdAvailableAt, actionAvailableAt });
     }
 
     return states;
-  }, [resolvedEntries, skillMap, getEntryRecastTime, getEntryCastTime]);
+  }, [insertionResolvedEntries, skillMap, getEntryRecastTime, getEntryCastTime]);
 
   // 個別リキャスト（クールダウン）のスパン: skillId → [{startTime, endTime, skillName, icon}]
   const cooldownSpans = useMemo(() => {
@@ -442,27 +459,31 @@ export function Timeline({
     [onRemoveEntry]
   );
 
-  /** GCDエントリのみをフィルタ */
-  const gcdResolvedEntries = useMemo(
-    () => resolvedEntries.filter((entry) => {
+  /**
+   * 挿入位置計算用の GCDエントリ（タイムライン内D&D中はドラッグ中エントリを除外）。
+   * ドラッグ中エントリを含めるとインデックス計算や no-op 判定でズレが生じるため、
+   * 挿入計算は必ずこの除外版を参照する。
+   */
+  const insertionGcdResolvedEntries = useMemo(
+    () => insertionResolvedEntries.filter((entry) => {
       const skill = skillMap.get(entry.skillId);
       return skill && skill.type === "gcd";
     }),
-    [resolvedEntries, skillMap]
+    [insertionResolvedEntries, skillMap]
   );
 
-  /** GCDフィルタ済みインデックスを全エントリ上のインデックスに変換 */
-  const mapGcdIndexToCombined = useCallback(
+  /** GCDフィルタ済みインデックスを挿入用エントリリスト上のインデックスに変換 */
+  const mapGcdIndexToInsertion = useCallback(
     (gcdIdx: number): number => {
-      if (gcdIdx >= gcdResolvedEntries.length) {
-        // 末尾に追加: 最後のGCD以降のoGCDも含めた全エントリの末尾
-        return resolvedEntries.length;
+      if (gcdIdx >= insertionGcdResolvedEntries.length) {
+        // 末尾に追加: 最後のGCD以降のoGCDも含めた末尾
+        return insertionResolvedEntries.length;
       }
       // gcdIdx番目のGCDエントリの前に挿入
-      const targetEntry = gcdResolvedEntries[gcdIdx];
-      return resolvedEntries.findIndex((e) => e.uid === targetEntry.uid);
+      const targetEntry = insertionGcdResolvedEntries[gcdIdx];
+      return insertionResolvedEntries.findIndex((e) => e.uid === targetEntry.uid);
     },
-    [resolvedEntries, gcdResolvedEntries]
+    [insertionResolvedEntries, insertionGcdResolvedEntries]
   );
 
   /**
@@ -476,19 +497,21 @@ export function Timeline({
   );
 
   /**
-   * ドラッグ中のマウス位置から挿入インデックス（resolvedEntries上）を計算する。
-   * GCD: GCDエントリのみで計算し、combined変換（GCDリキャスト境界間に配置）
+   * ドラッグ中のマウス位置から挿入インデックス（insertionResolvedEntries上）を計算する。
+   * タイムライン内D&D中はドラッグ中エントリを除外した並びで計算するため、
+   * 返されるインデックスは insertionResolvedEntries 上の位置を示す（ドロップ後の配置と一致）。
+   * GCD: GCDエントリのみで計算し、insertion変換（GCDリキャスト境界間に配置）
    * oGCD: 全エントリで計算、アニメーションロック基準の中央で判定（ウィービング対応）
    */
   const calcCombinedInsertIndex = useCallback(
     (mouseX: number, scrollLeft: number, type: "gcd" | "ogcd"): number => {
       if (type === "gcd") {
-        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, gcdResolvedEntries, skillMap, getEntryRecastTime);
-        return mapGcdIndexToCombined(gcdIdx);
+        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, insertionGcdResolvedEntries, skillMap, getEntryRecastTime);
+        return mapGcdIndexToInsertion(gcdIdx);
       }
-      return calcInsertIndex(mouseX, scrollLeft, resolvedEntries, skillMap, getAnimLockWidth);
+      return calcInsertIndex(mouseX, scrollLeft, insertionResolvedEntries, skillMap, getAnimLockWidth);
     },
-    [resolvedEntries, gcdResolvedEntries, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToCombined]
+    [insertionResolvedEntries, insertionGcdResolvedEntries, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToInsertion]
   );
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -513,7 +536,7 @@ export function Timeline({
         dragRafRef.current = null;
         setDragType(type);
 
-        if (scrollRef.current && resolvedEntries.length > 0) {
+        if (scrollRef.current && insertionResolvedEntries.length > 0) {
           const idx = calcCombinedInsertIndex(mouseX, scrollLeft, type);
           setInsertIndex(idx);
         } else {
@@ -521,7 +544,7 @@ export function Timeline({
         }
       });
     },
-    [resolvedEntries, detectDragType, calcCombinedInsertIndex]
+    [insertionResolvedEntries, detectDragType, calcCombinedInsertIndex]
   );
 
   const handleDragLeave = useCallback(() => {
@@ -561,27 +584,26 @@ export function Timeline({
 
       if (source === "timeline") {
         const movingUid = e.dataTransfer.getData("application/timeline-entry-uid");
-        if (movingUid && scrollRef.current && resolvedEntries.length > 0) {
+        if (movingUid && scrollRef.current && insertionResolvedEntries.length > 0) {
           const rect = scrollRef.current.getBoundingClientRect();
           const mouseX = e.clientX - rect.left;
           const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
-          const targetEntry = idx < resolvedEntries.length ? resolvedEntries[idx] : undefined;
-          // 同位置（直後のエントリが自分自身）へのドロップは no-op
-          if (!targetEntry || targetEntry.uid !== movingUid) {
-            shouldAutoScrollRef.current = false;
-            onMoveEntry(movingUid, targetEntry?.uid);
-          }
+          // insertionResolvedEntries はドラッグ中エントリを除外しているため、
+          // ここで得られる targetEntry が自分自身になることはない（= 不要な no-op 判定が消える）
+          const targetEntry = idx < insertionResolvedEntries.length ? insertionResolvedEntries[idx] : undefined;
+          shouldAutoScrollRef.current = false;
+          onMoveEntry(movingUid, targetEntry?.uid);
         }
       } else {
-        if (scrollRef.current && resolvedEntries.length > 0) {
+        if (scrollRef.current && insertionResolvedEntries.length > 0) {
           const rect = scrollRef.current.getBoundingClientRect();
           const mouseX = e.clientX - rect.left;
           const idx = calcCombinedInsertIndex(mouseX, scrollRef.current.scrollLeft, type);
-          const isInsertMiddle = idx < resolvedEntries.length;
+          const isInsertMiddle = idx < insertionResolvedEntries.length;
           if (isInsertMiddle) {
             shouldAutoScrollRef.current = false;
           }
-          onAddEntry(skillId, isInsertMiddle ? resolvedEntries[idx].uid : undefined);
+          onAddEntry(skillId, isInsertMiddle ? insertionResolvedEntries[idx].uid : undefined);
         } else {
           onAddEntry(skillId);
         }
@@ -591,13 +613,14 @@ export function Timeline({
       setDragType(null);
       setDraggingEntryUid(null);
     },
-    [onAddEntry, onMoveEntry, resolvedEntries, skillMap, calcCombinedInsertIndex, detectDragSource]
+    [onAddEntry, onMoveEntry, insertionResolvedEntries, skillMap, calcCombinedInsertIndex, detectDragSource]
   );
 
   /**
    * 挿入インジケーターのX座標。
    * A方式: 挿入後にスキルが実際に配置される位置（最速実行可能時刻）を表示する。
-   * 事前計算済みのtimelineStateAtIndexを使い、resolveTimelineと同じロジックで開始時刻を算出。
+   * insertionTimelineStateAtIndex は「ドラッグ中エントリを除外した並び」で計算済みなので、
+   * insertIndex も同じ除外済みインデックスとして扱う（ドロップ後の実配置と一致する）。
    */
   const indicatorX = useMemo(() => {
     if (insertIndex === null || dragType === null) return null;
@@ -607,7 +630,7 @@ export function Timeline({
       // 先頭に挿入: 時刻0から開始
       startTime = 0;
     } else {
-      const prevState = timelineStateAtIndex[insertIndex - 1];
+      const prevState = insertionTimelineStateAtIndex[insertIndex - 1];
       if (!prevState) {
         startTime = 0;
       } else if (dragType === "gcd") {
@@ -620,7 +643,7 @@ export function Timeline({
     }
 
     return startTime * PX_PER_SEC;
-  }, [insertIndex, dragType, timelineStateAtIndex]);
+  }, [insertIndex, dragType, insertionTimelineStateAtIndex]);
 
   // ドラッグオーバー時のstickyラベル背景色（ドロップゾーンの黄色みと視覚的に一致させる）
   const labelBg = dragOver ? "#1b1921" : "#0f0f23";

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -523,7 +523,10 @@ export function Timeline({
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
+      // ドラッグ元（パレット=copy / タイムライン内並び替え=move）に合わせる。
+      // effectAllowed（dragstart で "copy" or "move" を設定）と dropEffect が不一致だと
+      // ブラウザが drop を拒否し、handleDrop が発火せず並び替えが無言で失敗する。
+      e.dataTransfer.dropEffect = detectDragSource(e) === "timeline" ? "move" : "copy";
 
       // rAFでスロットリング: 前フレームの更新がまだ処理中なら新しいリクエストをスキップ
       if (dragRafRef.current !== null) return;
@@ -544,7 +547,7 @@ export function Timeline({
         }
       });
     },
-    [insertionResolvedEntries, detectDragType, calcCombinedInsertIndex]
+    [insertionResolvedEntries, detectDragType, detectDragSource, calcCombinedInsertIndex]
   );
 
   const handleDragLeave = useCallback(() => {


### PR DESCRIPTION
## 概要

#164 で追加したタイムライン内 D&D 並び替えが、「挿入インジケーターの表示位置と実際のドロップ結果が一致しない」「先頭GCDを前方にドラッグしても no-op になる」等の不具合を抱えていた。挿入位置計算とインジケーター描画から **ドラッグ中のエントリ自身を除外** することで、双方の不具合を根本から解消する。

## 変更点

- `src/client/components/Timeline.tsx`
  - `resolvedEntries` / `gcdResolvedEntries` の派生として、ドラッグ中エントリを除外した `insertionResolvedEntries` / `insertionGcdResolvedEntries` を追加
  - `timelineStateAtIndex` を `insertionTimelineStateAtIndex` に置換。除外後の並びで `resolveTimeline` と同等のタイミング規則（GCD: `max(gcdAvailable, actionAvailable)` / oGCD: `actionAvailable`）を再計算する
  - `mapGcdIndexToCombined` → `mapGcdIndexToInsertion` にリネームし、挿入用リスト基準のインデックスを返すよう変更
  - `calcCombinedInsertIndex` / `handleDragOver` / `handleDrop` / `indicatorX` をすべて `insertion*` 系参照に統一
  - `handleDrop` の明示的 no-op チェック（`targetEntry.uid !== movingUid`）を削除。`insertionResolvedEntries` から自身が除外されているため到達不能になった

## 修正されるバグ

1. **挿入インジケーターとドロップ後の実配置のズレ** — 除外版のタイミングで描画位置を計算するため、ドロップ後の再解決結果と一致する
2. **先頭GCDを先頭方向にドラッグすると no-op になる** — 旧実装では `mapGcdIndexToCombined(0)` がドラッグ中エントリ自身の位置を返し、`targetEntry.uid === movingUid` で早期 return されていた

## テスト

- `npm test` — 73件すべて通過（13ファイル）
- `npx tsc --noEmit` — 型エラーなし
- Playwright MCP でのシナリオ検証:
  - GCD (0s) / GCD (2.5s) / oGCD (4.0s) の3エントリ構成
  - 先頭 GCD を末尾方向へ D&D → インジケーター `2.5s` = 実配置 `2.5s` で一致
  - 末尾 GCD を先頭方向へ D&D → インジケーター `0s` = 実配置 `0s` で一致（旧実装では no-op）
  - パレットからの新規追加 / 削除ドロップエリアへのドロップが退行なく動作することを確認

closes #172

https://claude.ai/code/session_014NRfJpkyXGU93extts2556