### PR TITLE
refactor: Playwright MCP の起動引数を msedge に変更 #221

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--executable-path", "/opt/pw-browsers/chromium-1194/chrome-linux/chrome"]
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "msedge"]
     },
     "brave-search": {
       "command": "npx",


### PR DESCRIPTION
## 概要

開発環境を Windows ローカルへ移行したため、`.mcp.json` の Playwright MCP 起動引数を Linux 専用パス指定 (`--executable-path /opt/...`) から Windows 標準 Edge を使う `--browser msedge` に切り替える。

## 変更点

- `.mcp.json` の `playwright.args` を `["-y", "@playwright/mcp@latest", "--browser", "msedge"]` に変更（1行差分）

## テスト

- ローカル (Windows 11) で実施済み
  - Claude Desktop 再起動 → `mcp__playwright__browser_navigate http://localhost:5174` → Vite 起動中の FF14 Rotation Calculator トップページが正常レンダリング
  - WHM ジョブパレット・ステータス入力・タイムライン表示・コンソール（favicon 404 のみ＝benign）すべて確認
  - Brave Search MCP の動作にも影響なし（同一PR検証中に `brave_web_search` 呼び出し成功）

## 補足

- DevContainer/Linux 前提のドキュメント (`.claude/rules/playwright-mcp.md`, `mcp-setup.md`, `tech-stack.md`, `CONTRIBUTING.md`, `.devcontainer/`) は本PRでは触らず、別Issueで一括整理
- `package-lock.json` の Windows 環境差分（`@emnapi/*` optional/peer 92行追加）も別Issueで取り扱う

closes #221