### PR TITLE
fix: BLM の AF/UB に応じた MP 消費の動的計算を実装 #209

### DIFF
--- a/src/client/data/blm-buffs.ts
+++ b/src/client/data/blm-buffs.ts
@@ -52,6 +52,7 @@ export const BLM_BUFFS: BuffDefinition[] = [
   // ============================================================
   // アストラルファイア（AF）: ファイア系威力増、ブリザド系威力減
   // ============================================================
+  // AF 中はファイア系の MP 消費が 2 倍になる。アンブラルハートが残っていれば 1 消費して打ち消す
   {
     id: "astral-fire-1",
     name: "アストラルファイア I",
@@ -63,6 +64,13 @@ export const BLM_BUFFS: BuffDefinition[] = [
       { type: "potency", value: 1.4, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: 0.9, appliesToSkillIds: BLIZZARD_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      {
+        type: "resourceCostMultiplier",
+        value: 2,
+        resourceId: "mp",
+        appliesToSkillIds: FIRE_SKILL_IDS,
+        negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
+      },
     ],
     color: "#ef5350",
     acquiredLevel: 2,
@@ -78,6 +86,13 @@ export const BLM_BUFFS: BuffDefinition[] = [
       { type: "potency", value: 1.6, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: 0.8, appliesToSkillIds: BLIZZARD_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      {
+        type: "resourceCostMultiplier",
+        value: 2,
+        resourceId: "mp",
+        appliesToSkillIds: FIRE_SKILL_IDS,
+        negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
+      },
     ],
     color: "#e53935",
     acquiredLevel: 2,
@@ -93,6 +108,13 @@ export const BLM_BUFFS: BuffDefinition[] = [
       { type: "potency", value: 1.8, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: 0.7, appliesToSkillIds: BLIZZARD_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      {
+        type: "resourceCostMultiplier",
+        value: 2,
+        resourceId: "mp",
+        appliesToSkillIds: FIRE_SKILL_IDS,
+        negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
+      },
     ],
     color: "#c62828",
     acquiredLevel: 2,
@@ -102,6 +124,7 @@ export const BLM_BUFFS: BuffDefinition[] = [
   // アンブラルブリザード（UB）: ファイア系威力減、ブリザド系は等倍
   // （7.x ではアイス側に倍率ボーナスはなく、MP 回復・MP 消費 0 が主効果）
   // ============================================================
+  // UB 中はブリザド系の MP 消費が 0 になる（#209 では段階別倍率（UB1:50%/UB2:25%）は簡易対応で全段階 0、別Issue #210 で対応）
   {
     id: "umbral-ice-1",
     name: "アンブラルブリザード I",
@@ -112,6 +135,7 @@ export const BLM_BUFFS: BuffDefinition[] = [
     effects: [
       { type: "potency", value: 0.9, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
     ],
     color: "#42a5f5",
     acquiredLevel: 1,
@@ -126,6 +150,7 @@ export const BLM_BUFFS: BuffDefinition[] = [
     effects: [
       { type: "potency", value: 0.8, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
     ],
     color: "#1e88e5",
     acquiredLevel: 1,
@@ -140,6 +165,7 @@ export const BLM_BUFFS: BuffDefinition[] = [
     effects: [
       { type: "potency", value: 0.7, appliesToSkillIds: FIRE_SKILL_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
     ],
     color: "#1565c0",
     acquiredLevel: 1,

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -183,7 +183,14 @@ describe("BLM: フレアスターとアストラルソウル", () => {
   });
 
   it("ファイジャ 6 発でアストラルソウル 6 蓄積後、フレアスターを使うと正常に実行される", () => {
-    const entries: TimelineEntry[] = [entry("fire-3")];
+    // AF3 中のファイジャは MP 消費 2 倍 (-1600) になるため、UH なしでは 6 連射すると MP が
+    // 不足する。事前に blizzard-3 → blizzard-4 で UB3 経由 UH 3 を確保し、最初の 3 発を
+    // UH で打ち消して MP 切れを回避する（実機の標準ローテーションに近い形）。
+    const entries: TimelineEntry[] = [
+      entry("blizzard-3"),
+      entry("blizzard-4"),
+      entry("fire-3"),
+    ];
     for (let i = 0; i < 6; i++) entries.push(entry("fire-4"));
     entries.push(entry("flare-star"));
 
@@ -197,5 +204,110 @@ describe("BLM: フレアスターとアストラルソウル", () => {
     const flareStarEntry = result.entries[result.entries.length - 1];
     expect(flareStarEntry.resourceErrors).toEqual([]);
     expect(flareStarEntry.resourceSnapshot["astral-soul"]).toBe(0);
+  });
+});
+
+describe("BLM: AF/UB バフ連動 MP 消費（#209）", () => {
+  it("AF 外のファイアは MP を基本コスト 800 だけ消費する", () => {
+    const result = resolveTimeline(
+      [entry("fire")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    expect(result.entries[0].resourceErrors).toEqual([]);
+    expect(result.entries[0].resourceSnapshot["mp"]).toBe(10000 - 800);
+  });
+
+  it("AF 中のファイア系は MP 消費が 2 倍になる（UH なし時）", () => {
+    // fire-3 で AF3 付与 → fire-4: AF3 中なので MP -800 が -1600 になる
+    const result = resolveTimeline(
+      [entry("fire-3"), entry("fire-4")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    expect(result.entries[1].resourceErrors).toEqual([]);
+    // fire-3 で MP -2000 (AF未付与のため等倍) → 8000
+    // fire-4 で AF3 中、UH なしで MP -1600 → 6400
+    expect(result.entries[0].resourceSnapshot["mp"]).toBe(10000 - 2000);
+    expect(result.entries[1].resourceSnapshot["mp"]).toBe(10000 - 2000 - 1600);
+  });
+
+  it("AF 中でも UH があればファイア系の MP 消費は基本コストに戻り、UH を 1 消費する", () => {
+    // blizzard-3 (UB3 付与) → blizzard-4 (UH 3 付与) → fire-3 (AF3 付与) → fire-4 (UH 消費)
+    const result = resolveTimeline(
+      [entry("blizzard-3"), entry("blizzard-4"), entry("fire-3"), entry("fire-4")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    const fire4Entry = result.entries[3];
+    expect(fire4Entry.resourceErrors).toEqual([]);
+    // fire-4 直前は UH=3, MP=10000-800-0-2000=7200
+    // fire-4 で UH 1 消費して MP -800（倍化打ち消し）
+    expect(fire4Entry.resourceSnapshot["mp"]).toBe(10000 - 800 - 0 - 2000 - 800);
+    expect(fire4Entry.resourceSnapshot["umbral-heart"]).toBe(2);
+  });
+
+  it("UB 中のブリザド系の MP 消費は 0 になる", () => {
+    // blizzard で UB1 付与 → blizzard-3 で UB3 付与（UB1 中なのでブリザガの MP -800 は 0 になる）
+    const result = resolveTimeline(
+      [entry("blizzard"), entry("blizzard-3")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    expect(result.entries[1].resourceErrors).toEqual([]);
+    // blizzard: UB 未付与なので MP +400 回復、初期 10000 上限なので 10000 維持
+    // blizzard-3: UB1 中なので MP -800 が 0 になる → 10000 維持
+    expect(result.entries[0].resourceSnapshot["mp"]).toBe(10000);
+    expect(result.entries[1].resourceSnapshot["mp"]).toBe(10000);
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB 中でも UB を付与する側のスキル（fire-3）には MP 倍率は適用されない", () => {
+    // blizzard で UB1 → fire-3 (UB 中だが FIRE 系なので UB の resourceCostMultiplier 対象外)
+    const result = resolveTimeline(
+      [entry("blizzard"), entry("fire-3")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    // fire-3 は通常通り MP -2000 消費（UB の倍率は BLIZZARD_SKILL_IDS のみに適用）
+    expect(result.entries[1].resourceSnapshot["mp"]).toBe(10000 - 2000);
+  });
+
+  it("AF 中でも UH が足りなければ MP は 2 倍消費される（UH 残量 0 の場合は打ち消し不成立）", () => {
+    // blizzard-4 で UH 3 を確保し、fire-3 → fire-4 × 4 で UH を使い切る
+    const entries: TimelineEntry[] = [
+      entry("blizzard-3"),
+      entry("blizzard-4"),
+      entry("fire-3"),
+      entry("fire-4"),
+      entry("fire-4"),
+      entry("fire-4"),
+      entry("fire-4"),
+    ];
+    const result = resolveTimeline(
+      entries,
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    // 最後の fire-4: UH 0 なので MP -1600（打ち消されない）
+    // 4 発目直前の MP = 10000 - 800(blizzard-3) - 0(blizzard-4) - 2000(fire-3) - 800×3(fire-4×3、UH打ち消し)
+    //                 = 10000 - 800 - 2000 - 2400 = 4800
+    // 4 発目で MP -1600 → 3200
+    const lastFire4 = result.entries[result.entries.length - 1];
+    expect(lastFire4.resourceErrors).toEqual([]);
+    expect(lastFire4.resourceSnapshot["mp"]).toBe(3200);
+    expect(lastFire4.resourceSnapshot["umbral-heart"]).toBe(0);
   });
 });

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -436,6 +436,71 @@ function expireBuffs(
 }
 
 /**
+ * アクティブバフの `resourceCostMultiplier` 効果に従って、スキルのリソース消費（負の ResourceChange）を動的に書き換える。
+ *
+ * 用途: BLM の AF 中ファイア系 MP 消費 ×2（アンブラルハートで打ち消し）、UB 中ブリザド系 MP 消費 0 化。
+ *
+ * 処理:
+ * - アクティブバフの effects から `resourceCostMultiplier` 型を抽出し、`appliesToSkillIds` で絞り込み
+ * - 同一 resourceId に対する倍率は乗算で集約（AF/UB は exclusiveGroup 排他なので実質単独）
+ * - 倍率が 1 を超え、`negatedByResource` 指定があり対象リソース残量が足りる場合、倍率を 1 に戻して当該リソースを消費する追加 ResourceChange を末尾に付与
+ * - 入力 changes の負変動のうち resourceId が一致するものは amount に倍率を掛けて返す
+ *
+ * 正変動には作用しない。
+ */
+function applyBuffResourceCostMultipliers(
+  changes: ResourceChange[],
+  skillId: string,
+  activeBuffs: ActiveBuff[],
+  resourceState: ResourceSnapshot,
+  buffDefMap: Map<string, BuffDefinition>
+): ResourceChange[] {
+  if (activeBuffs.length === 0) return changes;
+
+  const multipliers = new Map<string, number>();
+  const negationConsumptions: ResourceChange[] = [];
+  // 同じ打ち消しリソースを複数バフが奪い合う場合に備え、消費可能残量を追跡する
+  const negationRemaining = new Map<string, number>();
+
+  for (const ab of activeBuffs) {
+    const def = buffDefMap.get(ab.buffId);
+    if (!def) continue;
+    for (const eff of def.effects) {
+      if (eff.type !== "resourceCostMultiplier") continue;
+      if (!eff.resourceId) continue;
+      if (eff.appliesToSkillIds && !eff.appliesToSkillIds.includes(skillId)) continue;
+
+      let multiplier = eff.value;
+
+      if (multiplier > 1 && eff.negatedByResource) {
+        const negResId = eff.negatedByResource.resourceId;
+        const consumeAmount = eff.negatedByResource.consumeAmount;
+        const remaining = negationRemaining.get(negResId) ?? (resourceState[negResId] ?? 0);
+        if (remaining >= consumeAmount) {
+          multiplier = 1;
+          negationRemaining.set(negResId, remaining - consumeAmount);
+          negationConsumptions.push({ resourceId: negResId, amount: -consumeAmount });
+        }
+      }
+
+      const prev = multipliers.get(eff.resourceId) ?? 1;
+      multipliers.set(eff.resourceId, prev * multiplier);
+    }
+  }
+
+  if (multipliers.size === 0 && negationConsumptions.length === 0) return changes;
+
+  const scaled = changes.map((c) => {
+    if (c.amount >= 0) return c;
+    const m = multipliers.get(c.resourceId);
+    if (m === undefined || m === 1) return c;
+    return { ...c, amount: c.amount * m };
+  });
+
+  return negationConsumptions.length > 0 ? [...scaled, ...negationConsumptions] : scaled;
+}
+
+/**
  * 正の ResourceChange について、アクティブバフの redirectResourceGain に従って振替先リソースに書き換える。
  * 負の変動はそのまま返す。未登録の toResourceId へのリダイレクトは無視する（onExpireResourceTransfer と同様に安全側倒し）。
  */
@@ -656,10 +721,22 @@ export function resolveTimeline(
       }
     }
 
+    // バフの resourceCostMultiplier 効果でリソース消費量を動的にスケールしたものを以降で使用する
+    // （リソース不足判定・実適用の両方が同じ実効値を参照するように、ここで一度だけ計算する）
+    const effectiveResourceChanges = skill.resourceChanges
+      ? applyBuffResourceCostMultipliers(
+          skill.resourceChanges,
+          skill.id,
+          currentActiveBuffs,
+          resourceState,
+          buffDefMap
+        )
+      : undefined;
+
     // リソース不足チェック
     const resourceErrors: string[] = [];
-    if (skill.resourceChanges) {
-      for (const change of skill.resourceChanges) {
+    if (effectiveResourceChanges) {
+      for (const change of effectiveResourceChanges) {
         if (change.amount < 0) {
           if (change.skipIfInsufficient) continue;
           if (skippedResourceId !== null && change.resourceId === skippedResourceId) continue;
@@ -862,12 +939,13 @@ export function resolveTimeline(
       };
 
       // リソース変動を適用（buffSkippableResource でスキップ対象になった負の変動は除外）
-      if (skill.resourceChanges) {
+      // 上で計算済みの effectiveResourceChanges（バフによるコスト倍率を反映済み）を使う
+      if (effectiveResourceChanges) {
         const filtered = skippedResourceId !== null
-          ? skill.resourceChanges.filter(
+          ? effectiveResourceChanges.filter(
               (c) => !(c.resourceId === skippedResourceId && c.amount < 0)
             )
-          : skill.resourceChanges;
+          : effectiveResourceChanges;
         const redirected = applyBuffRedirects(filtered, currentActiveBuffs, buffDefMap, resourceDefMap);
         applyResourceChanges(resourceState, redirected, resourceDefMap, resources, onResourceApplied);
       }

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -188,7 +188,7 @@ export interface CharacterStats {
 }
 
 /** バフ・デバフのエフェクト種別 */
-export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast";
+export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast" | "resourceCostMultiplier";
 
 /** バフ・デバフの効果 */
 export interface BuffEffect {
@@ -206,11 +206,12 @@ export interface BuffEffect {
    * - instantCast: 詠唱時間を0にする（値は未使用、詠唱時間を持つGCDスキル使用時に自動消費）
    * - stat: ステータス加算値
    * - resource: リソース変動量
+   * - resourceCostMultiplier: 指定リソースの消費量に乗じる倍率（2 = 2倍消費、0 = 消費なし）
    */
   value: number;
   /** statバフの対象ステータスキー */
   statKey?: keyof CharacterStats;
-  /** resourceバフの対象リソースID */
+  /** resource / resourceCostMultiplier バフの対象リソースID */
   resourceId?: string;
   /**
    * このエフェクトを適用するスキルIDのホワイトリスト（potency 等の対象スキル限定バフ用）。
@@ -219,6 +220,12 @@ export interface BuffEffect {
    * 同一バフが複数スキル群に異なる倍率を適用するケースで使用する。
    */
   appliesToSkillIds?: string[];
+  /**
+   * resourceCostMultiplier 専用: 指定リソースが消費可能な量だけ残っていれば倍率を打ち消す。
+   * 打ち消し成立時はそのリソースを消費する（例: BLMのアンブラルハートでAF中のMP2倍化を打ち消す）。
+   * 倍率が等倍以下（multiplier ≤ 1）の場合は打ち消し処理は行わない。
+   */
+  negatedByResource?: { resourceId: string; consumeAmount: number };
 }
 
 /** バフ・デバフの定義 */


### PR DESCRIPTION
## 概要

黒魔道士の AF（アストラルファイア）中ファイア系スキルの MP 消費 2 倍化、アンブラルハート（UH）による打ち消し、UB（アンブラルブリザード）中ブリザド系スキルの MP 消費 0 化を実装しました。

## 採用方針（案A: バフ連動型 resourceChanges）

`BuffEffect` に新型 `resourceCostMultiplier` を追加し、AF/UB バフの `effects` に持たせる形で実装。`resolve-timeline.ts` の `applyResourceChanges` 直前に動的なコストスケーリング処理を挿入する。

- BLM 専用ハードコードを避けつつ、既存の `BuffEffect.appliesToSkillIds` パターンと整合
- 将来の #210（AF/UB 段階別倍率の正確な実装）でも `multiplier` を変えるだけで対応可能

## 変更点

### `src/client/types/skill.ts`
- `BuffEffectType` ユニオンに `"resourceCostMultiplier"` を追加
- `BuffEffect` に `negatedByResource?: { resourceId: string; consumeAmount: number }` を追加（別リソースを 1 消費して倍率を打ち消す機構）

### `src/client/data/blm-buffs.ts`
- AF1/AF2/AF3 のバフに「ファイア系 MP ×2、UH 1 で打ち消し」を付与
- UB1/UB2/UB3 のバフに「ブリザド系 MP ×0」を付与

> UB1=50%/UB2=25%/UB3=0% の段階別倍率は本Issueでは簡易対応として全段階 0 化。詳細実装は別Issue #210 で対応。

### `src/client/logic/resolve-timeline.ts`
- `applyBuffResourceCostMultipliers(changes, skillId, activeBuffs, resourceState, buffDefMap)` を新設
  - アクティブバフの `resourceCostMultiplier` 効果を集約し、`appliesToSkillIds` で対象スキル絞り込み
  - `negatedByResource` があり対象リソース残量が足りる場合は倍率を 1 に戻し、当該リソースの消費を追加
  - 同一 resourceId は乗算で集約（AF/UB は exclusiveGroup 排他のため実質単独）
- メインループで `effectiveResourceChanges` を一度計算し、リソース不足判定（L659-）と適用（L865-）の両方で同じ実効値を参照するよう修正

### `src/client/logic/__tests__/blm-af-ub.test.ts`
- 既存テスト「ファイジャ 6 連発」を新仕様に合わせて修正（事前に UH 3 を確保するため `blizzard-3` → `blizzard-4` を追加）
- 新仕様検証用テストを 6 件追加:
  - AF 外のファイアは基本コスト 800 を消費
  - AF 中ファイア系は MP ×2（UH なし時）
  - AF 中でも UH があれば等倍（UH 1 消費）
  - UB 中ブリザド系の MP 消費は 0
  - UB を付与する側の FIRE 系には MP 倍率は適用されない
  - UH 残量 0 で打ち消し不成立 → MP ×2 が維持される

## 完了条件（DoD）の達成状況

- [x] AF中のファイア系スキル使用時に MP が基本コスト × 2 消費される
- [x] アンブラルハートがある場合は UH 1 消費で MP 2 倍化が打ち消される
- [x] UB中のブリザド系スキル使用時に MP が消費されない（0コスト）
- [x] デスペア（全消費）は従来通り全消費で動作する（`consumeAllOfResource` 経路で本機構の対象外、影響なし）
- [x] タイムライン上でMP推移が正確に表示される（既存 UI コードはリソース変動を読むだけなのでデータ層の修正で自動的に反映）
- [x] 既存のテストが通る（`npm test`: 98/98 パス）

> フレア（UH 全消費 + MP 2/3）は当該スキル自体が BLM 実装に存在しないため今回スコープ外（フレアスキル実装漏れは別途起票候補）。

## 公式仕様の出典

- [xiv-tactics「AF・UBの効果」](https://scrapbox.io/xiv-tactics/AF%E3%83%BBUB%E3%81%AE%E5%8A%B9%E6%9E%9C)（極性マスタリー適用時の表）
- [ゲームエイト 黒魔道士の特徴と攻略情報](https://game8.jp/ff14/280642)（UH の打ち消し挙動）

## テスト

- [x] `npm test` 全 98 件パス（新規 6 件、修正 1 件含む）
- [x] `npx tsc --noEmit` 型チェック通過
- [x] code-reviewer エージェントによる信頼度 80 以上の指摘なし

## 関連Issue

- 親: #209 黒魔道士のAF中ファイア系MP消費2倍とアンブラルハートによる軽減が未実装
- 後続: #210 黒魔道士のAF/UB各段階による詳細なMP消費・回復・威力倍率を実装する（本PRで導入する `resourceCostMultiplier` 機構を流用予定）

closes #209

https://claude.ai/code/session_01WUA5tRi9ew3iYqUvviYeA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUA5tRi9ew3iYqUvviYeA8)_