### PR TITLE
fix: タイムライン内D&Dの挿入インジケーター位置がパレットD&Dとズレる不具合を修正 #187

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -277,6 +277,26 @@ export function Timeline({
     return resolveTimeline(filteredRaw, skillMap, resources, stats, buffs, untargetableWindows).entries;
   }, [resolvedEntries, draggingEntryUid, skillMap, resources, stats, buffs, untargetableWindows]);
 
+  /**
+   * マウス位置と突き合わせる用の「見えている並び」。
+   * タイムライン内D&D中は、画面に表示されているエントリは元の resolvedEntries の
+   * startTime で配置されている（ドラッグ中エントリは半透明で残り、他は動かない）。
+   * 一方 insertionResolvedEntries は「ドラッグ中エントリを除いた並びで再 resolve」した結果で、
+   * 後続エントリの startTime が前詰めで左に寄っている。
+   *
+   * マウス位置は「見えている並び」に対するユーザー操作なので、calcInsertIndex での
+   * 中央時刻判定は insertionResolvedEntries ではなくこの「見えている並び」で行う必要がある。
+   * （insertionResolvedEntries で判定すると、マウスが見えている C-D 間にある時に
+   *   論理上の D（=前詰めで C の右隣）より右と判定されてしまい、挿入位置が 1 つ右にズレる）
+   *
+   * 一方で uid 順序は insertionResolvedEntries と一致するため、calcInsertIndex が返す
+   * idx は insertionResolvedEntries にもそのまま使える（indicatorX / drop target 特定）。
+   */
+  const visibleEntriesForInsert = useMemo(() => {
+    if (draggingEntryUid === null) return resolvedEntries;
+    return resolvedEntries.filter((e) => e.uid !== draggingEntryUid);
+  }, [resolvedEntries, draggingEntryUid]);
+
   // 個別リキャスト（クールダウン）のスパン: skillId → [{startTime, endTime, skillName, icon}]
   const cooldownSpans = useMemo(() => {
     const spans: Map<string, { startTime: number; endTime: number; skillName: string; icon: string }[]> = new Map();
@@ -439,6 +459,18 @@ export function Timeline({
     [insertionResolvedEntries, skillMap]
   );
 
+  /**
+   * マウス位置判定用 GCD-only エントリ（見えている並び準拠）。
+   * uid 順序は insertionGcdResolvedEntries と一致するため idx は互換。
+   */
+  const visibleGcdEntriesForInsert = useMemo(
+    () => visibleEntriesForInsert.filter((entry) => {
+      const skill = skillMap.get(entry.skillId);
+      return skill && skill.type === "gcd";
+    }),
+    [visibleEntriesForInsert, skillMap]
+  );
+
   /** GCDフィルタ済みインデックスを挿入用エントリリスト上のインデックスに変換 */
   const mapGcdIndexToInsertion = useCallback(
     (gcdIdx: number): number => {
@@ -465,20 +497,21 @@ export function Timeline({
 
   /**
    * ドラッグ中のマウス位置から挿入インデックス（insertionResolvedEntries上）を計算する。
-   * タイムライン内D&D中はドラッグ中エントリを除外した並びで計算するため、
-   * 返されるインデックスは insertionResolvedEntries 上の位置を示す（ドロップ後の配置と一致）。
+   * マウス位置は「見えている並び」（resolvedEntries の startTime 準拠）に対する操作なので、
+   * 中央時刻の比較は visibleEntriesForInsert / visibleGcdEntriesForInsert で行う。
+   * 返される idx は uid 順序を揃えてあるので insertionResolvedEntries にもそのまま使える。
    * GCD: GCDエントリのみで計算し、insertion変換（GCDリキャスト境界間に配置）
    * oGCD: 全エントリで計算、アニメーションロック基準の中央で判定（ウィービング対応）
    */
   const calcCombinedInsertIndex = useCallback(
     (mouseX: number, scrollLeft: number, type: "gcd" | "ogcd"): number => {
       if (type === "gcd") {
-        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, insertionGcdResolvedEntries, skillMap, getEntryRecastTime);
+        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, visibleGcdEntriesForInsert, skillMap, getEntryRecastTime);
         return mapGcdIndexToInsertion(gcdIdx);
       }
-      return calcInsertIndex(mouseX, scrollLeft, insertionResolvedEntries, skillMap, getAnimLockWidth);
+      return calcInsertIndex(mouseX, scrollLeft, visibleEntriesForInsert, skillMap, getAnimLockWidth);
     },
-    [insertionResolvedEntries, insertionGcdResolvedEntries, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToInsertion]
+    [visibleEntriesForInsert, visibleGcdEntriesForInsert, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToInsertion]
   );
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow, PpsRange } from "../types/skill";
 import { calcGcd, calcExpectedMultiplier } from "../logic/stat-calc";
 import { computeBuffTimespans } from "../logic/buff-timespans";
+import { resolveTimeline } from "../logic/resolve-timeline";
 import "./timeline.css";
 
 /** 1秒あたりのピクセル数 */
@@ -88,12 +89,6 @@ function calcInsertIndex(
 
   // 末尾に追加
   return resolvedEntries.length;
-}
-
-/** タイムラインの各エントリ処理後の状態 */
-interface TimelineState {
-  gcdAvailableAt: number;
-  actionAvailableAt: number;
 }
 
 export function Timeline({
@@ -263,52 +258,24 @@ export function Timeline({
 
   /**
    * 挿入位置計算用の resolvedEntries。
-   * タイムライン内D&D中はドラッグ中のエントリを除外し、ドロップ後の並びを基準にする。
-   * これにより挿入インジケーターと実際のドロップ結果が一致する。
+   * - パレットからのD&D（draggingEntryUid === null）: resolvedEntries をそのまま再利用。
+   *   既に App.tsx の resolveTimeline が計算した startTime / 各エントリの post-entry state
+   *   （gcdAvailableAt / actionAvailableAt）をそのまま使う。
+   * - タイムライン内D&D（draggingEntryUid !== null）: ドラッグ中エントリを除外した
+   *   生エントリ列で resolveTimeline を再実行する。これにより「ドロップ後の並び」における
+   *   各エントリの startTime と post-entry state が正確に得られ、パレットD&D時と
+   *   同一アルゴリズムで算出されるため、インジケーター位置が必ず一致する。
+   *
+   * 再実行コストは draggingEntryUid 変化時のみ（ドラッグ開始/終了）で、
+   * drag over の rAF コールバック内では useMemo のキャッシュを参照するだけ。
    */
-  const insertionResolvedEntries = useMemo(
-    () => (draggingEntryUid !== null
-      ? resolvedEntries.filter((e) => e.uid !== draggingEntryUid)
-      : resolvedEntries),
-    [resolvedEntries, draggingEntryUid]
-  );
-
-  /**
-   * 挿入位置計算用: insertionResolvedEntries の各エントリ処理後の状態を事前計算。
-   * 挿入インジケーターの正確な位置算出に使用する。
-   * ドラッグ中エントリを除外した並びで startTime を再計算するため、
-   * resolveTimeline と同じタイミング規則（GCD: max(gcdAvailable, actionAvailable), oGCD: actionAvailable）を適用。
-   * states[i] = entry[i]処理後の状態。挿入位置idxの開始時刻算出にはstates[idx-1]を参照。
-   */
-  const insertionTimelineStateAtIndex = useMemo(() => {
-    const states: TimelineState[] = [];
-    let gcdAvailableAt = 0;
-    let actionAvailableAt = 0;
-
-    for (const entry of insertionResolvedEntries) {
-      const skill = skillMap.get(entry.skillId);
-      if (!skill) {
-        states.push({ gcdAvailableAt, actionAvailableAt });
-        continue;
-      }
-
-      let startTime: number;
-      if (skill.type === "gcd") {
-        startTime = Math.max(gcdAvailableAt, actionAvailableAt);
-        const recast = getEntryRecastTime(skill, entry.activeBuffs);
-        const castTime = getEntryCastTime(skill, entry.activeBuffs);
-        gcdAvailableAt = startTime + recast;
-        actionAvailableAt = startTime + Math.max(castTime, skill.animationLock);
-      } else {
-        startTime = actionAvailableAt;
-        actionAvailableAt = startTime + skill.animationLock;
-      }
-
-      states.push({ gcdAvailableAt, actionAvailableAt });
-    }
-
-    return states;
-  }, [insertionResolvedEntries, skillMap, getEntryRecastTime, getEntryCastTime]);
+  const insertionResolvedEntries = useMemo(() => {
+    if (draggingEntryUid === null) return resolvedEntries;
+    const filteredRaw = resolvedEntries
+      .filter((e) => e.uid !== draggingEntryUid)
+      .map((e) => ({ uid: e.uid, skillId: e.skillId }));
+    return resolveTimeline(filteredRaw, skillMap, resources, stats, buffs, untargetableWindows).entries;
+  }, [resolvedEntries, draggingEntryUid, skillMap, resources, stats, buffs, untargetableWindows]);
 
   // 個別リキャスト（クールダウン）のスパン: skillId → [{startTime, endTime, skillName, icon}]
   const cooldownSpans = useMemo(() => {
@@ -622,8 +589,9 @@ export function Timeline({
   /**
    * 挿入インジケーターのX座標。
    * A方式: 挿入後にスキルが実際に配置される位置（最速実行可能時刻）を表示する。
-   * insertionTimelineStateAtIndex は「ドラッグ中エントリを除外した並び」で計算済みなので、
-   * insertIndex も同じ除外済みインデックスとして扱う（ドロップ後の実配置と一致する）。
+   * insertionResolvedEntries は「ドラッグ中エントリを除外した並び」で resolveTimeline を
+   * 再実行した結果（パレットD&D時は resolvedEntries そのもの）なので、
+   * 各エントリの post-entry state を gcdAvailableAt / actionAvailableAt から直接参照できる。
    */
   const indicatorX = useMemo(() => {
     if (insertIndex === null || dragType === null) return null;
@@ -633,20 +601,20 @@ export function Timeline({
       // 先頭に挿入: 時刻0から開始
       startTime = 0;
     } else {
-      const prevState = insertionTimelineStateAtIndex[insertIndex - 1];
-      if (!prevState) {
+      const prevEntry = insertionResolvedEntries[insertIndex - 1];
+      if (!prevEntry) {
         startTime = 0;
       } else if (dragType === "gcd") {
         // GCD: max(GCDリキャスト明け, 直前アクション硬直明け)
-        startTime = Math.max(prevState.gcdAvailableAt, prevState.actionAvailableAt);
+        startTime = Math.max(prevEntry.gcdAvailableAt, prevEntry.actionAvailableAt);
       } else {
         // oGCD: 直前アクション硬直明け
-        startTime = prevState.actionAvailableAt;
+        startTime = prevEntry.actionAvailableAt;
       }
     }
 
     return startTime * PX_PER_SEC;
-  }, [insertIndex, dragType, insertionTimelineStateAtIndex]);
+  }, [insertIndex, dragType, insertionResolvedEntries]);
 
   // ドラッグオーバー時のstickyラベル背景色（ドロップゾーンの黄色みと視覚的に一致させる）
   const labelBg = dragOver ? "#1b1921" : "#0f0f23";

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -29,6 +29,8 @@ function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimeli
     buffMultiplier: 1,
     critRateBonus: 0,
     dhRateBonus: 0,
+    gcdAvailableAt: startTime,
+    actionAvailableAt: startTime,
   };
 }
 

--- a/src/client/logic/__tests__/resolved-entry-post-state.test.ts
+++ b/src/client/logic/__tests__/resolved-entry-post-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+/**
+ * Issue #187: D&D挿入予定位置インジケーターが、パレットD&D時とタイムライン内D&D時で一致することを
+ * 支える基盤。ResolvedTimelineEntry.{gcdAvailableAt, actionAvailableAt} が
+ * resolveTimeline 内部で使う post-entry state と一致し、かつ
+ * 「filter後に再 resolve した結果」とも整合することを保証する。
+ */
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string, uid?: string): TimelineEntry {
+  return { uid: uid ?? `${skillId}-${Math.random()}`, skillId };
+}
+
+const trueThrust = makeSkill({ id: "true-thrust" });
+const disembowel = makeSkill({ id: "disembowel" });
+const chaoticSpring = makeSkill({ id: "chaotic-spring" });
+const lifeSurge = makeSkill({ id: "life-surge", type: "ogcd", recastTime: 45, animationLock: 0.6 });
+const allSkills = new Map([trueThrust, disembowel, chaoticSpring, lifeSurge].map((s) => [s.id, s]));
+
+describe("ResolvedTimelineEntry post-entry state (Issue #187)", () => {
+  it("GCD エントリの gcdAvailableAt / actionAvailableAt が次エントリの startTime と整合する", () => {
+    const entries: TimelineEntry[] = [
+      makeEntry("true-thrust", "a"),
+      makeEntry("disembowel", "b"),
+      makeEntry("chaotic-spring", "c"),
+    ];
+    const result = resolveTimeline(entries, allSkills, []);
+    expect(result.entries).toHaveLength(3);
+
+    // GCD → GCD: 次のGCDは max(gcdAvailableAt, actionAvailableAt) から開始
+    for (let i = 1; i < result.entries.length; i++) {
+      const prev = result.entries[i - 1];
+      const cur = result.entries[i];
+      const expected = Math.round(Math.max(prev.gcdAvailableAt, prev.actionAvailableAt) * 1000) / 1000;
+      expect(cur.startTime).toBeCloseTo(expected, 6);
+    }
+  });
+
+  it("oGCD エントリは gcdAvailableAt を引き継ぎ、actionAvailableAt のみ進む", () => {
+    const entries: TimelineEntry[] = [
+      makeEntry("true-thrust", "a"),
+      makeEntry("life-surge", "b"),
+      makeEntry("disembowel", "c"),
+    ];
+    const result = resolveTimeline(entries, allSkills, []);
+    const [gcd1, ogcd, gcd2] = result.entries;
+
+    // oGCD 後も gcdAvailableAt は GCD1 由来の値（2.5s）のまま
+    expect(ogcd.gcdAvailableAt).toBeCloseTo(gcd1.gcdAvailableAt, 6);
+    // actionAvailableAt は oGCD 硬直後
+    expect(ogcd.actionAvailableAt).toBeCloseTo(ogcd.startTime + 0.6, 6);
+    // 次のGCD（gcd2）は max(gcdAvailableAt, actionAvailableAt) から開始
+    const expected = Math.round(Math.max(ogcd.gcdAvailableAt, ogcd.actionAvailableAt) * 1000) / 1000;
+    expect(gcd2.startTime).toBeCloseTo(expected, 6);
+  });
+
+  it("エントリを除外して re-resolve した結果が、D&Dインジケーター算出の基準として機能する", () => {
+    // 3エントリのうち中央を除いて再計算した場合、残る2エントリ目の startTime は
+    // 1エントリ目の post-entry state に基づき算出される。
+    const entries: TimelineEntry[] = [
+      makeEntry("true-thrust", "a"),
+      makeEntry("disembowel", "b"),
+      makeEntry("chaotic-spring", "c"),
+    ];
+    const full = resolveTimeline(entries, allSkills, []);
+
+    const filtered = entries.filter((e) => e.uid !== "b");
+    const refiltered = resolveTimeline(filtered, allSkills, []);
+    expect(refiltered.entries).toHaveLength(2);
+
+    // filtered 版で 2 番目（chaotic-spring）の startTime は 1 番目（true-thrust）の
+    // post-entry gcdAvailableAt / actionAvailableAt の max と一致する必要がある。
+    const prev = refiltered.entries[0];
+    const cur = refiltered.entries[1];
+    const expected = Math.round(Math.max(prev.gcdAvailableAt, prev.actionAvailableAt) * 1000) / 1000;
+    expect(cur.startTime).toBeCloseTo(expected, 6);
+
+    // 追加: filtered 版の true-thrust の post-state は full 版の同エントリの post-state と一致する
+    // （先頭は除外対象の影響を受けない）。
+    expect(refiltered.entries[0].gcdAvailableAt).toBeCloseTo(full.entries[0].gcdAvailableAt, 6);
+    expect(refiltered.entries[0].actionAvailableAt).toBeCloseTo(full.entries[0].actionAvailableAt, 6);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -1101,6 +1101,8 @@ export function resolveTimeline(
       buffMultiplier,
       critRateBonus,
       dhRateBonus,
+      gcdAvailableAt,
+      actionAvailableAt,
     });
   }
 

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -366,4 +366,8 @@ export interface ResolvedTimelineEntry {
   critRateBonus: number;
   /** ダイレクトヒット発生率ボーナス（0.0 = バフなし、0.1 = +10%） */
   dhRateBonus: number;
+  /** このエントリ実行後、次のGCDが使用可能になる時刻（秒） */
+  gcdAvailableAt: number;
+  /** このエントリ実行後、次のアクション（GCD/oGCD問わず）が使用可能になる時刻（秒） */
+  actionAvailableAt: number;
 }


### PR DESCRIPTION
## 概要

タイムライン内スキルのドラッグ＆ドロップ並び替え時に表示される挿入予定位置インジケーター（縦線）が、パレットからの新規追加D&D時とズレて表示されていた問題に対する一次修正。resolveTimeline 内部で追跡している post-entry state（`gcdAvailableAt` / `actionAvailableAt`）を `ResolvedTimelineEntry` に公開し、Timeline コンポーネント側のインジケーター位置算出を単一ソース化した。加えて、マウス位置の基準を「見えている並び」（元の resolvedEntries からドラッグ中エントリを除外したもの、startTime は元値を保持）に統一し、`insertionResolvedEntries`（再 resolve 版）はインジケーター表示と uid 特定にのみ使用する構成とした。

## 原因

Timeline.tsx は `insertionTimelineStateAtIndex` という `useMemo` を手書きで用意し、ドラッグ中の「除外版並び」に対して GCD/oGCD のタイミング規則を再実装していた。しかし resolveTimeline 本体との差分（`startTime` の 3桁丸めを省略、速度バフ合成の順序と丸め回数が異なる、`entry.activeBuffs` が post-entry スナップショットのため recast 計算用には誤った buff セットになる等）により、特にタイムライン内D&D（ドラッグ中エントリ除外時）でインジケーター位置がドロップ後の実配置とズレていた。

## 変更点

- `src/client/types/skill.ts`
  - `ResolvedTimelineEntry` に `gcdAvailableAt` / `actionAvailableAt` を追加
- `src/client/logic/resolve-timeline.ts`
  - `resolved.push` 時点で既存ローカル変数 `gcdAvailableAt` / `actionAvailableAt` をそのまま格納
- `src/client/components/Timeline.tsx`
  - `insertionResolvedEntries` を `draggingEntryUid !== null` の場合のみ除外版で resolveTimeline を再実行する構成に変更
  - `indicatorX` の計算を `insertionResolvedEntries[idx-1].{gcdAvailableAt, actionAvailableAt}` の直接参照に変更
  - マウス位置判定用に `visibleEntriesForInsert` / `visibleGcdEntriesForInsert` を追加し、`calcCombinedInsertIndex` はこちらで idx 算出（uid 順序は insertionResolvedEntries と一致）
  - 旧 `insertionTimelineStateAtIndex` useMemo と未使用となった `TimelineState` interface を削除
- `src/client/logic/__tests__/resolved-entry-post-state.test.ts`（新規）
- `src/client/logic/__tests__/buff-timespans.test.ts`
  - 新フィールドに合わせてテストヘルパー `makeEntry` を更新

## テスト

- [x] `npx tsc --noEmit`: エラーなし
- [x] `npm test`: 14 ファイル / 76 テスト通過
- [x] `npx vite build`: 成功
- [ ] 実機D&D確認で「末尾側へドラッグすると 1 つ右にズレる」症状が残存。別Issue #190 として追跡

## 残課題

本PRは #187 の DoD を完全には満たせず、末尾側へドラッグした際に挿入位置が 1 つ右にズレる症状が残存している。該当症状は #190 として独立トラッキング中。#187 は #190 解消まで引き続き open のままとする。

refs #187
follow-up: #190
