### PR TITLE
fix: validate-branch-name.sh の commit message 本文中の git checkout -b 文字列誤マッチ修正 #242

### DIFF
--- a/.claude/hooks/__tests__/validate-branch-name.test.sh
+++ b/.claude/hooks/__tests__/validate-branch-name.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Manual test for ../validate-branch-name.sh
+#
+# Run: bash .claude/hooks/__tests__/validate-branch-name.test.sh
+#
+# Builds JSON inputs that mimic the PreToolUse hook protocol and feeds them to
+# the hook script via stdin. Each case asserts the hook's exit code.
+#
+# CLAUDE_PROJECT_DIR is irrelevant for this hook (it does not inspect the
+# current branch), so we leave it unset.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$HOOK_DIR/validate-branch-name.sh"
+
+if [[ ! -f "$HOOK" ]]; then
+  printf 'hook not found: %s\n' "$HOOK" >&2
+  exit 1
+fi
+
+pass=0
+fail=0
+
+run_case() {
+  local name="$1" expected="$2" command="$3"
+  local payload exit_code
+  payload=$(printf '%s' "$command" | node -e 'const c=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.stringify({tool_input:{command:c}}))')
+  set +e
+  bash "$HOOK" >/dev/null 2>&1 <<<"$payload"
+  exit_code=$?
+  set -e
+  if [[ "$exit_code" == "$expected" ]]; then
+    printf '  [PASS] %s (exit=%d)\n' "$name" "$exit_code"
+    pass=$((pass+1))
+  else
+    printf '  [FAIL] %s (expected exit=%s, got %d)\n' "$name" "$expected" "$exit_code"
+    fail=$((fail+1))
+  fi
+}
+
+printf -- '--- validate-branch-name.sh tests ---\n'
+
+# 1) Convention-compliant branch name — allow
+run_case "compliant feature branch (allow)" 0 \
+  'git checkout -b feature/#42-add-pictomancer-rotation'
+
+# 2) Convention-compliant fix branch via `git switch -c` — allow
+run_case "compliant fix branch via switch -c (allow)" 0 \
+  'git switch -c fix/#5-fix-damage-calculation'
+
+# 3) Convention violation — must block
+run_case "non-conforming name (must block)" 2 \
+  'git checkout -b invalid-branch-name'
+
+# 4) Convention violation via `git switch -c` — must block
+run_case "non-conforming name via switch -c (must block)" 2 \
+  'git switch -c bad-name-no-prefix'
+
+# 5) Exempt: claude/* — allow
+run_case "claude/* exempt (allow)" 0 \
+  'git checkout -b claude/some-session'
+
+# 6) Exempt: main / master / develop — allow
+run_case "main exempt (allow)" 0 \
+  'git checkout -b main'
+run_case "master exempt (allow)" 0 \
+  'git checkout -b master'
+run_case "develop exempt (allow)" 0 \
+  'git checkout -b develop'
+
+# 7) Non-branch-creating command — ignore
+run_case "non-branch command (ignored)" 0 \
+  'git status'
+
+# 8) [REGRESSION] commit message body containing `git checkout -b foo` — must allow
+#    Before the fix, the regex matched `foo` as a branch name and blocked the
+#    entire commit. Issue #242 / discovery: PR #241.
+run_case "REGRESSION: commit message mentions 'git checkout -b foo' (allow)" 0 \
+  'git commit -m "fix: 実機 git checkout -b foo で動作確認 #240"'
+
+# 9) [REGRESSION] HEREDOC body containing `git switch -c foo` — must allow
+heredoc_switch=$(cat <<'CMD'
+git commit -m "$(cat <<'EOF'
+fix: バグ修正 #5
+
+実機 git switch -c foo / git checkout -b bar で block/allow を検証
+EOF
+)"
+CMD
+)
+run_case "REGRESSION: HEREDOC mentions 'git switch -c foo' (allow)" 0 \
+  "$heredoc_switch"
+
+# 10) [REGRESSION] HEREDOC body containing a non-conforming branch name in
+#     `git checkout -b <bad-name>` — must still allow because the outer
+#     command is `git commit`, not branch creation.
+heredoc_bad=$(cat <<'CMD'
+git commit -m "$(cat <<'EOF'
+docs: hook の動作例 #242
+
+例: git checkout -b で が block される（で が branch 名として抽出された）
+EOF
+)"
+CMD
+)
+run_case "REGRESSION: HEREDOC contains broken branch-creation example (allow)" 0 \
+  "$heredoc_bad"
+
+printf '\nResults: %d pass, %d fail\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -14,6 +14,16 @@ set -euo pipefail
 input=$(cat)
 command=$(printf '%s' "$input" | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(d?.tool_input?.command||"")')
 
+# Skip git commit invocations entirely. Branch-name validation only applies to
+# branch-creation commands (`git checkout -b` / `git switch -c`). When a commit
+# message body contains the string `git checkout -b foo` (e.g. when documenting
+# hook behavior), the regex below would otherwise match `foo` as a branch name
+# and block the commit. Commit messages are validated separately by
+# validate-commit-message.sh.
+if [[ "$command" =~ git[[:space:]]+commit ]]; then
+  exit 0
+fi
+
 # Match: git checkout -b <branch>  or  git switch -c <branch>
 branch=""
 if [[ "$command" =~ git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([^[:space:]\;\&\|]+) ]]; then


### PR DESCRIPTION
## 概要

`.claude/hooks/validate-branch-name.sh` が Bash ツール経由のコマンド全体に対して `git checkout -b <name>` / `git switch -c <name>` の regex を走らせていたため、`git commit -m "..."` のコミットメッセージ本文や HEREDOC 本文中に `git checkout -b foo` のような文字列を含むと、message body を branch-creation コマンドと誤認して commit を **block** していた。

PR #241 (Issue #240 対応) の最初のコミット試行で実機発生：
```
[hook:validate-branch-name] Branch name 'で' violates the project convention.
```

## 変更点

### `.claude/hooks/validate-branch-name.sh` (+10)

`git commit` を含むコマンドは branch 検証対象外として早期 `exit 0` する **案A** を採用：

```bash
# Skip git commit invocations entirely. Branch-name validation only applies to
# branch-creation commands (`git checkout -b` / `git switch -c`). When a commit
# message body contains the string `git checkout -b foo` (e.g. when documenting
# hook behavior), the regex below would otherwise match `foo` as a branch name
# and block the commit. Commit messages are validated separately by
# validate-commit-message.sh.
if [[ "$command" =~ git[[:space:]]+commit ]]; then
  exit 0
fi
```

`validate-commit-message.sh` がすでに対称形のフィルタ (`if [[ ! "$command" =~ git[[:space:]]+commit ]]; then exit 0; fi`) を持っているのと一貫性が取れる。Issue #242 に記載された **案A** をそのまま適用。

理論上の盲点 `git commit -m "..." && git checkout -b foo` のような chain では branch 検証がスキップされるが、本プロジェクトのワークフロー (Phase 2 と Phase 5+ で別コマンドを発行) 上は発生しないため許容。

### `.claude/hooks/__tests__/validate-branch-name.test.sh` (+111, NEW)

`validate-commit-message.test.sh` (PR #239 / #241) と同じ pattern (Node.js による JSON payload 構築 + exit code assert) で新設。**12 ケース** 全 pass：

| # | ケース | 期待 | 実測 |
|---|---|---|---|
| 1 | compliant feature branch (allow) | exit 0 | ✅ |
| 2 | compliant fix branch via `switch -c` (allow) | exit 0 | ✅ |
| 3 | non-conforming name (must block) | exit 2 | ✅ |
| 4 | non-conforming name via `switch -c` (must block) | exit 2 | ✅ |
| 5 | claude/* exempt (allow) | exit 0 | ✅ |
| 6 | main / master / develop exempt (3 cases, allow) | exit 0 | ✅ |
| 7 | non-branch command (ignored) | exit 0 | ✅ |
| 8 | **REGRESSION**: commit message mentions `git checkout -b foo` (allow) | exit 0 | ✅ |
| 9 | **REGRESSION**: HEREDOC mentions `git switch -c foo` (allow) | exit 0 | ✅ |
| 10 | **REGRESSION**: HEREDOC contains broken branch-creation example (allow) | exit 0 | ✅ |

実行: `bash .claude/hooks/__tests__/validate-branch-name.test.sh`

## テスト

- ✅ 新規テストスクリプト 12/12 pass
- ✅ 既存 `validate-commit-message.test.sh` 8/8 pass (回帰なし)
- ✅ **実機回帰テスト**: 本 PR 自身のコミットメッセージに `git checkout -b foo` / `git switch -c foo` を含めた状態で hook が allow したことを確認 (修正前なら block されていた)
- ✅ `git checkout -b "fix/#242-..."` のブランチ作成は引き続き hook で validation され allow

## 関連

- 発見PR: #241 (Issue #240 対応中に踏んだ)
- 関連: PR #239 (HEREDOC false-positive 修正の commit message 側、本Issueと類似構造)
- 親Issue: #195 (知見ボード元コメント)

closes #242