### PR TITLE
refactor: .claude/tmp-* を .gitignore に追加し PR作成 Phase に staging 確認手順を追加 #235

### DIFF
--- a/.claude/skills/issue-start/phases/07-pr-creation.md
+++ b/.claude/skills/issue-start/phases/07-pr-creation.md
@@ -1,5 +1,16 @@
 # Phase 7: PR作成
 
+## 事前チェックリスト（push 前）
+
+push 前に以下を確認する。1つでも該当する場合は対応してから次のステップへ進む。
+
+- [ ] `git status --short` を実行し、`.claude/tmp-*` などの一時ファイルが staging / untracked に含まれていない
+  - 含まれている場合: `.gitignore` 側でカバーされているか確認し、必要なら `.gitignore` を修正してから `git rm --cached <path>` で取り除く
+- [ ] `git log origin/main..HEAD --stat` でこのブランチのコミットに無関係な変更（生成物・ログ・他Issueの修正等）が混入していない
+  - 混入している場合: `git reset --soft <correct-base>` で巻き戻して staging を整理し直す
+
+## 手順
+
 1. リモートにブランチをプッシュする：
 
    ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ npm-debug.log*
 # Playwright MCP runtime output
 .playwright-mcp/
 
+# Claude Code runtime tmp files (vite logs, issue payloads, patch files etc.)
+.claude/tmp-*
+
 # Environment
 .env
 .env.local


### PR DESCRIPTION
## 概要

`/issue-start` 実行中に生成される `.claude/tmp-*` 一時ファイル（vite log・Issue payload・patch 等）が `git add -A` で staging に混入する事故を防ぐため、`.gitignore` に機械的な除外パターンを追加する。あわせて Phase 7 のチェックリストに `git status --short` での staging 確認手順を追加し、二重で history 汚染を予防する。

## 変更点

- `.gitignore`: `.claude/tmp-*` パターンを `# Claude Code runtime tmp files` セクションとして追加
- `.claude/skills/issue-start/phases/07-pr-creation.md`: push 前の事前チェックリストを追加（`.claude/tmp-*` の staging 混入確認 + 無関係コミット混入確認）

## テスト

- `touch .claude/tmp-test.txt` を作成し `git status --short` で **untracked にならない** こと、`git check-ignore -v` で `.gitignore:33:.claude/tmp-*` のルールにマッチすることを確認
- `git status --short` 上は今回の意図した変更（`.gitignore` と `phases/07-pr-creation.md`）以外混入していないことを確認

closes #235