### PR TITLE
fix: ファイアスターターの消費対象をファイガ（fire-3）限定にする #197

### DIFF
--- a/src/client/data/blm-buffs.ts
+++ b/src/client/data/blm-buffs.ts
@@ -164,8 +164,8 @@ export const BLM_BUFFS: BuffDefinition[] = [
     shortName: "ﾌｧｲｱ\nｽﾀｰﾀｰ",
     icon: fire3Icon,
     duration: null,
-    // 次のファイガ詠唱を Instant 化（実スキル側の補正は別途対応。本バフは詠唱時間 0 化のみ担う）
-    effects: [{ type: "instantCast", value: 0 }],
+    // 次のファイガ（fire-3）詠唱のみ Instant 化する。実機ではファイア・ファイジャ等は対象外
+    effects: [{ type: "instantCast", value: 0, appliesToSkillIds: ["fire-3"] }],
     color: "#ff7043",
     acquiredLevel: 2,
   },

--- a/src/client/logic/__tests__/instant-cast.test.ts
+++ b/src/client/logic/__tests__/instant-cast.test.ts
@@ -239,6 +239,92 @@ describe("迅速魔（Swiftcast）統合スモークテスト", () => {
   );
 });
 
+describe("instantCast バフの appliesToSkillIds スコープ制限", () => {
+  it("appliesToSkillIds 指定時、対象スキル以外では消費・Instant 化されない", () => {
+    const scopedBuff: BuffDefinition = {
+      id: "scoped-instant",
+      name: "限定Instant",
+      shortName: "限",
+      icon: "",
+      duration: null,
+      effects: [{ type: "instantCast", value: 0, appliesToSkillIds: ["target-spell"] }],
+      color: "#ffab91",
+    };
+    const grant = makeSkill({ id: "grant", buffApplications: ["scoped-instant"] });
+    const otherSpell = makeSkill({ id: "other-spell", castTime: 2.5 });
+    const targetSpell = makeSkill({ id: "target-spell", castTime: 3.5 });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [otherSpell.id, otherSpell],
+      [targetSpell.id, targetSpell],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("other-spell"), makeEntry("target-spell"), makeEntry("target-spell")],
+      skillMap,
+      [],
+      undefined,
+      [scopedBuff]
+    );
+
+    // 対象外スキル（other-spell）では Instant 化されず、バフも消費されない
+    expect(result.entries[1].castTime).toBeCloseTo(2.5, 3);
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "scoped-instant")).toBe(true);
+
+    // 対象スキル（target-spell）では Instant 化され、バフが消費される
+    expect(result.entries[2].castTime).toBe(0);
+    expect(result.entries[2].activeBuffs.some((ab) => ab.buffId === "scoped-instant")).toBe(false);
+
+    // 消費後、次の対象スキルは通常詠唱に戻る
+    expect(result.entries[3].castTime).toBeCloseTo(3.5, 3);
+  });
+
+  it("BLM firestarter はファイガ（fire-3）のみを Instant 化し、ファイア（fire）では消費されない", () => {
+    const skillMap = new Map(BLM_ATTACK_SKILLS.map((s) => [s.id, s]));
+    const firestarterBuffDef = BLM_BUFFS.find((b) => b.id === "firestarter")!;
+    const fire = BLM_ATTACK_SKILLS.find((s) => s.id === "fire")!;
+    const fire3 = BLM_ATTACK_SKILLS.find((s) => s.id === "fire-3")!;
+
+    expect(firestarterBuffDef.effects[0]).toMatchObject({
+      type: "instantCast",
+      appliesToSkillIds: ["fire-3"],
+    });
+    expect(fire.castTime).toBeGreaterThan(0);
+    expect(fire3.castTime).toBeGreaterThan(0);
+
+    // パラドックス（AF 中に firestarter 付与）の前提条件を構築せず、テスト用 grant スキルで
+    // firestarter を直接付与する。fire-4 は requiredBuff: astral-fire-3 を持つためリソースエラーで
+    // 消費判定がスキップされ得るので、本テストでは fire / fire-3 のみで検証する。
+    const grant = makeSkill({ id: "test-grant-firestarter", buffApplications: ["firestarter"] });
+    const augmented = new Map(skillMap);
+    augmented.set(grant.id, grant);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("test-grant-firestarter"),
+        makeEntry("fire"),
+        makeEntry("fire-3"),
+        makeEntry("fire-3"),
+      ],
+      augmented,
+      [],
+      undefined,
+      BLM_BUFFS
+    );
+
+    // ファイア（fire）は Instant 化されず、firestarter は残ったまま
+    expect(result.entries[1].castTime).toBeGreaterThan(0);
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "firestarter")).toBe(true);
+
+    // ファイガ（fire-3）で初めて Instant 化されてバフが消費される
+    expect(result.entries[2].castTime).toBe(0);
+    expect(result.entries[2].activeBuffs.some((ab) => ab.buffId === "firestarter")).toBe(false);
+
+    // 消費後の 2 発目ファイガは通常詠唱に戻る
+    expect(result.entries[3].castTime).toBeGreaterThan(0);
+  });
+});
+
 describe("consumeOnGcd と instantCast を併せ持つバフ（消費ロジック統合）", () => {
   // 現状そのようなバフ定義は存在しないが、将来追加された際に同一バフが
   // 1 発で 2 回デクリメントされる構造的リスクを排除した #198 の回帰テスト。

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -106,15 +106,24 @@ function getSpeedMultiplier(
 
 /**
  * アクティブなバフに詠唱破棄（instantCast）効果を持つものが含まれるか判定する。
+ * targetSkillId が指定されている場合、appliesToSkillIds に
+ * 該当スキルIDが含まれないエフェクトは無視する（例: ファイアスターターはファイガ限定）。
  */
 function hasInstantCastBuff(
   activeBuffs: ActiveBuff[],
-  buffDefMap: Map<string, BuffDefinition>
+  buffDefMap: Map<string, BuffDefinition>,
+  targetSkillId?: string
 ): boolean {
   for (const ab of activeBuffs) {
     const def = buffDefMap.get(ab.buffId);
     if (!def) continue;
-    if (def.effects.some((e) => e.type === "instantCast")) return true;
+    for (const effect of def.effects) {
+      if (effect.type !== "instantCast") continue;
+      if (effect.appliesToSkillIds && targetSkillId !== undefined) {
+        if (!effect.appliesToSkillIds.includes(targetSkillId)) continue;
+      }
+      return true;
+    }
   }
   return false;
 }
@@ -534,8 +543,9 @@ export function resolveTimeline(
       const speedMul = getSpeedMultiplier(currentActiveBuffs, buffDefMap);
       const recastTime = Math.round(baseRecast * speedMul * 1000) / 1000;
       // instantCast バフがアクティブなら詠唱時間を 0 に上書きする（三連魔・ファイアスターター等）
+      // 対象スキル限定バフ（appliesToSkillIds）を正しくフィルタするため originalSkill.id を渡す
       const instantCast = originalSkill.castTime
-        ? hasInstantCastBuff(currentActiveBuffs, buffDefMap)
+        ? hasInstantCastBuff(currentActiveBuffs, buffDefMap, originalSkill.id)
         : false;
       resolvedCastTime = originalSkill.castTime && !instantCast
         ? Math.round(originalSkill.castTime * speedMul * 1000) / 1000
@@ -773,6 +783,7 @@ export function resolveTimeline(
     // （スキル実行中に新たに付与されたバフは消費対象外）
     // - consumeOnGcd: 全 GCD スキル実行後に消費
     // - instantCast: 詠唱時間 > 0 の GCD スキル実行後にのみ消費（非詠唱 GCD / oGCD では消費しない）
+    //   appliesToSkillIds 指定時は該当スキルIDのみ消費対象（例: firestarter は fire-3 限定）
     const consumeBuffTargets = new Set<string>();
     if (skill.type === "gcd") {
       const isCastingGcd = !!originalSkill.castTime && originalSkill.castTime > 0;
@@ -780,7 +791,11 @@ export function resolveTimeline(
         const def = buffDefMap.get(ab.buffId);
         if (!def) continue;
         const hasConsumeOnGcd = def.effects.some((e) => e.type === "consumeOnGcd");
-        const hasInstantCast = isCastingGcd && def.effects.some((e) => e.type === "instantCast");
+        const hasInstantCast = isCastingGcd && def.effects.some((e) => {
+          if (e.type !== "instantCast") return false;
+          if (e.appliesToSkillIds && !e.appliesToSkillIds.includes(originalSkill.id)) return false;
+          return true;
+        });
         if (hasConsumeOnGcd || hasInstantCast) {
           consumeBuffTargets.add(ab.buffId);
         }


### PR DESCRIPTION
## 概要

親Issue #171 の汎用 `instantCast` 機構導入時に、`firestarter`（ファイアスターター）バフが任意の詠唱 GCD を Instant 化する状態になっていた。実機仕様ではファイガ（`fire-3`）のみが対象のため、`BuffEffect.appliesToSkillIds` を `instantCast` エフェクトでも尊重するよう拡張し、`firestarter` を `fire-3` 限定に修正した。

## 変更点

- **resolver**: `src/client/logic/resolve-timeline.ts`
  - `hasInstantCastBuff` シグネチャに `targetSkillId?: string` を追加し、`appliesToSkillIds` 指定時は対象スキルIDのみマッチさせる（`getPotencyMultiplier` と同パターン）
  - 詠唱時間決定の呼び出し（L538 周辺）で `originalSkill.id` を渡す
  - GCD 実行後の消費判定（L783 周辺）でも `appliesToSkillIds` を尊重し、対象外スキルでは消費しないようにする
- **バフ定義**: `src/client/data/blm-buffs.ts`
  - `firestarter.effects[0]` に `appliesToSkillIds: ["fire-3"]` を付与
- **テスト**: `src/client/logic/__tests__/instant-cast.test.ts`
  - 新規 describe `instantCast バフの appliesToSkillIds スコープ制限` を追加（2ケース）
    - mock buff: 対象外スキルでは消費・Instant 化されないこと、対象スキルでは Instant 化＋消費されること、消費後は通常詠唱に戻ること
    - BLM 実データ: `firestarter` がファイア（`fire`）では消費されず、ファイガ（`fire-3`）のみで Instant 化＋消費されること

## 設計判断

- 解決時点で参照する skillId は `originalSkill.id`（autoTransform より前のため）。BLM には `autoTransform` を持つスキルが存在しないため、当面はこの判断で問題ない（`getPotencyMultiplier` は `resolvedSkillId` を使うので将来 autoTransform 対象に同種制約を入れる場合は別途検討）
- 二重消費リスク（#198 で導入した Set ベース統合消費）には影響しない。今回の変更は収集側のフィルタ追加のみ

## テスト

- [x] `npm test` — 全 15 スイート / 89 ケース通過
- [x] `tsc --noEmit` — 型エラーなし
- [x] 既存 `instant-cast.test.ts`（11ケース）+ 新規 2ケース = 13/13 通過

## 非対象

- `triplecast` / `swiftcast`：FF14 仕様上どの詠唱 GCD も対象。`appliesToSkillIds` 未指定で従来通り動作（既存テストで回帰確認）
- 他ジョブの類似バフ：必要なら別Issue

closes #197


---
_Generated by [Claude Code](https://claude.ai/code/session_01648rMWmF5ceTUeN5ZHzfVq)_