### PR TITLE
feat: instantCast バフ（詠唱破棄）の汎用機構を追加 #171

### DIFF
--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -221,27 +221,6 @@ export function Timeline({
     [getRecastTime, buffDefMap]
   );
 
-  /** エントリのアクティブバフを考慮した詠唱時間計算 */
-  const getEntryCastTime = useCallback(
-    (skill: Skill, activeBuffs: ActiveBuff[]) => {
-      if (!skill.castTime) return 0;
-      let cast = skill.castTime;
-      if (skill.type === "gcd" && activeBuffs.length > 0) {
-        for (const ab of activeBuffs) {
-          const def = buffDefMap.get(ab.buffId);
-          if (!def) continue;
-          for (const effect of def.effects) {
-            if (effect.type === "speed") {
-              cast = Math.round(cast * effect.value * 1000) / 1000;
-            }
-          }
-        }
-      }
-      return cast;
-    },
-    [buffDefMap]
-  );
-
   const gcdEntries: (ResolvedTimelineEntry & { skill: Skill; displaySkill: Skill })[] = [];
   const ogcdEntries: (ResolvedTimelineEntry & { skill: Skill; displaySkill: Skill })[] = [];
   for (const entry of resolvedEntries) {
@@ -941,7 +920,7 @@ export function Timeline({
                   {gcdEntries.map((entry) => {
                     const hasError = entriesWithErrors.has(entry.uid);
                     const recast = getEntryRecastTime(entry.skill, entry.activeBuffs);
-                    const castTime = getEntryCastTime(entry.skill, entry.activeBuffs);
+                    const castTime = entry.castTime;
                     const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
                     const entryExpMul = stats ? calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus) : null;
                     const expectedPot = hasError ? null : (

--- a/src/client/data/blm-buffs.ts
+++ b/src/client/data/blm-buffs.ts
@@ -163,7 +163,8 @@ export const BLM_BUFFS: BuffDefinition[] = [
     shortName: "ﾌｧｲｱ\nｽﾀｰﾀｰ",
     icon: fire3Icon,
     duration: null,
-    effects: [],
+    // 次のファイガ詠唱を Instant 化（実スキル側の補正は別途対応。本バフは詠唱時間 0 化のみ担う）
+    effects: [{ type: "instantCast", value: 0 }],
     color: "#ff7043",
     acquiredLevel: 2,
   },
@@ -178,7 +179,8 @@ export const BLM_BUFFS: BuffDefinition[] = [
     icon: triplecastIcon,
     duration: 15,
     maxStacks: 3,
-    effects: [],
+    // 詠唱時間を持つ次 3 発の GCD を Instant 化
+    effects: [{ type: "instantCast", value: 0 }],
     color: "#ffee58",
     acquiredLevel: 66,
   },

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -31,6 +31,7 @@ function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimeli
     dhRateBonus: 0,
     gcdAvailableAt: startTime,
     actionAvailableAt: startTime,
+    castTime: 0,
   };
 }
 

--- a/src/client/logic/__tests__/instant-cast.test.ts
+++ b/src/client/logic/__tests__/instant-cast.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+const triplecastBuff: BuffDefinition = {
+  id: "triplecast-test",
+  name: "三連魔",
+  shortName: "三連魔",
+  icon: "",
+  duration: 15,
+  maxStacks: 3,
+  effects: [{ type: "instantCast", value: 0 }],
+  color: "#ffee58",
+};
+
+const firestarterBuff: BuffDefinition = {
+  id: "firestarter-test",
+  name: "ファイアスターター",
+  shortName: "FS",
+  icon: "",
+  duration: null,
+  effects: [{ type: "instantCast", value: 0 }],
+  color: "#ff7043",
+};
+
+describe("instantCast バフ（詠唱破棄）", () => {
+  it("triplecast 3スタックは詠唱GCDを打つ度に1スタック消費し、3発目後に失効する", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["triplecast-test"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("cast-spell"),
+        makeEntry("cast-spell"),
+        makeEntry("cast-spell"),
+        makeEntry("cast-spell"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [triplecastBuff]
+    );
+
+    // 1〜3発目の詠唱スキルは castTime=0（Instant化）
+    expect(result.entries[1].castTime).toBe(0);
+    expect(result.entries[2].castTime).toBe(0);
+    expect(result.entries[3].castTime).toBe(0);
+
+    // 4発目は triplecast 失効済みのため castTime が元の値で計算される（速度バフなし = 2.8）
+    expect(result.entries[4].castTime).toBeCloseTo(2.8, 3);
+
+    // 最終エントリの activeBuffs は triplecast を含まない（3発で使い切った）
+    expect(result.entries[4].activeBuffs.some((ab) => ab.buffId === "triplecast-test")).toBe(false);
+  });
+
+  it("firestarter（単発バフ）は1回の詠唱GCDで消費され、次の詠唱スキルは通常の詠唱時間に戻る", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["firestarter-test"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("cast-spell"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [firestarterBuff]
+    );
+
+    expect(result.entries[1].castTime).toBe(0);
+    // 消費後は通常詠唱
+    expect(result.entries[2].castTime).toBeCloseTo(2.8, 3);
+
+    // 消費されたので2発目時点ではバフは存在しない
+    expect(result.entries[2].activeBuffs.some((ab) => ab.buffId === "firestarter-test")).toBe(false);
+  });
+
+  it("非詠唱GCD（castTime 未設定）は instantCast バフを消費しない", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["firestarter-test"] });
+    const instantSkill = makeSkill({ id: "instant-skill" }); // castTime なし
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [instantSkill.id, instantSkill],
+      [castSpell.id, castSpell],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("instant-skill"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [firestarterBuff]
+    );
+
+    // 非詠唱GCD では消費されず、次の詠唱スキルで消費される
+    expect(result.entries[1].castTime).toBe(0);
+    expect(result.entries[2].castTime).toBe(0);
+    // 3発目の詠唱スキルで firestarter が消費されている（snapshot は消費後なので含まれない）
+    expect(result.entries[2].activeBuffs.some((ab) => ab.buffId === "firestarter-test")).toBe(false);
+  });
+
+  it("oGCD は instantCast バフを消費しない（詠唱GCDでのみ消費）", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["firestarter-test"] });
+    const ability = makeSkill({ id: "ability", type: "ogcd", recastTime: 30 });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [ability.id, ability],
+      [castSpell.id, castSpell],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("ability"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [firestarterBuff]
+    );
+
+    // oGCD 実行後も firestarter バフは残り、次の詠唱 GCD で Instant 化される
+    expect(result.entries[2].castTime).toBe(0);
+  });
+
+  it("instantCast バフなしでは詠唱スキルが speed バフの影響を受ける（回帰チェック）", () => {
+    const speedBuff: BuffDefinition = {
+      id: "speed-buff",
+      name: "スピード",
+      shortName: "SP",
+      icon: "",
+      duration: 30,
+      effects: [{ type: "speed", value: 0.85 }],
+      color: "#888888",
+    };
+    const grant = makeSkill({ id: "grant", buffApplications: ["speed-buff"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [speedBuff]
+    );
+
+    // speed バフで詠唱が 2.8 * 0.85 = 2.38 になる
+    expect(result.entries[1].castTime).toBeCloseTo(2.38, 3);
+  });
+
+  it("speed バフと instantCast バフが共存すると instantCast が優先される（castTime=0）", () => {
+    const speedBuff: BuffDefinition = {
+      id: "speed-buff",
+      name: "スピード",
+      shortName: "SP",
+      icon: "",
+      duration: 30,
+      effects: [{ type: "speed", value: 0.85 }],
+      color: "#888888",
+    };
+    const grant = makeSkill({ id: "grant", buffApplications: ["speed-buff", "triplecast-test"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [speedBuff, triplecastBuff]
+    );
+
+    expect(result.entries[1].castTime).toBe(0);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -105,6 +105,21 @@ function getSpeedMultiplier(
 }
 
 /**
+ * アクティブなバフに詠唱破棄（instantCast）効果を持つものが含まれるか判定する。
+ */
+function hasInstantCastBuff(
+  activeBuffs: ActiveBuff[],
+  buffDefMap: Map<string, BuffDefinition>
+): boolean {
+  for (const ab of activeBuffs) {
+    const def = buffDefMap.get(ab.buffId);
+    if (!def) continue;
+    if (def.effects.some((e) => e.type === "instantCast")) return true;
+  }
+  return false;
+}
+
+/**
  * アクティブなバフからクリティカル発生率ボーナスを計算する。
  */
 function getCritRateBonus(
@@ -505,6 +520,7 @@ export function resolveTimeline(
     if (!originalSkill) continue;
 
     let startTime: number;
+    let resolvedCastTime = 0;
 
     if (originalSkill.type === "gcd") {
       const baseRecast = stats ? calcGcd(originalSkill.recastTime, stats) : originalSkill.recastTime;
@@ -517,13 +533,17 @@ export function resolveTimeline(
       // 速度バフを適用してリキャスト・詠唱時間計算
       const speedMul = getSpeedMultiplier(currentActiveBuffs, buffDefMap);
       const recastTime = Math.round(baseRecast * speedMul * 1000) / 1000;
-      const castTime = originalSkill.castTime
+      // instantCast バフがアクティブなら詠唱時間を 0 に上書きする（三連魔・ファイアスターター等）
+      const instantCast = originalSkill.castTime
+        ? hasInstantCastBuff(currentActiveBuffs, buffDefMap)
+        : false;
+      resolvedCastTime = originalSkill.castTime && !instantCast
         ? Math.round(originalSkill.castTime * speedMul * 1000) / 1000
         : 0;
 
       gcdAvailableAt = startTime + recastTime;
       // 詠唱中はoGCDを挟めない: actionAvailableAtは詠唱完了時刻かアニメーションロック完了時刻の遅い方
-      actionAvailableAt = startTime + Math.max(castTime, originalSkill.animationLock);
+      actionAvailableAt = startTime + Math.max(resolvedCastTime, originalSkill.animationLock);
     } else {
       startTime = actionAvailableAt;
       startTime = Math.round(startTime * 1000) / 1000;
@@ -755,6 +775,18 @@ export function resolveTimeline(
         const def = buffDefMap.get(ab.buffId);
         if (def?.effects.some((e) => e.type === "consumeOnGcd")) {
           consumeOnGcdTargets.push(ab.buffId);
+        }
+      }
+    }
+
+    // 詠唱時間を持つGCDスキル実行前に、instantCast対象のバフIDを記録しておく
+    // （非詠唱GCD・oGCDでは消費しない。スキル実行中に新たに付与されたバフも消費対象外）
+    const instantCastTargets: string[] = [];
+    if (skill.type === "gcd" && originalSkill.castTime && originalSkill.castTime > 0) {
+      for (const ab of currentActiveBuffs) {
+        const def = buffDefMap.get(ab.buffId);
+        if (def?.effects.some((e) => e.type === "instantCast")) {
+          instantCastTargets.push(ab.buffId);
         }
       }
     }
@@ -1074,6 +1106,25 @@ export function resolveTimeline(
       }
     }
 
+    // 詠唱GCD実行後、スキル実行前にアクティブだったinstantCastバフを消費（三連魔・ファイアスターター等）
+    // スキル実行中に新規付与されたバフは消費しない
+    if (!hasError && instantCastTargets.length > 0) {
+      for (const buffId of instantCastTargets) {
+        const idx = currentActiveBuffs.findIndex((ab) => ab.buffId === buffId);
+        if (idx >= 0) {
+          const ab = currentActiveBuffs[idx];
+          if (ab.stacks !== undefined) {
+            ab.stacks = Math.max(0, ab.stacks - 1);
+            if (ab.stacks === 0) {
+              currentActiveBuffs.splice(idx, 1);
+            }
+          } else {
+            currentActiveBuffs.splice(idx, 1);
+          }
+        }
+      }
+    }
+
     // コンボ状態更新: GCDスキルを使用した場合、コンボ状態を更新
     // comboFromを持つスキルまたはコンボ系スキルの起点となるスキルはコンボ状態を更新する
     if (skill.type === "gcd" && !hasError) {
@@ -1103,6 +1154,7 @@ export function resolveTimeline(
       dhRateBonus,
       gcdAvailableAt,
       actionAvailableAt,
+      castTime: resolvedCastTime,
     });
   }
 

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -188,7 +188,7 @@ export interface CharacterStats {
 }
 
 /** バフ・デバフのエフェクト種別 */
-export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd";
+export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast";
 
 /** バフ・デバフの効果 */
 export interface BuffEffect {
@@ -203,6 +203,7 @@ export interface BuffEffect {
    * - guaranteedCrit: 次のWS使用時にクリティカル率を100%にする（値は未使用）
    * - guaranteedDh: 次のWS使用時にダイレクトヒット率を100%にする（値は未使用）
    * - consumeOnGcd: GCDスキル使用時に自動消費される（値は未使用）
+   * - instantCast: 詠唱時間を0にする（値は未使用、詠唱時間を持つGCDスキル使用時に自動消費）
    * - stat: ステータス加算値
    * - resource: リソース変動量
    */
@@ -370,4 +371,11 @@ export interface ResolvedTimelineEntry {
   gcdAvailableAt: number;
   /** このエントリ実行後、次のアクション（GCD/oGCD問わず）が使用可能になる時刻（秒） */
   actionAvailableAt: number;
+  /**
+   * 実行時に適用された詠唱時間（秒）。
+   * 速度バフ・instantCast バフ（三連魔・ファイアスターター等）を反映済み。
+   * 非詠唱スキル・oGCDでは 0。
+   * UI 側で activeBuffs を再解釈しなくても、この値を直接描画できる。
+   */
+  castTime: number;
 }


### PR DESCRIPTION
## 概要

三連魔・ファイアスターターのような「次の詠唱 GCD を Instant 化するバフ」を汎用的に表現できる `instantCast` エフェクト型を導入した。`BuffEffectType` に `"instantCast"` を追加し、resolver 側で詠唱時間 > 0 の GCD 実行時のみ `castTime` を 0 に上書き＆スタック消費する。

## 変更点

- **型**: `src/client/types/skill.ts`
  - `BuffEffectType` に `"instantCast"` を追加
  - `ResolvedTimelineEntry` に `castTime: number` フィールドを追加（速度バフ・instantCast バフを反映済みの実効詠唱時間）
- **resolver**: `src/client/logic/resolve-timeline.ts`
  - `hasInstantCastBuff` ヘルパーを追加
  - 詠唱時間計算で instantCast バフがあれば `castTime = 0` に上書き
  - `originalSkill.castTime > 0` の GCD 実行後にのみ該当バフを消費（非詠唱 GCD / oGCD では消費しない）
  - スタック式バフはデクリメント、単発バフは削除
- **バフ定義**: `src/client/data/blm-buffs.ts`
  - `triplecast`（3スタック・15秒）/ `firestarter`（単発・永続）の `effects` を `[{ type: "instantCast", value: 0 }]` に置換
- **UI**: `src/client/components/Timeline.tsx`
  - `getEntryCastTime` の動的算出を廃止し、`entry.castTime` を直接参照するように変更（消費後 snapshot でもバー描画が正しくなる）
- **テスト**: `src/client/logic/__tests__/instant-cast.test.ts` を新規追加（6ケース）
  - triplecast 3スタック消費 / firestarter 単発消費 / 非詠唱 GCD で消費されない / oGCD で消費されない / speed バフ単独の回帰 / speed + instantCast 共存時は instantCast 優先

## 非対象（子Issueへ切り出し）

レビューで検出したスコープ外項目は個別Issueとして起票済み：

- #197: fix: ファイアスターターの消費対象をファイガ（fire-3）限定にする
- #198: refactor: consumeOnGcd / instantCast の消費ロジックを統合し二重消費リスクを排除する

## テスト

- [x] `npm test` — 全 Vitest スイート通過
- [x] `tsc --noEmit` — 型エラーなし
- [x] 既存の `buff-timespans.test.ts` にも `castTime: 0` を追加し、ヘルパーが新フィールドに追従

closes #171
