### PR TITLE
fix: 挿入インジケーター位置を見えている並び基準に修正 #190

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -621,10 +621,18 @@ export function Timeline({
 
   /**
    * 挿入インジケーターのX座標。
-   * A方式: 挿入後にスキルが実際に配置される位置（最速実行可能時刻）を表示する。
-   * insertionResolvedEntries は「ドラッグ中エントリを除外した並び」で resolveTimeline を
-   * 再実行した結果（パレットD&D時は resolvedEntries そのもの）なので、
-   * 各エントリの post-entry state を gcdAvailableAt / actionAvailableAt から直接参照できる。
+   * 画面に描画されているエントリアイコンと同じ座標系で描画する必要があるため、
+   * 「見えている並び」(visibleEntriesForInsert) の post-entry state を使う。
+   *
+   * insertionResolvedEntries（= ドラッグ中エントリを除いて再 resolve した結果）は
+   * ドラッグ中エントリが抜けた分、後続エントリの startTime / gcdAvailableAt が前詰めされており、
+   * これを indicatorX に使うと画面上のアイコンより 1 スロット分左にズレてしまう
+   * （特に末尾側へドラッグした際に顕著で、最右スロットにインジケーターが出ない症状を引き起こす）。
+   *
+   * 一方 visibleEntriesForInsert は元 resolvedEntries をドラッグ中エントリだけフィルタした並びで、
+   * 各エントリの startTime / gcdAvailableAt / actionAvailableAt は画面描画に使われている値と同一。
+   * calcInsertIndex も visibleEntriesForInsert を基準に idx を決めているので、
+   * idx と indicatorX の座標系が完全に一致する。
    */
   const indicatorX = useMemo(() => {
     if (insertIndex === null || dragType === null) return null;
@@ -634,7 +642,7 @@ export function Timeline({
       // 先頭に挿入: 時刻0から開始
       startTime = 0;
     } else {
-      const prevEntry = insertionResolvedEntries[insertIndex - 1];
+      const prevEntry = visibleEntriesForInsert[insertIndex - 1];
       if (!prevEntry) {
         startTime = 0;
       } else if (dragType === "gcd") {
@@ -647,7 +655,7 @@ export function Timeline({
     }
 
     return startTime * PX_PER_SEC;
-  }, [insertIndex, dragType, insertionResolvedEntries]);
+  }, [insertIndex, dragType, visibleEntriesForInsert]);
 
   // ドラッグオーバー時のstickyラベル背景色（ドロップゾーンの黄色みと視覚的に一致させる）
   const labelBg = dragOver ? "#1b1921" : "#0f0f23";


### PR DESCRIPTION
## 概要

タイムライン内D&Dで末尾側にドラッグしたときに、挿入予定位置インジケーターがマウス位置より 1 スロット左にズレる不具合（特に「最後尾より右にドラッグしたとき最右スロットにインジケーターが出ない」症状）を修正する。

closes #190

## 原因

`indicatorX` の算出に `insertionResolvedEntries`（ドラッグ中エントリを除いた並びで `resolveTimeline` を再実行した結果）の `startTime` / `gcdAvailableAt` / `actionAvailableAt` を使っていたが、これらは**ドラッグ中エントリが抜けた分、後続エントリが前詰めで左に寄った値**である。一方、タイムライン上のスキルアイコンは元の `resolvedEntries`（ドラッグ中エントリを含む計算）の座標で描画されている（半透明で残るドラッグ中エントリの位置は変わらず、他のアイコンも元位置のまま）。

そのため、インジケーターだけが「B が前詰めされた仮想タイムライン」の座標で描画され、画面上のアイコンより約 1 スロット分（= 抜けたエントリ分の recast）左にズレる。末尾側ケースでは `insertIndex = length` のとき `prevEntry = 末尾エントリ(再resolve版)` の `gcdAvailableAt` が、画面上の末尾アイコン左端ちょうどに重なる位置となり、「最右スロットに出ない」として観測されていた。

`calcInsertIndex` は `visibleEntriesForInsert`（元 `resolvedEntries` をドラッグ中エントリのみフィルタした並び）を基準に idx を決めており、uid 順序は `insertionResolvedEntries` と一致する。したがって `indicatorX` も `visibleEntriesForInsert` を参照すれば座標系が揃う。

## 変更点

- `src/client/components/Timeline.tsx`
  - `indicatorX` の `prevEntry` 参照を `insertionResolvedEntries[insertIndex - 1]` → `visibleEntriesForInsert[insertIndex - 1]` に変更（L637 / L645 相当）
  - `useMemo` 依存配列を `insertionResolvedEntries` → `visibleEntriesForInsert` に更新
  - 上記の設計意図を記したコメント（L622-637）を更新

ドロップ処理（`handleDrop`）は引き続き `insertionResolvedEntries[idx].uid` を uid 経由で参照しているため、影響なし（既に PR #188 で正しい順序に修正済み）。

## テスト

- [x] `npx tsc --noEmit`: エラーなし
- [x] `npm test`: 14 ファイル / 76 テスト通過（既存テストに破壊的変更なし）
- [x] `npx vite build`: 成功
- [ ] 実ブラウザでのD&D動作確認: Playwright MCP の `browser_drag` が HTML5 DnD イベントを正しく発火できず、タイムラインへのスキル追加が再現できなかったため未検証。ロジック変更は差分 2 行かつ座標系の食い違いという明確な根本原因に対する最小修正で、既存 76 テストに回帰はない。実機D&D挙動はユーザー側で確認をお願いしたい。

## 関連Issue

- #187 タイムライン内D&D時の挿入予定位置インジケーターがパレットD&Dとズレる（本修正の親Issue、PR #188 で一次修正）
- #172 タイムライン上のスキルのドラッグ＆ドロップによる並び替えが正常に動作しない（PR #184 で対応済み）
- #59 タイムラインのスキル挿入予定位置表示アルゴリズムの改修（未解決・根本改修）
- #84 アビリティ（oGCD）の挿入予定位置がズレて表示される