### PR TITLE
fix: マナフォントから誤付与されていた firestarter を削除 #214

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -437,13 +437,13 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 100,
     acquiredLevel: 30,
-    // MP 全回復 + AF3 + アンブラルハート 3 + ファイアスターター付与（7.2 仕様）
+    // MP 全回復 + AF3 + アンブラルハート 3 + パラドックス + サンダーヘッド付与（7.2 仕様）
     resourceChanges: [
       { resourceId: "mp", amount: 10000 },
       { resourceId: "umbral-heart", amount: 3 },
       { resourceId: "paradox-gauge", amount: 1 },
     ],
-    buffApplications: ["astral-fire-3", "firestarter", "thunderhead"],
+    buffApplications: ["astral-fire-3", "thunderhead"],
   },
   {
     id: "triplecast",

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -147,7 +147,7 @@ describe("BLM: ポリグロット自動蓄積", () => {
 });
 
 describe("BLM: マナフォント", () => {
-  it("マナフォントは MP 全回復 + AF3 + アンブラルハート3 + ファイアスターター + サンダーヘッドを付与する", () => {
+  it("マナフォントは MP 全回復 + AF3 + アンブラルハート3 + パラドックス + サンダーヘッドを付与する（ファイアスターターは付与しない）", () => {
     // 先に fire-3 で MP を消費 → manafont で回復
     const result = resolveTimeline(
       [entry("fire-3"), entry("manafont")],
@@ -164,7 +164,7 @@ describe("BLM: マナフォント", () => {
     expect(manafontEntry.resourceSnapshot["umbral-heart"]).toBe(3);
     expect(manafontEntry.resourceSnapshot["paradox-gauge"]).toBe(1);
     expect(manafontEntry.activeBuffs.some((ab) => ab.buffId === "astral-fire-3")).toBe(true);
-    expect(manafontEntry.activeBuffs.some((ab) => ab.buffId === "firestarter")).toBe(true);
+    expect(manafontEntry.activeBuffs.some((ab) => ab.buffId === "firestarter")).toBe(false);
     expect(manafontEntry.activeBuffs.some((ab) => ab.buffId === "thunderhead")).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要

パッチ7.2の Manafont 公式仕様には含まれていない `firestarter` 付与を削除し、現状実装を公式仕様に追従させる。

## 背景

Issue #214 で「7.2 仕様を再確認したい」と挙げられていた Manafont の効果について、公式情報源（[FFXIV Wiki](https://ffxiv.consolegameswiki.com/wiki/Manafont) / [NA公式ジョブガイド](https://na.finalfantasyxiv.com/jobguide/blackmage/)）を確認した結果、**Firestarter は Manafont の付与効果に含まれない** ことが判明した。

### 公式7.2仕様 vs 現状実装

| 項目 | 公式仕様 | 現状実装 | 判定 |
|------|---------|---------|------|
| MP 全回復 | ✓ | `mp +10000` | 一致 |
| Astral Fire III | ✓ | `astral-fire-3` | 一致 |
| Thunderhead | ✓ | `thunderhead` | 一致 |
| Umbral Hearts 3 | ✓ | `umbral-heart +3` | 一致 |
| Paradox | ✓ | `paradox-gauge +1` | 一致 |
| **Firestarter** | **❌ 仕様にない** | **付与あり** | **乖離（修正対象）** |

## 変更点

- `src/client/data/blm-skills.ts`: マナフォントの `buffApplications` から `firestarter` を削除し、コメントを公式仕様の表記（`+ パラドックス + サンダーヘッド付与`）に更新
- `src/client/logic/__tests__/blm-af-ub.test.ts`: マナフォントテストの期待値を `firestarter: false`（付与しないことを検証）に変更し、it 名・説明も更新

## やらなかったこと（スコープ外）

- 使用条件「AF状態中のみ実行可」の実装（`requiredBuff` の OR 条件機構が現状なく、本Issueの DoD にも含まれないためスコープ外。必要であれば別Issueで対応）

## テスト

- `npm test`: 15 ファイル / 98 テスト全通過
- `tsc --noEmit`: 型エラーなし
- `blm-af-ub.test.ts` の Manafont 単体テスト: 通過（firestarter 非付与を検証）

closes #214

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxvQp9ZaQqA8UmexcyCJZa)_