### PR TITLE
fix: 黒魔道士の詠唱スキルcastTimeを公式ジョブガイド準拠に修正 #200

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -73,7 +73,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: fireIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.5,
+    castTime: 2.0,
     acquiredLevel: 2,
     resourceChanges: [
       { resourceId: "mp", amount: -800 },
@@ -107,7 +107,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: fire4Icon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.8,
+    castTime: 2.0,
     acquiredLevel: 60,
     // AF3 中でのみ実用、AF1/AF2 でもゲーム上は使用可能
     requiredBuff: "astral-fire-3",
@@ -126,7 +126,6 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: despairIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 3.0,
     acquiredLevel: 72,
     // AF 中のみ使用可（AF3 へ直接引き上げる）
     requiredBuff: "astral-fire-3",
@@ -143,7 +142,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: flareStarIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 3.0,
+    castTime: 2.0,
     acquiredLevel: 100,
     // アストラルソウル 6 を消費
     resourceChanges: [
@@ -200,7 +199,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: blizzardIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.5,
+    castTime: 2.0,
     acquiredLevel: 1,
     resourceChanges: [
       // 通常ヒット時に MP 回復（UB 中はさらに多く回復すべきだが簡易化）
@@ -233,7 +232,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: blizzard4Icon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.5,
+    castTime: 2.0,
     acquiredLevel: 58,
     // UB 中のみ使用可
     requiredBuff: "umbral-ice-3",
@@ -289,7 +288,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: freezeIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.8,
+    castTime: 2.0,
     acquiredLevel: 40,
     resourceChanges: [
       { resourceId: "mp", amount: -1000 },
@@ -310,7 +309,6 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     icon: paradoxIcon,
     recastTime: GCD_RECAST,
     animationLock: DEFAULT_ANIMATION_LOCK,
-    castTime: 2.5,
     acquiredLevel: 90,
     // パラドックスゲージを 1 消費
     resourceChanges: [

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -129,8 +129,8 @@ describe("BLM: ポリグロット自動蓄積", () => {
   it("AF/UB 中は 30 秒ごとにポリグロットが 1 蓄積される", () => {
     // fire-3 で AF3 を付与し、以降 GCD を多数配置して 30 秒経過させる
     const entries: TimelineEntry[] = [entry("fire-3")];
-    // GCD 2.5s × 12 回 = 30 秒
-    for (let i = 0; i < 12; i++) {
+    // fire-3 cast 3.5s + fire-4 (cast 2.0s, GCD 2.5s) × 13 = 36 秒（30秒を確実に超える）
+    for (let i = 0; i < 13; i++) {
       entries.push(entry("fire-4"));
     }
     const result = resolveTimeline(


### PR DESCRIPTION
## 概要

黒魔道士（BLM）の詠唱スキルの `castTime` を公式ジョブガイド（パッチ7.2 以降）と照合し、差異がある8スキルを修正。デスペアとパラドックスは7.2でInstant化されているため `castTime` プロパティを削除。

参照: https://jp.finalfantasyxiv.com/jobguide/blackmage/

## 変更点

### `src/client/data/blm-skills.ts`

| スキル名 | 変更前 | 変更後 | 備考 |
|---------|-------|-------|------|
| ファイア | 2.5s | **2.0s** | 7.2で統一 |
| ファイガ | 3.5s | 3.5s | 変更なし（公式と一致） |
| ファイジャ | 2.8s | **2.0s** | 7.2で統一 |
| デスペア | 3.0s | **Instant** | castTime 削除（7.2でInstant化） |
| フレアスター | 3.0s | **2.0s** | 7.2で統一 |
| ファイラ | 3.0s | 3.0s | 変更なし（範囲スキルは据え置き） |
| ハイファイア | 3.0s | 3.0s | 変更なし |
| ブリザド | 2.5s | **2.0s** | 7.2で統一 |
| ブリザガ | 3.5s | 3.5s | 変更なし（公式と一致） |
| ブリザジャ | 2.5s | **2.0s** | 7.2で統一 |
| ブリザラ | 3.0s | 3.0s | 変更なし |
| ハイブリザラ | 3.0s | 3.0s | 変更なし |
| フリーズ | 2.8s | **2.0s** | 7.2で統一 |
| パラドックス | 2.5s | **Instant** | castTime 削除（7.2でInstant化） |

### `src/client/logic/__tests__/blm-af-ub.test.ts`

- castTime 短縮の副次変更で、ポリグロット自動蓄積テストの GCD 配置数を 12→13 に調整（30秒経過を確実に超えるため）

### Issue #200 完了条件の確認

- [x] **全BLM詠唱スキルの castTime が公式ジョブガイドと一致**: 8スキル修正、6スキルは元から一致
- [x] **AF中・UB中の詠唱変化が反映**: 既存の `instantCast` バフ機構（三連魔・ファイアスターター・サンダーヘッド等）でカバー済み。本Issueでの追加実装は不要
- [x] **Instant スキル（サンダガ/ハイサンダー/ゼノグロシー/ファウル）は castTime 未設定のまま維持**
- [x] **既存のテストが通る**

## スコープ外の発見事項（別Issue起票済み）

- #203 黒魔道士「ハイファイア」のスキル名が公式と異なる（正: ハイファイラ）

## テスト

- [x] `npm test`: 85/85 pass
- [x] `npx tsc --noEmit`: エラーなし
- [x] `npx vite build`: ビルド成功

## 参考情報源

- [公式ジョブガイド（黒魔道士）](https://jp.finalfantasyxiv.com/jobguide/blackmage/)
- [パッチ7.2黒魔道士のファーストインプレッション（蒼隆太郎 note）](https://note.com/dragontarou/n/nb88dbe44da19): 「ほとんどの詠唱スキルの詠唱時間を 2.0 秒に統一（例外はブリザガ、ファイガのみ）」

closes #200

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDW436DpYTBP3qrDkdxFRw)_