### PR TITLE
refactor: BLM のファイア/ブリザド系スキルID列挙を blm-skills.ts に集約 #216

### DIFF
--- a/src/client/data/blm-buffs.ts
+++ b/src/client/data/blm-buffs.ts
@@ -1,4 +1,5 @@
 import type { BuffDefinition } from "../types/skill";
+import { BLM_FIRE_FAMILY_IDS, BLM_BLIZZARD_FAMILY_IDS } from "./blm-skills";
 
 // === バフアイコン ===
 import fireIcon from "../assets/icons/blm/Fire.png";
@@ -24,32 +25,6 @@ import swiftcastIcon from "../assets/icons/blm/role_actions/Swiftcast.png";
  *    正確な値は実機検証で必要に応じて調整する。
  */
 
-// === AF/UB で対象となるスキルID群 ===
-// 隠しスキル（fire-up-af2 等）も autoTransform 経由で実行されるため対象に含める
-const FIRE_SKILL_IDS = [
-  "fire",
-  "fire-2",
-  "fire-3",
-  "fire-4",
-  "high-fire-2",
-  "despair",
-  "flare-star",
-  "fire-up-af2",
-  "fire-up-af3",
-  "fire-stay-af3",
-];
-const BLIZZARD_SKILL_IDS = [
-  "blizzard",
-  "blizzard-2",
-  "blizzard-3",
-  "blizzard-4",
-  "high-blizzard-2",
-  "freeze",
-  "blizzard-up-ub2",
-  "blizzard-up-ub3",
-  "blizzard-stay-ub3",
-];
-
 /** エノキアン倍率（Lv86 特性、AF/UB 中常時）。Lv100 想定の近似値 */
 const ENOCHIAN_MULTIPLIER = 1.23;
 
@@ -68,14 +43,14 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 1.4, appliesToSkillIds: FIRE_SKILL_IDS },
-      { type: "potency", value: 0.9, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "potency", value: 1.4, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
+      { type: "potency", value: 0.9, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
       {
         type: "resourceCostMultiplier",
         value: 2,
         resourceId: "mp",
-        appliesToSkillIds: FIRE_SKILL_IDS,
+        appliesToSkillIds: BLM_FIRE_FAMILY_IDS,
         negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
       },
     ],
@@ -90,14 +65,14 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 1.6, appliesToSkillIds: FIRE_SKILL_IDS },
-      { type: "potency", value: 0.8, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "potency", value: 1.6, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
+      { type: "potency", value: 0.8, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
       {
         type: "resourceCostMultiplier",
         value: 2,
         resourceId: "mp",
-        appliesToSkillIds: FIRE_SKILL_IDS,
+        appliesToSkillIds: BLM_FIRE_FAMILY_IDS,
         negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
       },
     ],
@@ -112,14 +87,14 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 1.8, appliesToSkillIds: FIRE_SKILL_IDS },
-      { type: "potency", value: 0.7, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "potency", value: 1.8, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
+      { type: "potency", value: 0.7, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
       {
         type: "resourceCostMultiplier",
         value: 2,
         resourceId: "mp",
-        appliesToSkillIds: FIRE_SKILL_IDS,
+        appliesToSkillIds: BLM_FIRE_FAMILY_IDS,
         negatedByResource: { resourceId: "umbral-heart", consumeAmount: 1 },
       },
     ],
@@ -140,11 +115,11 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 0.9, appliesToSkillIds: FIRE_SKILL_IDS },
+      { type: "potency", value: 0.9, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
-      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
       // UB1 中にブリザド系を撃つと命中時に MP +2500（実行前バフで判定）
-      { type: "resourceGainOnSkill", resourceId: "mp", value: 2500, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "resourceGainOnSkill", resourceId: "mp", value: 2500, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
     ],
     color: "#42a5f5",
     acquiredLevel: 1,
@@ -157,10 +132,10 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 0.8, appliesToSkillIds: FIRE_SKILL_IDS },
+      { type: "potency", value: 0.8, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
-      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
-      { type: "resourceGainOnSkill", resourceId: "mp", value: 5000, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
+      { type: "resourceGainOnSkill", resourceId: "mp", value: 5000, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
     ],
     color: "#1e88e5",
     acquiredLevel: 1,
@@ -173,10 +148,10 @@ export const BLM_BUFFS: BuffDefinition[] = [
     duration: null,
     exclusiveGroup: EXCLUSIVE_GROUP_AF_UB,
     effects: [
-      { type: "potency", value: 0.7, appliesToSkillIds: FIRE_SKILL_IDS },
+      { type: "potency", value: 0.7, appliesToSkillIds: BLM_FIRE_FAMILY_IDS },
       { type: "potency", value: ENOCHIAN_MULTIPLIER },
-      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLIZZARD_SKILL_IDS },
-      { type: "resourceGainOnSkill", resourceId: "mp", value: 10000, appliesToSkillIds: BLIZZARD_SKILL_IDS },
+      { type: "resourceCostMultiplier", value: 0, resourceId: "mp", appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
+      { type: "resourceGainOnSkill", resourceId: "mp", value: 10000, appliesToSkillIds: BLM_BLIZZARD_FAMILY_IDS },
     ],
     color: "#1565c0",
     acquiredLevel: 1,

--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -657,3 +657,39 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     buffApplications: ["astral-fire-1", "thunderhead"],
   },
 ];
+
+// ============================================================
+// AF/UB バフ効果の対象スキル ID 群
+// ============================================================
+// blm-buffs.ts の AF/UB バフが potency 倍率・MP 消費倍率・
+// MP 回復対象を判定する際に参照する。隠しスキル（fire-up-af2 等）も
+// autoTransform 経由で実行されるため対象に含める。
+// 新スキルや段階進行用の隠しスキルを追加した際は、ここを更新するだけで
+// blm-buffs.ts の AF/UB 効果が自動追従する。
+
+/** AF（アストラルファイア）効果の対象となるファイア系スキル ID 群 */
+export const BLM_FIRE_FAMILY_IDS = [
+  "fire",
+  "fire-2",
+  "fire-3",
+  "fire-4",
+  "high-fire-2",
+  "despair",
+  "flare-star",
+  "fire-up-af2",
+  "fire-up-af3",
+  "fire-stay-af3",
+];
+
+/** UB（アンブラルブリザード）効果の対象となるブリザド系スキル ID 群 */
+export const BLM_BLIZZARD_FAMILY_IDS = [
+  "blizzard",
+  "blizzard-2",
+  "blizzard-3",
+  "blizzard-4",
+  "high-blizzard-2",
+  "freeze",
+  "blizzard-up-ub2",
+  "blizzard-up-ub3",
+  "blizzard-stay-ub3",
+];

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -351,7 +351,7 @@ describe("BLM: UB 中の他ブリザド系スキルの MP 回復", () => {
     );
     const before = result.entries[0].resourceSnapshot["mp"];
     const after = result.entries[1].resourceSnapshot["mp"];
-    // ブリザガは BLIZZARD_SKILL_IDS で AF の倍率対象外、UB バフ非アクティブのため回復もなし
+    // ブリザガは BLM_BLIZZARD_FAMILY_IDS で AF の倍率対象外、UB バフ非アクティブのため回復もなし
     expect(after - before).toBe(-800);
     expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
   });
@@ -511,7 +511,7 @@ describe("BLM: AF/UB バフ連動 MP 消費（#209）", () => {
       undefined,
       BLM_BUFFS,
     );
-    // fire-3 は通常通り MP -2000 消費（UB の倍率は BLIZZARD_SKILL_IDS のみに適用）
+    // fire-3 は通常通り MP -2000 消費（UB の倍率は BLM_BLIZZARD_FAMILY_IDS のみに適用）
     expect(result.entries[1].resourceSnapshot["mp"]).toBe(10000 - 2000);
   });
 


### PR DESCRIPTION
## 概要

`src/client/data/blm-buffs.ts` に直書きされていた `FIRE_SKILL_IDS` / `BLIZZARD_SKILL_IDS` を、定義側 `src/client/data/blm-skills.ts` に `BLM_FIRE_FAMILY_IDS` / `BLM_BLIZZARD_FAMILY_IDS` として export し、`blm-buffs.ts` から import する形に変更した。スキル定義と対象 ID 列挙の二重管理を解消し、新スキル追加時の追従漏れによるサイレントバグを防ぎやすくする。

## 変更点

- `src/client/data/blm-skills.ts`: 末尾に `BLM_FIRE_FAMILY_IDS`（10 ID）/ `BLM_BLIZZARD_FAMILY_IDS`（9 ID）の export を追加。AF/UB バフ効果の対象スキル ID 群であることを JSDoc とセクションヘッダで明記
- `src/client/data/blm-buffs.ts`: 旧 `FIRE_SKILL_IDS` / `BLIZZARD_SKILL_IDS` のローカル定数定義を削除し、新 export を import。AF1/AF2/AF3/UB1/UB2/UB3 各バフの `appliesToSkillIds` 14 箇所すべてを新名にリネーム（配列内容は完全一致、挙動変更なし）
- `src/client/logic/__tests__/blm-af-ub.test.ts`: コメント中の旧名 2 箇所を新名に追従更新

## テスト

- ✅ `npx tsc --noEmit`: 型エラーなし
- ✅ `npm test -- --run`: 15 ファイル / 112 テスト全 passed
- ✅ Pure refactor のため挙動変更なし（旧 ID 配列と新 export の中身を 1 対 1 で確認）

## レビュー結果

`code-reviewer` 3 並列（簡潔さ・バグ・規約整合）すべて信頼度 80 以上の問題なしと判定。
スコープ外候補（`as const` 化・他ジョブ横展開）は `priority:low` 案件として起票見送り。

closes #216