### PR TITLE
refactor: consumeOnGcd / instantCast の消費ロジックをSetで統合 #198

### DIFF
--- a/src/client/logic/__tests__/instant-cast.test.ts
+++ b/src/client/logic/__tests__/instant-cast.test.ts
@@ -238,3 +238,90 @@ describe("迅速魔（Swiftcast）統合スモークテスト", () => {
     }
   );
 });
+
+describe("consumeOnGcd と instantCast を併せ持つバフ（消費ロジック統合）", () => {
+  // 現状そのようなバフ定義は存在しないが、将来追加された際に同一バフが
+  // 1 発で 2 回デクリメントされる構造的リスクを排除した #198 の回帰テスト。
+  it("両エフェクトを持つスタック式バフは詠唱GCD 1発でスタックが1だけ減る（二重消費しない）", () => {
+    const dualBuff: BuffDefinition = {
+      id: "dual-effect-test",
+      name: "両効果バフ",
+      shortName: "両",
+      icon: "",
+      duration: null,
+      maxStacks: 2,
+      effects: [
+        { type: "instantCast", value: 0 },
+        { type: "consumeOnGcd", value: 0 },
+      ],
+      color: "#90caf9",
+    };
+    const grant = makeSkill({ id: "grant", buffApplications: ["dual-effect-test"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("cast-spell"),
+        makeEntry("cast-spell"),
+        makeEntry("cast-spell"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [dualBuff]
+    );
+
+    // ActiveBuff オブジェクトはエントリ間で参照を共有するため stacks の数値比較は
+    // 安定しない。配列への含有／除外（splice の有無）でスタックの段階消費を検証する。
+    // 二重消費が起きていれば 1 発目で stacks=0 になり splice されて entries[1] から消失する。
+
+    // 1発目 cast-spell 後: dualBuff はまだ存在する（stacks 2→1。二重消費していない）
+    expect(
+      result.entries[1].activeBuffs.some((ab) => ab.buffId === "dual-effect-test")
+    ).toBe(true);
+
+    // 2発目 cast-spell 後: stacks 1→0 で splice され消失
+    expect(
+      result.entries[2].activeBuffs.some((ab) => ab.buffId === "dual-effect-test")
+    ).toBe(false);
+
+    // 1〜2発目は instantCast で詠唱破棄、3発目はバフ失効後で通常詠唱
+    expect(result.entries[1].castTime).toBe(0);
+    expect(result.entries[2].castTime).toBe(0);
+    expect(result.entries[3].castTime).toBeCloseTo(2.8, 3);
+  });
+
+  it("両エフェクトを持つ単発バフは詠唱GCD 1発で消費される（重複削除エラーなし）", () => {
+    const dualSingleBuff: BuffDefinition = {
+      id: "dual-single-test",
+      name: "両効果単発バフ",
+      shortName: "両単",
+      icon: "",
+      duration: null,
+      effects: [
+        { type: "instantCast", value: 0 },
+        { type: "consumeOnGcd", value: 0 },
+      ],
+      color: "#a5d6a7",
+    };
+    const grant = makeSkill({ id: "grant", buffApplications: ["dual-single-test"] });
+    const castSpell = makeSkill({ id: "cast-spell", castTime: 2.8 });
+    const skillMap = new Map([[grant.id, grant], [castSpell.id, castSpell]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("cast-spell"), makeEntry("cast-spell")],
+      skillMap,
+      [],
+      undefined,
+      [dualSingleBuff]
+    );
+
+    // 1発目で消費されてバフ消失（2回 splice しようとしてもエラーにならない）
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "dual-single-test")).toBe(false);
+    // 1発目は instantCast 適用、2発目はバフ失効で通常詠唱
+    expect(result.entries[1].castTime).toBe(0);
+    expect(result.entries[2].castTime).toBeCloseTo(2.8, 3);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -767,26 +767,22 @@ export function resolveTimeline(
       // state未登録 = 初回使用 → エラーなし
     }
 
-    // GCDスキル実行前に、consumeOnGcd対象のバフIDを記録しておく
+    // GCDスキル実行前に、消費対象（consumeOnGcd / instantCast）のバフIDを Set で収集する。
+    // 同一バフが両エフェクトを併せ持つ場合に 1 発で 2 回デクリメントされるリスクを排除するため、
+    // 和集合として 1 度だけ消費するように Set 化している。
     // （スキル実行中に新たに付与されたバフは消費対象外）
-    const consumeOnGcdTargets: string[] = [];
+    // - consumeOnGcd: 全 GCD スキル実行後に消費
+    // - instantCast: 詠唱時間 > 0 の GCD スキル実行後にのみ消費（非詠唱 GCD / oGCD では消費しない）
+    const consumeBuffTargets = new Set<string>();
     if (skill.type === "gcd") {
+      const isCastingGcd = !!originalSkill.castTime && originalSkill.castTime > 0;
       for (const ab of currentActiveBuffs) {
         const def = buffDefMap.get(ab.buffId);
-        if (def?.effects.some((e) => e.type === "consumeOnGcd")) {
-          consumeOnGcdTargets.push(ab.buffId);
-        }
-      }
-    }
-
-    // 詠唱時間を持つGCDスキル実行前に、instantCast対象のバフIDを記録しておく
-    // （非詠唱GCD・oGCDでは消費しない。スキル実行中に新たに付与されたバフも消費対象外）
-    const instantCastTargets: string[] = [];
-    if (skill.type === "gcd" && originalSkill.castTime && originalSkill.castTime > 0) {
-      for (const ab of currentActiveBuffs) {
-        const def = buffDefMap.get(ab.buffId);
-        if (def?.effects.some((e) => e.type === "instantCast")) {
-          instantCastTargets.push(ab.buffId);
+        if (!def) continue;
+        const hasConsumeOnGcd = def.effects.some((e) => e.type === "consumeOnGcd");
+        const hasInstantCast = isCastingGcd && def.effects.some((e) => e.type === "instantCast");
+        if (hasConsumeOnGcd || hasInstantCast) {
+          consumeBuffTargets.add(ab.buffId);
         }
       }
     }
@@ -1087,29 +1083,13 @@ export function resolveTimeline(
       consumeGuaranteedDhBuffs(currentActiveBuffs, buffDefMap, consumedByBuffConsumptions);
     }
 
-    // GCDスキル実行後、スキル実行前にアクティブだったconsumeOnGcdバフを消費（竜眼等）
-    // スキル実行中に新規付与されたバフは消費しない
-    if (!hasError && consumeOnGcdTargets.length > 0) {
-      for (const buffId of consumeOnGcdTargets) {
-        const idx = currentActiveBuffs.findIndex((ab) => ab.buffId === buffId);
-        if (idx >= 0) {
-          const ab = currentActiveBuffs[idx];
-          if (ab.stacks !== undefined) {
-            ab.stacks = Math.max(0, ab.stacks - 1);
-            if (ab.stacks === 0) {
-              currentActiveBuffs.splice(idx, 1);
-            }
-          } else {
-            currentActiveBuffs.splice(idx, 1);
-          }
-        }
-      }
-    }
-
-    // 詠唱GCD実行後、スキル実行前にアクティブだったinstantCastバフを消費（三連魔・ファイアスターター等）
-    // スキル実行中に新規付与されたバフは消費しない
-    if (!hasError && instantCastTargets.length > 0) {
-      for (const buffId of instantCastTargets) {
+    // GCDスキル実行後、スキル実行前にアクティブだった消費対象バフを 1 ループで消費する。
+    // - consumeOnGcd: 竜眼等（全 GCD で消費）
+    // - instantCast: 三連魔・ファイアスターター等（詠唱 GCD でのみ消費）
+    // 同一バフが両エフェクトを併せ持っても収集側で Set 化済みのため二重消費は起きない。
+    // スキル実行中に新規付与されたバフは消費しない（収集を実行前に済ませているため）。
+    if (!hasError && consumeBuffTargets.size > 0) {
+      for (const buffId of consumeBuffTargets) {
         const idx = currentActiveBuffs.findIndex((ab) => ab.buffId === buffId);
         if (idx >= 0) {
           const ab = currentActiveBuffs[idx];


### PR DESCRIPTION
## 概要

`consumeOnGcd` と `instantCast` の消費ロジックを `Set<string>` ベースで一本化し、両エフェクトを併せ持つバフが 1 発の GCD 実行で 2 回デクリメントされる構造的リスクを排除した防衛的リファクタ。

## 変更点

- **`src/client/logic/resolve-timeline.ts:770-788`** — 消費対象収集を `Set<string>` に統合
  - `consumeOnGcd` 対象（全 GCD で消費）と `instantCast` 対象（詠唱 GCD かつ `castTime > 0` でのみ消費）の和集合を 1 度の走査で収集
  - 同一バフが両エフェクトを持っても Set により重複しない
- **`src/client/logic/resolve-timeline.ts:1086-1106`** — 消費ループを 1 本化
  - 旧来の 2 つの独立ループ（`consumeOnGcdTargets` / `instantCastTargets`）を削除し、`consumeBuffTargets` の単一イテレーションに置き換え
  - スタック減算・splice 処理は従来と同一
- **`src/client/logic/__tests__/instant-cast.test.ts`** — 回帰テスト追加
  - `describe("consumeOnGcd と instantCast を併せ持つバフ（消費ロジック統合）")` に 2 ケース
    - スタック式バフ（`maxStacks: 2`）で 1 発目消費後にバフが配列に残ること（=stacks 1 のままで splice されないこと）を `activeBuffs.some(...)` で検証
    - 単発バフでも 1 発消費で削除が 1 度だけ行われ重複 splice エラーが起きないことを検証
  - `ActiveBuff` がエントリ間で参照を共有する制約のもと、配列への含有/除外で段階消費を検証するアプローチを採用

## 既存挙動の維持

- 消費条件: `consumeOnGcd` は全 GCD 実行後、`instantCast` は詠唱時間 > 0 の GCD 実行後のみ（変更なし）
- 消費タイミング: スキル実行**前**に消費対象を収集し、実行**後**に消費（変更なし）
- スキル実行中に新規付与されたバフは消費対象外（変更なし）
- エラー時（`hasError === true`）は消費しない（変更なし）

## テスト

- [x] `npm test` — 全 87 テスト通過（うち新規 2 ケース）
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] code-reviewer 3 並列レビュー — 信頼度 80 以上の指摘なし

## 関連

- 親Issue: #171（instantCast 機構） / PR #199
- 子Issue: #202（迅速魔・三連魔の同時消費バグ — 別レイヤーの問題として独立対応）

closes #198


---
_Generated by [Claude Code](https://claude.ai/code/session_01WaYp3yh7ffQpCSGFXh2FjY)_