### PR TITLE
docs: 登録済み worktree でも Edit/Write のパス取り違えに注意するガイドを追加 #243

### DIFF
--- a/.claude/skills/issue-start/phases/01-issue-analysis.md
+++ b/.claude/skills/issue-start/phases/01-issue-analysis.md
@@ -17,7 +17,7 @@ git worktree list
 | pwd の状態 | 扱い |
 |---|---|
 | `git rev-parse --show-toplevel` と一致 | **メインリポ作業**: 通常通り |
-| `git worktree list` の登録 worktree と一致 | **真の worktree 作業**: 通常通り |
+| `git worktree list` の登録 worktree と一致 | **真の worktree 作業**: **Edit/Write の `file_path` は必ずこの worktree のパスを使う。メインリポ側のパスで指定すると pwd 基準の bash 実行と乖離して『編集したはずなのに反映されない』無音失敗を起こす（PR #241 で実例）** |
 | `.claude/worktrees/<name>/` 配下なのに **登録 worktree でない** | **亡霊 worktree モード**: 以降のすべての Edit/Write/bash 相対パスをメインリポ絶対パス基準に切り替える |
 
 ### 亡霊 worktree モードでの作業ガイド


### PR DESCRIPTION
## 概要

登録済み worktree で作業中に Edit/Write の `file_path` をメインリポ側絶対パスで誤指定すると「無音失敗」が起きうる（PR #241 で実例）。`.claude/skills/issue-start/phases/01-issue-analysis.md` の判定マトリクスにある「真の worktree 作業」行の説明を強化し、Edit/Write の `file_path` を必ず worktree 側のパスに向けるよう明記した。

## 変更点

- `.claude/skills/issue-start/phases/01-issue-analysis.md`:
  - 判定マトリクスの「真の worktree 作業」行の説明を「通常通り」から、「Edit/Write の `file_path` は必ずこの worktree のパスを使う。メインリポ側のパスで指定すると pwd 基準の bash 実行と乖離して『編集したはずなのに反映されない』無音失敗を起こす（PR #241 で実例）」に変更

## スコープ外（別Issue化）

- `CLAUDE.md` への追記: 索引としての役割を保ち詳細は別ファイルに分けるユーザー方針に従い、本PRでは見送り
- PreToolUse hook による機械的検知: 中コストで設計検討が必要なため #246 で別Issue化

## テスト

- ドキュメントのみの変更につき自動テスト対象外
- markdown table の行が崩れていないか目視確認

closes #243