### PR TITLE
fix: 黒魔道士「ハイファイア」を「ハイファイラ」に修正 #203

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -171,7 +171,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
   },
   {
     id: "high-fire-2",
-    name: "ハイファイア",
+    name: "ハイファイラ",
     potency: 140,
     type: "gcd",
     target: "enemy",


### PR DESCRIPTION
## 概要

黒魔道士の `high-fire-2`（ファイラの置き換え版、Lv82習得）の表示名を、公式ジョブガイド準拠の「ハイファイラ」に修正。

## 変更点

### `src/client/data/blm-skills.ts`

| プロパティ | 変更前 | 変更後 |
|-----------|-------|-------|
| `high-fire-2.name` | `"ハイファイア"` | `"ハイファイラ"` |

- `id`（`high-fire-2`）はコードベースの慣習維持のため変更しない
- アイコンファイル名も変更しない（影響大のため）
- 同系統の `high-blizzard-2` は元から「ハイブリザラ」と正しく表記されており整合する

## 公式値の根拠

- [公式ジョブガイド（黒魔道士）](https://jp.finalfantasyxiv.com/jobguide/blackmage/)
- パッチ6.1: 「Lv82：ハイファイラ、ハイブリザラ、極性マスタリーIV ⇒ ファイラがハイファイラに」
- パッチ7.2 関連ブログ: 「『ファイラ』が『ハイファイラ』に」

## 影響範囲

- `src/client/data/blm-skills.ts` 1行のみ
- `grep "ハイファイア"` で全域確認、他参照ゼロ

## テスト

- [x] `npm test`: 92/92 pass
- [x] `npx tsc --noEmit`: エラーなし

closes #203

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDW436DpYTBP3qrDkdxFRw)_