### PR TITLE
feat: GitHub MCP を .mcp.json に登録して Windows 11 でも常時利用可能にする #229

### DIFF
--- a/.claude/rules/mcp-setup.md
+++ b/.claude/rules/mcp-setup.md
@@ -9,8 +9,9 @@
 |---------|------|----------------|------|
 | `playwright` | stdio | なし | UI 視覚検証（`.claude/rules/playwright-mcp.md` 参照） |
 | `brave-search` | stdio | `BRAVE_API_KEY` | FF14 公式ジョブガイド等の外部情報検索 |
+| `github` | stdio | `GITHUB_PERSONAL_ACCESS_TOKEN` | Issue / PR の取得・作成・コメント・ラベル付与等の GitHub 操作 |
 
-GitHub / context7 MCP はプロジェクト `.mcp.json` では管理せず、Claude Code ホスト側（グローバル）で設定されている。
+context7 MCP は本リポジトリでは未登録。必要になった時点で `.mcp.json` に追加する。
 
 ## 環境変数による API キー注入
 
@@ -61,6 +62,49 @@ PowerShell（一般ユーザー権限）でユーザー環境変数として永�
 [Environment]::SetEnvironmentVariable("BRAVE_API_KEY", $null, "User")
 ```
 
+## GitHub MCP の取得と設定
+
+GitHub MCP は GitHub 公式の Go バイナリ [`github/github-mcp-server`](https://github.com/github/github-mcp-server) を `.mcp.json` から stdio で起動する。npm パッケージ `@modelcontextprotocol/server-github` は archived のため使わない。
+
+### 1. バイナリのインストール（Windows 11）
+
+1. [Releases](https://github.com/github/github-mcp-server/releases) から `github-mcp-server_Windows_x86_64.zip` をダウンロード（v1.0.3 以降を推奨）
+2. 任意の永続フォルダに解凍する（例: `C:\Tools\github-mcp-server\`）
+3. 解凍先フォルダを **ユーザー環境変数 `Path`** に追加（PowerShell・管理者権限不要）：
+
+   ```powershell
+   $tool = "C:\Tools\github-mcp-server"
+   $current = [Environment]::GetEnvironmentVariable("Path", "User")
+   if ($current -notlike "*$tool*") {
+     [Environment]::SetEnvironmentVariable("Path", "$current;$tool", "User")
+   }
+   ```
+
+4. **新しい PowerShell を開いて** `github-mcp-server --version` で動作確認
+
+PATH に追加せず `.mcp.json` でフルパス指定したい場合は、`"command": "C:\\Tools\\github-mcp-server\\github-mcp-server.exe"` に書き換えてもよい（ただしマシンごとに差が出るので非推奨）。
+
+### 2. PAT の取得と設定
+
+1. GitHub の [Settings → Developer settings → Personal access tokens (classic)](https://github.com/settings/tokens) で PAT を発行
+2. **必要スコープ**:
+   - `repo`（プライベートリポジトリのIssue/PR操作）
+   - `read:org`（組織情報の読み取り）
+   - `gist`（必要に応じて）
+3. PowerShell でユーザー環境変数として永続的に設定：
+
+   ```powershell
+   [Environment]::SetEnvironmentVariable("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_your_actual_token_here", "User")
+   ```
+
+4. **Claude Desktop を完全終了 → 再起動**（タスクトレイから Quit）。再起動後の新セッションで `ToolSearch select:mcp__github__add_issue_comment` 等でツール取得確認
+
+削除する場合：
+
+```powershell
+[Environment]::SetEnvironmentVariable("GITHUB_PERSONAL_ACCESS_TOKEN", $null, "User")
+```
+
 ## 接続状態の確認
 
 セッション開始後、以下で確認する：
@@ -80,6 +124,7 @@ MCP は**補助的な手段**。接続エラー・未設定時はフロー全体
 |---------|----------------|
 | `brave-search` | `WebSearch` 組み込みツール、またはユーザーに手動検索を依頼 |
 | `playwright` | UI 動作確認はユーザーに依頼。その旨を完了報告に明記 |
+| `github` | `gh.exe` のフルパス起動 (`/c/Program Files/GitHub CLI/gh.exe`) を Bash 経由で利用。Issue/PR 取得は `gh issue view` / `gh pr view`、コメント投稿は `gh issue comment --body-file <tmpfile>`、PR 作成は `gh pr create`。公開リポジトリの読み取りのみなら `WebFetch` でも代用可（コメント投稿は不可）|
 
 ## トラブルシューティング
 
@@ -88,4 +133,6 @@ MCP は**補助的な手段**。接続エラー・未設定時はフロー全体
 | `brave_web_search` が `ToolSearch` で見つからない | `BRAVE_API_KEY` 未設定 or stdio 起動失敗 | 環境変数設定 → セッション再起動 |
 | `${BRAVE_API_KEY}` が展開されずそのまま渡っている | 古い Claude Code バージョン | Claude Code を更新 |
 | `/mcp` で `brave-search` が `failed` | npx キャッシュ破損 or ネットワーク | `npx clear-npx-cache` 後、セッション再起動 |
-| stdio サーバー（Playwright/Brave）が途中で切断 | セッション長時間放置 | `.claude/rules/playwright-mcp.md` の「切断時の再接続手順」参照 |
+| stdio サーバー（Playwright/Brave/GitHub）が途中で切断 | セッション長時間放置 | `.claude/rules/playwright-mcp.md` の「切断時の再接続手順」参照（共通） |
+| `mcp__github__*` ツールが `ToolSearch` で見つからない | `GITHUB_PERSONAL_ACCESS_TOKEN` 未設定、`github-mcp-server` バイナリが PATH に無い、PAT スコープ不足のいずれか | 上記「GitHub MCP の取得と設定」を実施 → Claude Desktop 再起動 |
+| `github-mcp-server` 実行時に `401 Unauthorized` | PAT が無効 or スコープ不足 | PAT を再発行し `repo` / `read:org` を付与 → 環境変数を再設定 → Claude Desktop 再起動 |

--- a/.claude/rules/tech-stack.md
+++ b/.claude/rules/tech-stack.md
@@ -16,11 +16,13 @@
 | テスト配信 | Cloudflare Pages（Git連携） | Pages 自身が repo を監視しフロントエンドを自動ビルド＆配信（プロジェクト名: `ff14-rotation-calc`、トークン不要） |
 | 本番デプロイ | pm2 or systemd + Nginx | オンプレUbuntu + Cloudflare（CDN/DNS層） |
 | UI視覚検証 | Playwright MCP (`@playwright/mcp`) | Claude Code セッション (Claude Desktop) から `browser_navigate` 等でフロントエンド操作・スクリーンショット取得。Windows 標準の Microsoft Edge を使用（リポジトリ直下 `.mcp.json` に `--browser msedge` で登録） |
+| Issue/PR操作 | GitHub MCP (`github/github-mcp-server` Go バイナリ) | Issue / PR の取得・作成・コメント・ラベル付与等を Claude Code セッションから直接操作。リポジトリ直下 `.mcp.json` に stdio 登録。PAT は OS ユーザー環境変数 `GITHUB_PERSONAL_ACCESS_TOKEN` から `${...}` 展開（詳細は `.claude/rules/mcp-setup.md`） |
 
 ## 開発環境
 
 - **Windows 11 ローカル開発** を前提とする
 - 必要ツール: Node.js (v22 以上推奨, CIは v22)、npm、git、Microsoft Edge（Playwright MCP 用、Windows 11 標準）
+- 任意ツール: `github-mcp-server` バイナリ（GitHub MCP 用、`.claude/rules/mcp-setup.md` にインストール手順）、`gh` CLI（MCP 未設定時のフォールバック）
 - ネイティブモジュール (better-sqlite3 等) は基本 prebuilt バイナリで導入されるため、Visual Studio Build Tools は通常不要。フォールバック時のみ必要
 - DB は SQLite ファイル (`dev.db`) をリポジトリ直下に配置（gitignore 済み）
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,13 @@
       "env": {
         "BRAVE_API_KEY": "${BRAVE_API_KEY}"
       }
+    },
+    "github": {
+      "command": "github-mcp-server",
+      "args": ["stdio"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,3 +223,41 @@ Claude Desktop セッションで `ToolSearch` に `mcp__playwright__browser_nav
 - `.mcp.json` の playwright エントリが `--browser msedge` を指しているか
 - `@playwright/mcp` が `npx` で取得可能か（ネットワーク到達性、`npx clear-npx-cache` 後に再試行）
 - Claude Desktop を完全終了→再起動（タスクトレイから Quit）して `.mcp.json` を再読み込み
+
+---
+
+## MCP サーバー（GitHub MCP による Issue/PR 操作）
+
+リポジトリルートの `.mcp.json` に GitHub MCP（[`github/github-mcp-server`](https://github.com/github/github-mcp-server)、Go バイナリ）を登録しており、Claude Desktop セッションから Issue / PR の取得・作成・コメント・ラベル付与等を直接操作できます。
+
+### 構成
+
+`.mcp.json` の github エントリ：
+
+```jsonc
+"github": {
+  "command": "github-mcp-server",
+  "args": ["stdio"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+  }
+}
+```
+
+`@modelcontextprotocol/server-github`（npm 版）は archived のため使いません。
+
+### 初回セットアップ
+
+1. **バイナリのインストール**: [Releases](https://github.com/github/github-mcp-server/releases) から `github-mcp-server_Windows_x86_64.zip` をダウンロードし、任意の永続フォルダ（例: `C:\Tools\github-mcp-server\`）に解凍。解凍先を **ユーザー環境変数 `Path`** に追加
+2. **PAT の発行**: GitHub の Settings → Developer settings → Personal access tokens (classic) で発行。最小スコープは `repo` / `read:org`
+3. **環境変数の設定**: PowerShell（管理者権限不要）で：
+   ```powershell
+   [Environment]::SetEnvironmentVariable("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_your_actual_token_here", "User")
+   ```
+4. **Claude Desktop を完全終了 → 再起動**（タスクトレイから Quit）
+
+詳細手順とトラブルシューティングは `.claude/rules/mcp-setup.md` を参照してください。
+
+### 接続確認
+
+Claude Desktop セッションで `ToolSearch` に `mcp__github__add_issue_comment` 等を投げて該当ツールが返ってくれば接続成功です。返ってこない場合は `mcp-setup.md` のトラブルシューティング表を参照してください。


### PR DESCRIPTION
## 概要

Windows 11 ローカル環境への移行後、GitHub MCP が `ToolSearch` で `issue_read` 等のツールが見つからない状態になっていた問題に対し、GitHub 公式の Go バイナリ [`github/github-mcp-server`](https://github.com/github/github-mcp-server) をリポジトリ直下 `.mcp.json` に stdio 登録し、リポジトリを開けば誰でも同じ MCP 構成になる状態にする。あわせて Windows 向けセットアップ手順を `.claude/rules/mcp-setup.md` / `tech-stack.md` / `CONTRIBUTING.md` に追記する。

## 変更点

- **`.mcp.json`**: `github` サーバーを追加。`command: github-mcp-server`, `args: ["stdio"]`, `env.GITHUB_PERSONAL_ACCESS_TOKEN` を `${...}` で OS 環境変数から展開
- **`.claude/rules/mcp-setup.md`**:
  - 登録済 MCP 一覧表に `github` 行を追加
  - 「GitHub / context7 MCP はホスト側で設定」の旧記述を削除（context7 のみ未登録扱いとして注記）
  - 新セクション「GitHub MCP の取得と設定」を追加: バイナリ DL → PATH 追加 → PAT 発行 → 環境変数設定 → Claude Desktop 再起動
  - フォールバック表に `github` 行（`gh.exe` フルパス起動 / `WebFetch` 代用）を追加
  - トラブルシューティング表に `mcp__github__*` 未検出と `401 Unauthorized` の行を追加
- **`.claude/rules/tech-stack.md`**: レイヤー表に「Issue/PR操作 = GitHub MCP」行を追加。開発環境の任意ツール欄に `github-mcp-server` バイナリと `gh` CLI を追記
- **`CONTRIBUTING.md`**: 既存「MCP サーバー（Playwright）」セクションと同形式で「MCP サーバー（GitHub MCP による Issue/PR 操作）」セクションを追加（人間向けセットアップ手順）

archived な npm パッケージ `@modelcontextprotocol/server-github` は使わない方針。

## テスト

- `node -e "JSON.parse(...)"`: `.mcp.json` が有効なJSONであることを確認済み
- ドキュメント差分の整合性は人間レビュー前提（コードロジック変更なし）
- **未検証（要ユーザー操作）**: 以下は本PRマージ後にユーザーが手動で実施
  - `github-mcp-server_Windows_x86_64.zip` のDL・配置・PATH追加
  - `GITHUB_PERSONAL_ACCESS_TOKEN` の発行・環境変数設定
  - Claude Desktop 再起動 → 新セッションで `ToolSearch select:mcp__github__add_issue_comment` 等でツールロード確認

## 関連

- 知見ボード元コメント: #195 (2026-05-10)
- 関連: 開発環境 Windows 11 化（#225, #221, #228）

closes #229
