### PR TITLE
fix: validate-commit-message.sh の HEREDOC 誤検出修正と古いmain派生ブランチ検知ガイド #232

### DIFF
--- a/.claude/hooks/__tests__/validate-commit-message.test.sh
+++ b/.claude/hooks/__tests__/validate-commit-message.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Manual test for ../validate-commit-message.sh
+#
+# Run: bash .claude/hooks/__tests__/validate-commit-message.test.sh
+#
+# Builds JSON inputs that mimic the PreToolUse hook protocol and feeds them to
+# the hook script via stdin. Each case asserts the hook's exit code.
+#
+# CLAUDE_PROJECT_DIR is overridden to a non-existent path so the hook's git
+# branch lookup fails and `current_branch` becomes empty, forcing the strict
+# "issue number required" branch — independent of whatever branch the test is
+# actually run from.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$HOOK_DIR/validate-commit-message.sh"
+
+if [[ ! -f "$HOOK" ]]; then
+  printf 'hook not found: %s\n' "$HOOK" >&2
+  exit 1
+fi
+
+pass=0
+fail=0
+
+run_case() {
+  local name="$1" expected="$2" command="$3"
+  local payload exit_code
+  payload=$(jq -n --arg cmd "$command" '{tool_input:{command:$cmd}}')
+  set +e
+  CLAUDE_PROJECT_DIR=/nonexistent bash "$HOOK" >/dev/null 2>&1 <<<"$payload"
+  exit_code=$?
+  set -e
+  if [[ "$exit_code" == "$expected" ]]; then
+    printf '  [PASS] %s (exit=%d)\n' "$name" "$exit_code"
+    pass=$((pass+1))
+  else
+    printf '  [FAIL] %s (expected exit=%s, got %d)\n' "$name" "$expected" "$exit_code"
+    fail=$((fail+1))
+  fi
+}
+
+printf -- '--- validate-commit-message.sh tests ---\n'
+
+# 1) Simple double-quoted, valid format
+run_case "simple double-quoted (valid)" 0 \
+  'git commit -m "feat: スキルを追加 #1"'
+
+# 2) HEREDOC form — the regression target.
+#    Before the fix, the `-m "..."` regex would greedily capture
+#    `$(cat <<'\''EOF'\''` as the subject line and block.
+heredoc_cmd=$(cat <<'CMD'
+git commit -m "$(cat <<'EOF'
+fix: バグ修正 #5
+
+Co-Authored-By: Claude
+EOF
+)"
+CMD
+)
+run_case "HEREDOC \$(cat <<'EOF') multi-line (regression: was false-positive)" 0 \
+  "$heredoc_cmd"
+
+# 3) Single-quoted, valid format
+run_case "simple single-quoted (valid)" 0 \
+  "git commit -m 'feat: 機能追加 #1'"
+
+# 4) Invalid type prefix — must block
+run_case "invalid type prefix (must block)" 2 \
+  'git commit -m "wip 進行中 #1"'
+
+# 5) Missing issue number on a non-claude branch — must block
+run_case "missing issue number (must block, non-claude branch)" 2 \
+  'git commit -m "feat: 機能追加"'
+
+# 6) --amend — hook intentionally skips validation
+run_case "--amend (skipped)" 0 \
+  'git commit --amend -m "feat: 何でも"'
+
+# 7) Non-commit invocation — hook ignores
+run_case "non-commit invocation (ignored)" 0 \
+  'git status'
+
+# 8) HEREDOC with invalid type prefix — must still block
+heredoc_bad=$(cat <<'CMD'
+git commit -m "$(cat <<'EOF'
+wip not allowed #1
+
+body
+EOF
+)"
+CMD
+)
+run_case "HEREDOC with invalid type prefix (must block)" 2 \
+  "$heredoc_bad"
+
+printf '\nResults: %d pass, %d fail\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/.claude/hooks/validate-commit-message.sh
+++ b/.claude/hooks/validate-commit-message.sh
@@ -21,13 +21,26 @@ if [[ "$command" =~ --amend ]]; then
   exit 0
 fi
 
-# Extract message: try -m "..." then -m '...' then heredoc payload
+# Extract message. Priority order matters:
+#   1) HEREDOC payload — checked FIRST because the recommended Bash recipe is
+#      `git commit -m "$(cat <<'EOF' ... EOF)"`. The `-m "..."` regex below
+#      would otherwise match the entire `$(cat <<'EOF'\n...\nEOF\n)` body and
+#      treat `$(cat <<'EOF'` as the subject line (false positive block).
+#   2) -m "<simple>" double-quoted message
+#   3) -m '<simple>' single-quoted message
+#
+# HEREDOC body capture limit: bash POSIX ERE `.` does not match newlines,
+# so the original `(.*)` could only capture single-line bodies. Since this
+# hook only validates the FIRST line (subject), capturing `[^${NL}]+` (the
+# very first body line right after `<<EOF\n`) is sufficient and correct
+# regardless of body length.
+NL=$'\n'
 msg=""
-if [[ "$command" =~ -m[[:space:]]+\"([^\"]+)\" ]]; then
+if [[ "$command" =~ \<\<-?[\'\"]?EOF[\'\"]?[[:space:]]*${NL}([^${NL}]+) ]]; then
+  msg="${BASH_REMATCH[1]}"
+elif [[ "$command" =~ -m[[:space:]]+\"([^\"]+)\" ]]; then
   msg="${BASH_REMATCH[1]}"
 elif [[ "$command" =~ -m[[:space:]]+\'([^\']+)\' ]]; then
-  msg="${BASH_REMATCH[1]}"
-elif [[ "$command" =~ \<\<[\'\"]?EOF[\'\"]?[[:space:]]*$'\n'(.*)$'\n'[[:space:]]*EOF ]]; then
   msg="${BASH_REMATCH[1]}"
 fi
 

--- a/.claude/skills/issue-start/phases/02-branch-setup.md
+++ b/.claude/skills/issue-start/phases/02-branch-setup.md
@@ -31,3 +31,37 @@ git checkout -b <type>/#<issue番号>-<kebab-case説明>
 ```
 
 > **Hooks による自動検証**: `.claude/hooks/validate-branch-name.sh` がブランチ名を PreToolUse で検証する。規約違反だとブロックされるので、上記フォーマットに必ず従うこと。
+
+## 古い main 派生ブランチの検知
+
+`git pull origin main` を忘れる、worktree がローカル main を更新できなかった、別作業から復帰した直後など、新ブランチが古い main から派生してしまう事故が起き得る（過去事例: #210）。テストが失敗するまで気付かないと `stash → fetch → merge → unstash` の手戻りが発生する。
+
+ブランチ作成後の最初のコミット前に **必ず** 以下を実行する：
+
+```bash
+git fetch origin main
+behind=$(git rev-list --count HEAD..origin/main)
+if [ "$behind" -gt 0 ]; then
+  echo "⚠ 新ブランチは origin/main より $behind コミット遅れています"
+fi
+```
+
+### `behind > 0` の場合の対処
+
+新ブランチに切り替えてから古さを発見した場合、以下のいずれかで取り込む：
+
+```bash
+# 作業中の変更がある場合は先に stash する
+git stash push -m "issue-start wip"
+
+# main の最新を新ブランチへ取り込む
+git fetch origin main
+git merge origin/main      # ファストフォワード or 3-way merge
+
+# stash を戻す
+git stash pop
+```
+
+`git merge origin/main` により新ブランチに `Merge branch 'main' into <feature>` コミットが追加される。これは正常な挙動で、PR を `main` へ squash merge する運用なら最終 commit 履歴には影響しない。
+
+> **なぜ自動化しないか**: `git merge` を hook で強制すると stash の取り扱いミスや conflict 解消の自動化リスクが大きい。検知だけ自動化し、対処は明示的な人手 (Claude) で行う方針。


### PR DESCRIPTION
## 概要

`/issue-start` 中に発生した 2 件の Git まわりの躓きを解消する：

1. **HEREDOC 誤検出**: `git commit -m "$(cat <<'EOF' ... EOF)"` 形式（Bash ツール標準ガイドが推奨する書き方）で commit メッセージを渡すと、`validate-commit-message.sh` の `-m "..."` regex が greedy に `$(cat <<'EOF' ... EOF)` 全体を捕捉し、`$(cat <<'EOF'` を subject 行として誤検出してブロック → 新規セッションごとに同じ罠
2. **古い main 派生ブランチ**: ローカルブランチが古い main から派生して PR マージ済み機構を欠いた状態で実装着手し、テスト失敗で初めて気付くケース（過去事例: #210）

## 変更点

### `.claude/hooks/validate-commit-message.sh`（+17 / -4）

1. **メッセージ抽出の優先順序を入れ替え**: HEREDOC → `-m "..."` → `-m '...'` に変更。最も specific な HEREDOC パターンを最初に判定することで、`$(cat <<'EOF' ... EOF)` 形式が正しく body 行を抽出できる
2. **HEREDOC body の取り込み方法を改良**: `(.*)` は bash POSIX ERE で改行を跨がず複数行 body の捕捉に失敗する問題があった。subject 行のみ検証する用途に合わせ、`<<EOF\n` 直後の **最初の 1 行** を `[^${NL}]+` で捕捉する形式に変更
3. **`<<-EOF` 変種にも対応**: `<<-?` で `<<-EOF` (タブ剥がし変種) も受理

### `.claude/hooks/__tests__/validate-commit-message.test.sh`（新規）

PreToolUse hook の JSON 入力を `jq -n` で組み立てて hook に流し込み、exit code を assert する手動テストスクリプトを追加。8 ケースを網羅：

| # | ケース | 期待 | 実測 |
|---|---|---|---|
| 1 | simple double-quoted (valid) | exit 0 | ✅ |
| 2 | **HEREDOC `$(cat <<'EOF')` multi-line（回帰テスト対象）** | exit 0 | ✅ |
| 3 | simple single-quoted (valid) | exit 0 | ✅ |
| 4 | invalid type prefix (must block) | exit 2 | ✅ |
| 5 | missing issue number on non-claude branch (must block) | exit 2 | ✅ |
| 6 | --amend (skipped) | exit 0 | ✅ |
| 7 | non-commit invocation (ignored) | exit 0 | ✅ |
| 8 | HEREDOC with invalid type prefix (must still block) | exit 2 | ✅ |

実行方法: `bash .claude/hooks/__tests__/validate-commit-message.test.sh`（要 `jq` PATH）。`CLAUDE_PROJECT_DIR=/nonexistent` で current_branch を空に強制し、テスト時のブランチ非依存で「issue 番号必須」フローを再現。

### `.claude/skills/issue-start/phases/02-branch-setup.md`（+34）

「ブランチ作成手順」直後に新規セクション「## 古い main 派生ブランチの検知」を追加：

- 検知コマンド: `git fetch origin main && behind=$(git rev-list --count HEAD..origin/main)`
- `behind > 0` の対処手順: `stash → fetch → merge → unstash` の具体例
- なぜ自動化しないかの注記（hook 化は conflict 解消の自動化リスクが大きい）

## テスト

- **新規テストスクリプト**: 8 ケース全 pass を確認（jq インストール後にローカルで実行）
- **既存挙動の維持**: 単純 `-m "..."` / `-m '...'` / `--amend` / 非 commit invocation はそのまま動作（ケース 1/3/6/7）
- **回帰テスト**: HEREDOC 形式が exit 0 で通ること（ケース 2）。同形式で型 prefix 違反時に exit 2 で blocked になること（ケース 8）
- ドキュメント変更（02-branch-setup.md）は手順追加のみで既存セクションは未変更

## 関連

- 知見ボード元コメント: #195 (#7 #10)
- 過去事例: #210（古い main 派生）

closes #232