### PR TITLE
fix: hook の jq 依存を Node.js に置換 #240

### DIFF
--- a/.claude/hooks/__tests__/validate-commit-message.test.sh
+++ b/.claude/hooks/__tests__/validate-commit-message.test.sh
@@ -27,7 +27,7 @@ fail=0
 run_case() {
   local name="$1" expected="$2" command="$3"
   local payload exit_code
-  payload=$(jq -n --arg cmd "$command" '{tool_input:{command:$cmd}}')
+  payload=$(printf '%s' "$command" | node -e 'const c=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.stringify({tool_input:{command:c}}))')
   set +e
   CLAUDE_PROJECT_DIR=/nonexistent bash "$HOOK" >/dev/null 2>&1 <<<"$payload"
   exit_code=$?

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 input=$(cat)
-command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+command=$(printf '%s' "$input" | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(d?.tool_input?.command||"")')
 
 # Match: git checkout -b <branch>  or  git switch -c <branch>
 branch=""

--- a/.claude/hooks/validate-commit-message.sh
+++ b/.claude/hooks/validate-commit-message.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 input=$(cat)
-command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+command=$(printf '%s' "$input" | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(d?.tool_input?.command||"")')
 
 # Only inspect git commit invocations
 if [[ ! "$command" =~ git[[:space:]]+commit ]]; then


### PR DESCRIPTION
## 概要
Windows 11 ローカル環境では `jq` が標準で入っておらず、`set -euo pipefail` の hook が `jq: command not found` で **exit 127** していた。Claude Code 側はこれを block (exit 2) 扱いせず素通しさせていたため、規約違反の commit / branch が **無音で許可される silent failure** が続いていた。

開発前提として既に必須の Node.js でクロスプラットフォームに置換し、追加依存ゼロで Windows 11 でも hook が機能するようにする。

## 変更点
- `.claude/hooks/validate-commit-message.sh:12` — `jq -r '.tool_input.command // ""'` を `node -e 'JSON.parse(...).tool_input.command'` に置換
- `.claude/hooks/validate-branch-name.sh:15` — 同上
- `.claude/hooks/__tests__/validate-commit-message.test.sh:30` — `jq -n --arg cmd ...` を `node -e 'JSON.stringify({tool_input:{command:c}})'` に置換（command を stdin 経由で渡し HEREDOC の改行も安全に扱う）

## テスト
- ✅ `bash .claude/hooks/__tests__/validate-commit-message.test.sh` が `jq` 不要で実行可能、Windows 11 ローカル（jq 未導入）で **8/8 pass**（PR #239 で追加された HEREDOC 含む全ケース）
- ✅ 実機 `git checkout -b invalid-branch-name-test` → 想定通り **block** (exit 2)
- ✅ 実機 `git commit -m "wip 進行中"` → type prefix 違反として **block**
- ✅ 実機 `git commit -m "feat: テスト追加"` on `fix/#240-...` ブランチ → issue 番号無しとして **block**
- ✅ 実機 `claude/test-jq-allow` ブランチで hook を直接呼び出し、issue 番号無しでも **allow** (exit 0) を確認
- ✅ 本 PR のコミット自身が hook を通過していること（規約準拠 commit message）

## 関連
- 親Issue: #195（知見ボード元コメント）
- 関連: PR #239（HEREDOC 修正・テスト追加。本PRはそのテストを Node.js 置換）
- 後続候補: hook テストの CI 統合（別Issue）

closes #240