### PR TITLE
refactor: Playwright MCP の HTML5 ネイティブDnD 対応と stdio 切断時の運用ガイド整備 #230

### DIFF
--- a/.claude/rules/playwright-mcp.md
+++ b/.claude/rules/playwright-mcp.md
@@ -47,6 +47,46 @@ browser_close                             # 検証終わりに必ず閉じる
 
 `click`/`type`/`hover` 等はセレクタではなく **snapshot で得た ref を使う**。ref なしで呼ぶとエラー。
 
+## HTML5 ネイティブ DnD のワークアラウンド（`browser_drag` が発火しない場合）
+
+本リポジトリの SkillPalette → Timeline ドラッグや Timeline 内の並び替えは、React の `onDragStart` + `dataTransfer.setData(...)` による **HTML5 ネイティブ DnD** で実装されている（`src/client/components/SkillPalette.tsx`, `src/client/components/Timeline.tsx`）。`mcp__playwright__browser_drag` 内部の `dragTo` は **マウス移動イベントをエミュレートするだけで `dragstart` / `drop` を発火しない** ため、ドラッグしても何も起きない（スキルが追加されない／並び替わらない）。
+
+回避策: `browser_evaluate` で **DataTransfer インスタンスを共有**しつつ DragEvent 群を直接 dispatch する。Windows 11 + Microsoft Edge で動作検証済（2026-05-10、Issue #230）。
+
+```js
+() => {
+  // 1. ソース・ターゲットを DOM クエリで特定
+  //    ref は browser_snapshot 毎に変わるので、title/data-testid/textContent 等の安定属性を使う
+  const source = document.querySelector('[title="グレアガ (威力: 350)"]');
+  const placeholder = Array.from(document.querySelectorAll('div')).find(
+    el => el.textContent === 'スキルパレットからドラッグ＆ドロップしてスキルを追加' && el.children.length === 0
+  );
+  // ドロップゾーンは onDrop が attach された div（このアプリでは placeholder の直接の親）
+  const target = placeholder?.parentElement;
+  if (!source || !target) return { error: 'source or target not found' };
+
+  // 2. dragstart → dragenter → dragover → drop → dragend を、共有 DataTransfer で順に dispatch
+  const dt = new DataTransfer();
+  source.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer: dt }));
+  target.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer: dt }));
+  target.dispatchEvent(new DragEvent('dragover',  { bubbles: true, cancelable: true, dataTransfer: dt }));
+  target.dispatchEvent(new DragEvent('drop',      { bubbles: true, cancelable: true, dataTransfer: dt }));
+  source.dispatchEvent(new DragEvent('dragend',   { bubbles: true, cancelable: true, dataTransfer: dt }));
+
+  return { skillId: dt.getData('application/skill-id') };
+}
+```
+
+実装上のポイント:
+
+1. **ソース・ターゲットは安定属性で指定**: `browser_snapshot` の `ref=eNN` は snapshot を取り直すたびに変わるため、ここでは使えない。`[title="..."]` / `data-testid` / 一意な textContent 等を使う
+2. **ターゲットは onDrop が直接 attach された要素**: 本アプリの場合、placeholder（「スキルパレットからドラッグ＆ドロップして...」）の **直接の親 div**。先祖を辿りすぎると React の合成イベントが onDrop に届かない
+3. **DataTransfer を共有**: `dragstart` で React の handler が `setData("application/skill-id", ...)` する。同じ `DataTransfer` を `drop` に渡さないと skillId が取れず、handler は no-op になる
+4. **dragover の preventDefault は React handler が行う**: 戻り値の `overEv.defaultPrevented === true` で確認できる。false なら drop は発火しない（= ターゲットが正しくない）
+5. 検証は **`browser_snapshot` で UI 状態の変化（スキル追加・期待威力の更新等）を直接観察** する
+
+並び替え（Timeline 内 DnD）も同じパターンで動く。ソースを既存エントリに、ターゲットを別エントリ／挿入位置にすればよい。
+
 ## 失敗時の診断
 
 | 症状 | 原因 | 対処 |
@@ -57,10 +97,13 @@ browser_close                             # 検証終わりに必ず閉じる
 | `browser_navigate` でタイムアウト／接続拒否 | Vite が起動していない・ポート違い | `npm run dev:client` のログで実 URL（5173 or 5174）を確認 |
 | `msedge` が見つからない／起動しない | システム Edge がアンインストールされている／プロファイル破損 | Edge を再インストール、または `--browser chrome` に切り替え（Chrome がインストールされている場合） |
 | 一度使えていた `mcp__playwright__*` ツールが突然 `No matching deferred tools found` になる | セッション長時間放置で stdio サーバーが切断 | 下記「切断時の再接続手順」を参照 |
+| `browser_drag` を呼んでも DnD ターゲットが反応しない（スキルが追加されない／並び替わらない／削除されない） | アプリが React の HTML5 ネイティブ DnD（`onDragStart` + `dataTransfer.setData`）で実装されており、`browser_drag` 内部の `dragTo` がマウス移動をエミュレートするだけで `dragstart` / `drop` を発火しない | 上記「HTML5 ネイティブ DnD のワークアラウンド」のスニペットを `browser_evaluate` で実行する |
 
 ## 切断時の再接続手順（Claude 向け）
 
 Playwright MCP は stdio サーバーのため、HTTP/SSE サーバーと違って **Claude Code の自動再接続対象外** になり得る。セッション開始時は `<system-reminder>` で deferred tools が列挙されるが、長時間放置すると `The following deferred tools are no longer available (their MCP server disconnected)` が飛んできて、それ以降 `ToolSearch` でも見つからない状態になる。
+
+> **検出環境の注記**: この事象は元々 Claude Code クラウド／devcontainer 環境で観測された（知見ボード #195、2026-04-28）。Windows 11 ローカル環境で同じアイドルタイムアウトが起きるかは 2026-05-10 時点で独立検証していないが、**stdio + アイドル時の socket close という機構自体は OS 非依存**であり、十分長い放置（目安: 30 分以上）では同様に再現し得る前提で復旧手順を整備しておく。Windows 11 で再現が確認できたら本セクションに環境別の挙動差分を追記する。
 
 ### Claude 側で取るべきアクション
 


### PR DESCRIPTION
## 概要

Playwright MCP の `browser_drag` が React の HTML5 ネイティブ DnD（`onDragStart` + `dataTransfer.setData`）を発火させない問題に対し、`browser_evaluate` 経由で DataTransfer を共有しつつ DragEvent 群を直接 dispatch する **ワークアラウンドを `.claude/rules/playwright-mcp.md` にドキュメント化**する。あわせて stdio 長時間放置時の切断について、観測環境（クラウド／devcontainer）と Windows 11 環境差分の現状を注記する。

## 変更点

`.claude/rules/playwright-mcp.md` のみ編集（+43 / -0）：

1. **新セクション「HTML5 ネイティブ DnD のワークアラウンド」を追加**（「典型フロー」の直後）
   - 問題説明: SkillPalette → Timeline / Timeline 内並び替えが React の HTML5 ネイティブ DnD で実装されており、`browser_drag` 内部の `dragTo` がマウス移動エミュレートのみで `dragstart` / `drop` を発火しない
   - 動作検証済（Windows 11 + msedge, 2026-05-10）の `browser_evaluate` スニペットを掲載
   - 実装上のポイント 5 項目（ソース・ターゲット指定／onDrop の attach 位置／DataTransfer の共有／preventDefault 確認／snapshot による検証）
2. **失敗時の診断表に新規行を追加**: `browser_drag` を呼んでも DnD ターゲットが反応しないパターン → 上記ワークアラウンドへの誘導
3. **「切断時の再接続手順」セクションに環境注記を追記**: stdio アイドル切断はクラウド／devcontainer 環境で観測（#195, 2026-04-28）、Windows 11 ローカルでは独立検証未済だが OS 非依存の機構なので同手順を整備しておく旨。Windows 11 で再現確認できたら環境別差分を追記する余地を残す

## テスト

- **DnD ワークアラウンド**: 本PR作成セッションで Vite dev サーバー起動 → Playwright MCP で SkillPalette「グレアガ」→ Timeline ドラッグを `browser_evaluate` で実行 → `browser_snapshot` でグレアガ追加・期待威力 357・PPS 142.80 を確認済
- **stdio 切断**: 単一セッション内での再現は非現実的（30分以上のアイドルが必要）。ドキュメント追記のみで挙動には変更なし
- ドキュメントのみの変更でコードロジック・設定ファイルは未変更（CI への影響なし）

## 関連

- 知見ボード元コメント: #195 (2026-04-28 ×2件)

closes #230