### PR TITLE
feat: 亡霊 worktree の検知ガードを SessionStart hook と Phase 1 ガイドに追加 #237

### DIFF
--- a/.claude/hooks/session-start-info.sh
+++ b/.claude/hooks/session-start-info.sh
@@ -29,6 +29,64 @@ else
   printf -- '- Working tree: clean\n'
 fi
 
+# --- Ghost worktree detection ---------------------------------------------
+# Compare the launch cwd (Claude's project directory) against the registered
+# worktree list. If the launch cwd lives under `.claude/worktrees/<name>/` but
+# is NOT a registered worktree, warn the model: edits made via that path
+# will silently land in a gitignored area.
+launch_pwd="$PWD"
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+worktree_paths=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2}')
+
+# Normalize paths for comparison:
+#   - backslash -> forward slash
+#   - lowercase (Windows is case-insensitive; Git's output and bash's $PWD differ)
+#   - strip trailing slash
+#   - convert MSYS-style "/d/foo" -> "d:/foo" so it matches Git's "D:/foo" output
+norm_path() {
+  local p
+  p=$(printf '%s' "$1" | tr '\\' '/' | tr '[:upper:]' '[:lower:]')
+  p="${p%/}"
+  if [[ "$p" =~ ^/([a-z])(/.*|$) ]]; then
+    p="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
+  fi
+  printf '%s' "$p"
+}
+n_orig=$(norm_path "$launch_pwd")
+n_top=$(norm_path "$toplevel")
+
+is_registered_worktree=0
+while IFS= read -r wt; do
+  [[ -z "$wt" ]] && continue
+  n_wt=$(norm_path "$wt")
+  if [[ "$n_orig" == "$n_wt" ]]; then
+    is_registered_worktree=1
+    break
+  fi
+done <<<"$worktree_paths"
+
+# Always show registered worktrees (so the model can cross-check).
+if [[ -n "$worktree_paths" ]]; then
+  printf '\n## Git worktrees (registered)\n'
+  while IFS= read -r wt; do
+    [[ -z "$wt" ]] && continue
+    printf -- '- `%s`\n' "$wt"
+  done <<<"$worktree_paths"
+fi
+
+# Ghost detection: cwd lives under .claude/worktrees/<name>/ but is not in the list.
+if [[ -n "$n_top" ]] \
+   && [[ "$n_orig" != "$n_top" ]] \
+   && [[ "$is_registered_worktree" -eq 0 ]] \
+   && [[ "$n_orig" == *"/.claude/worktrees/"* ]]; then
+  printf '\n## ⚠ Ghost worktree detected\n'
+  printf -- '- Launch cwd: `%s`\n' "$launch_pwd"
+  printf -- '- Main repo (git toplevel): `%s`\n' "$toplevel"
+  printf -- '- This path looks like a worktree but is **not registered** (likely a leftover after `git worktree remove`).\n'
+  printf -- '- Use the **main repo absolute path** for `Edit`/`Write` `file_path` and `gh ... --body-file <abs>` invocations. Edits to the launch cwd will land in a gitignored area and silently disappear.\n'
+  printf -- '- For git operations, prefer `git -C "%s" ...` over relying on the current shell pwd.\n' "$toplevel"
+fi
+
 printf '\n## 行動原則リマインダー\n'
 printf -- '- 方針が定まらないときは、長時間の内部思考ではなくユーザーに質問する\n'
 printf -- '- 大きなファイルを読んだ後は、理解した内容を要約してから次のアクションに進む\n'

--- a/.claude/skills/issue-start/phases/01-issue-analysis.md
+++ b/.claude/skills/issue-start/phases/01-issue-analysis.md
@@ -2,6 +2,40 @@
 
 Issueの内容を十分に把握してから実装に入ることが重要。曖昧なまま進めると手戻りが大きくなるため、ここで確実に情報を揃える。
 
+## 0. 作業環境チェック（Phase 1 着手前）
+
+セッション開始時の SessionStart hook 出力を必ず確認する。`## ⚠ Ghost worktree detected` が含まれていたら、**亡霊 worktree モード** で作業する（後述）。出力されていない場合でも、自分で確認したいときは以下のコマンドで判定できる。
+
+```bash
+pwd
+git rev-parse --show-toplevel
+git worktree list
+```
+
+判定マトリクス：
+
+| pwd の状態 | 扱い |
+|---|---|
+| `git rev-parse --show-toplevel` と一致 | **メインリポ作業**: 通常通り |
+| `git worktree list` の登録 worktree と一致 | **真の worktree 作業**: 通常通り |
+| `.claude/worktrees/<name>/` 配下なのに **登録 worktree でない** | **亡霊 worktree モード**: 以降のすべての Edit/Write/bash 相対パスをメインリポ絶対パス基準に切り替える |
+
+### 亡霊 worktree モードでの作業ガイド
+
+亡霊 worktree (`.claude/worktrees/<name>/` ディレクトリは残っているが `git worktree` には未登録の状態) は `.gitignore` 配下のため、その配下に書き込んだ Edit/Write は `git status` に出ず **無音で消える**。さらに bash 相対パスは pwd（亡霊側）基準で解決されるので、メインリポ側に書いた tmp ファイル等が辿れない事故が起きる。
+
+このため：
+
+- **`Edit` / `Write` の `file_path` は常にメインリポ絶対パスで指定する**
+  - 例: `D:\ドキュメント_D\for_claude\ff14-dev\RotationCalc\src\client\...`
+  - `worktrees/<name>/` をパスに含めない
+- **`Bash` での相対パスを避け、絶対パスを使う**
+  - 例: `gh ... --body-file "D:/ドキュメント_D/for_claude/ff14-dev/RotationCalc/.claude/tmp-foo.md"`
+- **`git` 操作は `git -C "<main repo absolute path>" <subcommand>` 形式を常用する**
+  - pwd に依存した暗黙の解決を避ける
+
+SessionStart hook が亡霊を検出したら警告セクションを出力する。警告がある時は迷わず上記モードに切り替えること（推測でメインリポ側か worktree 側か悩む必要はない）。
+
 ## 手順
 
 1. GitHub MCPの `issue_read`（method: `get`）でIssueの本文・ラベルを取得し、`issue_read`（method: `get_comments`）でコメントも取得する


### PR DESCRIPTION
## 概要

PR マージ後に登録解除された worktree ディレクトリ (`.claude/worktrees/<name>/`) の残骸が新セッションの cwd になる「亡霊 worktree」シナリオで、Edit/Write が `.gitignore` 配下に消える事故を検知・予防する。SessionStart hook に検知ロジックを入れ、`phases/01-issue-analysis.md` 冒頭に作業環境チェックと亡霊モード時の作業ガイドを明文化する。

## 変更点

### `.claude/hooks/session-start-info.sh`（+58）

1. `git worktree list --porcelain` を取得し、`## Git worktrees (registered)` セクションで常時表示
2. `pwd` を `git rev-parse --show-toplevel` および登録 worktree 一覧と突合し、以下 3 条件すべて成立で `## ⚠ Ghost worktree detected` 警告セクションを出力：
   - `pwd` ≠ toplevel
   - `pwd` がいずれの登録 worktree とも一致しない
   - `pwd` が `.claude/worktrees/<name>/` パターンに該当
3. 警告本文には Launch cwd / 主リポ toplevel / メインリポ絶対パスでの作業ガイド (`Edit/Write` の `file_path`、`gh ... --body-file <abs>`、`git -C "<abs>" ...`) を提示
4. Windows 環境のパス形式差分（MSYS の `/d/...` vs git 出力の `D:/...`）を吸収する `norm_path()` ヘルパーを追加（lowercase化 + slash 正規化 + ドライブレター変換）

### `.claude/skills/issue-start/phases/01-issue-analysis.md`（+34）

1. `# Phase 1: Issue分析 & 不足確認` 直下に `## 0. 作業環境チェック（Phase 1 着手前）` を新設
2. SessionStart hook の警告に従う前提で、`pwd` / toplevel / `git worktree list` 確認コマンドと判定マトリクスを掲載
3. 「亡霊 worktree モードでの作業ガイド」を明記:
   - `Edit`/`Write` の `file_path` はメインリポ絶対パス
   - `Bash` の相対パス禁止 → 絶対パス使用
   - `git -C "<main repo absolute path>" <subcommand>` を常用

## テスト

3 シナリオを手動で実行し全 pass を確認：

| シナリオ | 設定 | 期待結果 | 実測 |
|---|---|---|---|
| 1. メインリポ | `CLAUDE_PROJECT_DIR = main repo path` | 警告なし、登録 worktree 一覧に main 1 件 | ✅ |
| 2. 亡霊 worktree | `mkdir .claude/worktrees/_test-ghost`、`CLAUDE_PROJECT_DIR = ghost path` | `Ghost worktree detected` 警告と案内が表示 | ✅ |
| 3. 登録済み worktree | `git worktree add --detach .claude/worktrees/_test-real` 後、`CLAUDE_PROJECT_DIR = real worktree path` | 警告なし、一覧に main + _test-real | ✅ |

テスト用ディレクトリ・worktree は完全クリーンアップ済（`rmdir` / `git worktree remove`）。

## 関連

- 知見ボード元コメント: #195 (Issue #231 セッション)
- 関連既知問題: 同セッションで `gh ... --body-file` の bash 相対パスが亡霊 cwd 起因で失敗した実例あり（PR #236 作業ログ参照）

closes #237
