### PR TITLE
feat: 迅速魔（Swiftcast）をWHM/PCT/BLMに追加 #186

### DIFF
--- a/src/client/data/blm-buffs.ts
+++ b/src/client/data/blm-buffs.ts
@@ -7,6 +7,7 @@ import thunderIcon from "../assets/icons/blm/Thunder.png";
 import fire3Icon from "../assets/icons/blm/Fire_III.png";
 import leyLinesIcon from "../assets/icons/blm/Ley_Lines.png";
 import triplecastIcon from "../assets/icons/blm/Triplecast.png";
+import swiftcastIcon from "../assets/icons/blm/role_actions/Swiftcast.png";
 
 /**
  * 黒魔道士のバフ定義。
@@ -196,5 +197,15 @@ export const BLM_BUFFS: BuffDefinition[] = [
     ],
     color: "#ab47bc",
     acquiredLevel: 52,
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    shortName: "迅速魔",
+    icon: swiftcastIcon,
+    duration: 10,
+    effects: [{ type: "instantCast", value: 0 }],
+    color: "#80deea",
+    acquiredLevel: 18,
   },
 ];

--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -28,6 +28,7 @@ import triplecastIcon from "../assets/icons/blm/Triplecast.png";
 import leyLinesIcon from "../assets/icons/blm/Ley_Lines.png";
 import transposeIcon from "../assets/icons/blm/Transpose.png";
 import amplifierIcon from "../assets/icons/blm/Amplifier.png";
+import swiftcastIcon from "../assets/icons/blm/role_actions/Swiftcast.png";
 
 /** GCDリキャスト（秒） */
 const GCD_RECAST = 2.5;
@@ -505,5 +506,18 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     resourceChanges: [
       { resourceId: "polyglot", amount: 1 },
     ],
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: swiftcastIcon,
+    recastTime: DEFAULT_ANIMATION_LOCK,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    cooldown: 60,
+    acquiredLevel: 18,
+    buffApplications: ["swiftcast"],
   },
 ];

--- a/src/client/data/pct-buffs.ts
+++ b/src/client/data/pct-buffs.ts
@@ -8,6 +8,7 @@ import starPrismIcon from "../assets/icons/pct/Star_Prism.png";
 import starryMuseIcon from "../assets/icons/pct/Starry_Muse.png";
 import rainbowDripIcon from "../assets/icons/pct/Rainbow_Drip.png";
 import mogOfTheAgesIcon from "../assets/icons/pct/Mog_of_the_Ages.png";
+import swiftcastIcon from "../assets/icons/pct/role_actions/Swiftcast.png";
 
 export const PCT_BUFFS: BuffDefinition[] = [
   // ============================================================
@@ -206,5 +207,15 @@ export const PCT_BUFFS: BuffDefinition[] = [
     duration: null,
     effects: [],
     color: "#e57373",
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    shortName: "迅速魔",
+    icon: swiftcastIcon,
+    duration: 10,
+    effects: [{ type: "instantCast", value: 0 }],
+    color: "#80deea",
+    acquiredLevel: 18,
   },
 ];

--- a/src/client/data/pct-skills.ts
+++ b/src/client/data/pct-skills.ts
@@ -28,6 +28,7 @@ import retributionOfTheMadeenIcon from "../assets/icons/pct/Retribution_of_the_M
 import strikingMuseIcon from "../assets/icons/pct/Striking_Muse.png";
 import subtractivePaletteIcon from "../assets/icons/pct/Subtractive_Palette.png";
 import starryMuseIcon from "../assets/icons/pct/Starry_Muse.png";
+import swiftcastIcon from "../assets/icons/pct/role_actions/Swiftcast.png";
 
 /** GCDリキャスト（秒） */
 const GCD_RECAST = 2.5;
@@ -519,5 +520,18 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
       { resourceId: "scape-canvas", amount: -1 },
     ],
     buffApplications: ["starry-muse", "installation", "star-prism-ready", "subtractive-ready"],
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: swiftcastIcon,
+    recastTime: DEFAULT_ANIMATION_LOCK,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    cooldown: 60,
+    acquiredLevel: 18,
+    buffApplications: ["swiftcast"],
   },
 ];

--- a/src/client/data/whm-buffs.ts
+++ b/src/client/data/whm-buffs.ts
@@ -2,6 +2,7 @@ import type { BuffDefinition } from "../types/skill";
 
 import presenceOfMindIcon from "../assets/icons/whm/Presence_of_Mind.png";
 import sacredSightIcon from "../assets/icons/whm/traits/Enhanced_Presence_of_Mind.png";
+import swiftcastIcon from "../assets/icons/whm/role_actions/Swiftcast.png";
 
 /**
  * 白魔道士（WHM）バフ定義
@@ -31,5 +32,15 @@ export const WHM_BUFFS: BuffDefinition[] = [
     color: "#ffcc00",
     maxStacks: 3,
     acquiredLevel: 92,
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    shortName: "迅速魔",
+    icon: swiftcastIcon,
+    duration: 10,
+    effects: [{ type: "instantCast", value: 0 }],
+    color: "#80deea",
+    acquiredLevel: 18,
   },
 ];

--- a/src/client/data/whm-skills.ts
+++ b/src/client/data/whm-skills.ts
@@ -17,6 +17,7 @@ import afflatus_solaceIcon from "../assets/icons/whm/Afflatus_Solace.png";
 import afflatus_raptureIcon from "../assets/icons/whm/Afflatus_Rapture.png";
 import assizeIcon from "../assets/icons/whm/Assize.png";
 import presenceOfMindIcon from "../assets/icons/whm/Presence_of_Mind.png";
+import swiftcastIcon from "../assets/icons/whm/role_actions/Swiftcast.png";
 
 /** GCDのデフォルトリキャストタイム（秒） */
 const GCD_RECAST = 2.5;
@@ -276,5 +277,18 @@ export const WHM_ATTACK_SKILLS: Skill[] = [
     cooldown: 120,
     acquiredLevel: 30,
     buffApplications: ["presence-of-mind", "sacred-sight"],
+  },
+  {
+    id: "swiftcast",
+    name: "迅速魔",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: swiftcastIcon,
+    recastTime: DEFAULT_ANIMATION_LOCK,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    cooldown: 60,
+    acquiredLevel: 18,
+    buffApplications: ["swiftcast"],
   },
 ];

--- a/src/client/logic/__tests__/instant-cast.test.ts
+++ b/src/client/logic/__tests__/instant-cast.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { resolveTimeline } from "../resolve-timeline";
 import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+import { WHM_ATTACK_SKILLS } from "../../data/whm-skills";
+import { WHM_BUFFS } from "../../data/whm-buffs";
+import { PCT_ATTACK_SKILLS } from "../../data/pct-skills";
+import { PCT_BUFFS } from "../../data/pct-buffs";
+import { BLM_ATTACK_SKILLS } from "../../data/blm-skills";
+import { BLM_BUFFS } from "../../data/blm-buffs";
 
 function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
   return {
@@ -191,4 +197,44 @@ describe("instantCast バフ（詠唱破棄）", () => {
 
     expect(result.entries[1].castTime).toBe(0);
   });
+});
+
+describe("迅速魔（Swiftcast）統合スモークテスト", () => {
+  it.each([
+    { job: "WHM", skills: WHM_ATTACK_SKILLS, buffs: WHM_BUFFS, castSkillId: "stone" },
+    { job: "PCT", skills: PCT_ATTACK_SKILLS, buffs: PCT_BUFFS, castSkillId: "fire-in-red" },
+    { job: "BLM", skills: BLM_ATTACK_SKILLS, buffs: BLM_BUFFS, castSkillId: "fire-3" },
+  ])(
+    "$job: 迅速魔バフ中の次の詠唱GCDは castTime=0 で発動し、消費後は通常詠唱に戻る",
+    ({ skills, buffs, castSkillId }) => {
+      const skillMap = new Map(skills.map((s) => [s.id, s]));
+      const swiftcastSkill = skills.find((s) => s.id === "swiftcast");
+      const castSpell = skills.find((s) => s.id === castSkillId);
+      const swiftcastBuff = buffs.find((b) => b.id === "swiftcast");
+
+      expect(swiftcastSkill).toBeDefined();
+      expect(castSpell).toBeDefined();
+      expect(castSpell!.castTime ?? 0).toBeGreaterThan(0);
+      expect(swiftcastBuff).toBeDefined();
+      expect(swiftcastBuff!.duration).toBe(10);
+      expect(swiftcastBuff!.effects.some((e) => e.type === "instantCast")).toBe(true);
+
+      const result = resolveTimeline(
+        [makeEntry("swiftcast"), makeEntry(castSkillId), makeEntry(castSkillId)],
+        skillMap,
+        [],
+        undefined,
+        buffs
+      );
+
+      // 1発目の詠唱GCDはInstant化
+      expect(result.entries[1].castTime).toBe(0);
+      // 消費後は通常詠唱に戻る（speedバフ等は付与していないので castTime はそのまま）
+      expect(result.entries[2].castTime).toBeCloseTo(castSpell!.castTime!, 3);
+      // 2発目時点で swiftcast バフは消費済み
+      expect(
+        result.entries[2].activeBuffs.some((ab) => ab.buffId === "swiftcast")
+      ).toBe(false);
+    }
+  );
 });


### PR DESCRIPTION
## 概要

ロールアクション「迅速魔（Swiftcast）」を WHM/PCT/BLM の 3 ジョブに追加する。次の 1 回の詠唱 GCD を Instant 化（castTime = 0）する効果。

## 設計上のポイント

Issue 本文では「`BuffEffectType` への `instantCast` 新規追加が必要」「`resolve-timeline.ts` の詠唱時間計算ロジック拡張が必要」と記載されていたが、コード探索の結果、これらは既に三連魔（Triplecast）／ファイアスターター実装のために整備済みであることを確認した。本 PR は **データ追加のみ**で完結し、型・解決ロジック・UI コンポーネントには一切手を入れていない。

- `BuffEffectType.instantCast` は `src/client/types/skill.ts:191` に既存
- 詠唱時間 0 上書きは `src/client/logic/resolve-timeline.ts:536-542` に実装済み
- バフ消費（`maxStacks` 未指定時は単発消費 → 削除）は `resolve-timeline.ts:1109-1124` に実装済み
- 迅速魔アイコンは `src/client/assets/icons/{whm,blm,pct}/role_actions/Swiftcast.png` に既配置

## 変更点

- `src/client/data/whm-skills.ts` / `pct-skills.ts` / `blm-skills.ts` に `id: "swiftcast"` の oGCD スキルを追加
  - `type: "ogcd"`, `target: "self"`, `potency: 0`, `cooldown: 60`, `acquiredLevel: 18`, `buffApplications: ["swiftcast"]`
- `src/client/data/whm-buffs.ts` / `pct-buffs.ts` / `blm-buffs.ts` に `id: "swiftcast"` のバフを追加
  - `duration: 10`, `effects: [{ type: "instantCast", value: 0 }]`, `maxStacks` 未指定（単発バフ）
- `src/client/logic/__tests__/instant-cast.test.ts` に WHM/PCT/BLM 各ジョブの実データを使った統合スモークテストを `it.each` で追加（迅速魔バフ付与 → 次の詠唱GCDが castTime=0 → 2発目は通常詠唱に戻り、バフは消費済み）

設計判断（ユーザー確認済み）:
- 3 ジョブ共通で `id: "swiftcast"` を使用（各ジョブの skills/buffs 配列は独立しているため衝突しない）
- 共通ロールアクションディレクトリは作らず、各ジョブファイルに個別記載
- スタック付き実装ではなく単発バフ（迅速魔は 1 スタック固定のため）

## テスト

- `npx tsc --noEmit`: エラーなし
- `npm test`: 15 ファイル / 85 件 すべて pass（迅速魔の 3 ジョブ統合スモークテストを含む）
- `npx vite build`: 成功
- `code-reviewer` 2 並列レビュー（バグ・正確性 / 規約・整合性）: 信頼度 80 以上の指摘ゼロ
- UI 動作確認: 未実施（本変更はデータ追加のみで UI コンポーネントの変更はなく、テスト＋ビルドで機能の正しさを確認済み）

closes #186

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8dCZ6gnXmyWm6MmVerR2z)_