### PR TITLE
refactor: .gitignore に SQLite 一時ファイルパターンを追加 #223

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ articles/
 # Prisma
 generated/
 *.db
+*.db-journal
+*.db-shm
+*.db-wal
 
 # Fankit raw downloads
 FFXIVIcons*/


### PR DESCRIPTION
## 概要

`prisma migrate` 実行や WAL モード時に生成される SQLite 一時ファイル (`*.db-journal`, `*.db-shm`, `*.db-wal`) を `.gitignore` に追加し、`git status` の汚染を防ぐ。

## 変更点

- `.gitignore` の Prisma セクションに 3 行追加：
  - `*.db-journal`
  - `*.db-shm`
  - `*.db-wal`

## テスト

- ローカル (Windows 11) で `git check-ignore -v dev.db-journal` を実行し、`.gitignore:43:*.db-journal	dev.db-journal` が返ることを確認
- `git status` で `dev.db-journal` が表示されなくなることを確認

closes #223