### PR TITLE
fix: 黒魔道士のトランスポーズが thunderhead を付与する不具合を修正 #219

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -493,7 +493,8 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     cooldown: 5,
     acquiredLevel: 4,
     // 無極性時の簡易フォールバック（実機では無極性時は何も起きないが、現行ツールの簡易挙動を維持）
-    buffApplications: ["umbral-ice-1", "thunderhead"],
+    // 実機ではトランスでサンダーヘッドは付与されない（ファイア／ブリザド系命中時のみ付与）
+    buffApplications: ["umbral-ice-1"],
     // AF 中は UB1 へ、UB 中は AF1 へ切替
     autoTransform: [
       { buffId: "astral-fire-3", skillId: "transpose-to-ub1" },
@@ -640,7 +641,7 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     cooldown: 5,
     acquiredLevel: 4,
     hidden: true,
-    buffApplications: ["umbral-ice-1", "thunderhead"],
+    buffApplications: ["umbral-ice-1"],
   },
   {
     id: "transpose-to-af1",
@@ -654,6 +655,6 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     cooldown: 5,
     acquiredLevel: 4,
     hidden: true,
-    buffApplications: ["astral-fire-1", "thunderhead"],
+    buffApplications: ["astral-fire-1"],
   },
 ];

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -399,6 +399,59 @@ describe("BLM: トランスポーズの逆状態切替", () => {
     expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(false);
     expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "astral-fire-1")).toBe(true);
   });
+
+  // 実機ではトランスポーズでサンダーヘッドは付与されない（Issue #219）。
+  // thunderhead はファイア／ブリザド系命中時のみ付与される。
+  it("無極性時のトランスはサンダーヘッドを付与しない", () => {
+    const result = resolveTimeline(
+      [entry("transpose")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+
+    expect(result.entries[0].activeBuffs.some((ab) => ab.buffId === "thunderhead")).toBe(false);
+  });
+
+  it("AF 中のトランス（→UB1）はサンダーヘッドを再付与しない", () => {
+    const result = resolveTimeline(
+      [entry("fire-3"), entry("transpose")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+
+    // fire-3 命中時に thunderhead が付与済み。トランスが thunderhead を再付与した場合、
+    // startTime がトランス時刻に上書きされるため、fire-3 時の startTime と同一であることで
+    // 「トランス自身が thunderhead を付与していない」ことを検証する。
+    const beforeTranspose = result.entries[0];
+    const afterTranspose = result.entries[1];
+    const thunderheadBefore = beforeTranspose.activeBuffs.find((ab) => ab.buffId === "thunderhead");
+    const thunderheadAfter = afterTranspose.activeBuffs.find((ab) => ab.buffId === "thunderhead");
+    expect(thunderheadBefore).toBeDefined();
+    expect(thunderheadAfter).toBeDefined();
+    expect(thunderheadAfter!.startTime).toBe(thunderheadBefore!.startTime);
+  });
+
+  it("UB 中のトランス（→AF1）はサンダーヘッドを再付与しない", () => {
+    const result = resolveTimeline(
+      [entry("blizzard-3"), entry("transpose")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+
+    const beforeTranspose = result.entries[0];
+    const afterTranspose = result.entries[1];
+    const thunderheadBefore = beforeTranspose.activeBuffs.find((ab) => ab.buffId === "thunderhead");
+    const thunderheadAfter = afterTranspose.activeBuffs.find((ab) => ab.buffId === "thunderhead");
+    expect(thunderheadBefore).toBeDefined();
+    expect(thunderheadAfter).toBeDefined();
+    expect(thunderheadAfter!.startTime).toBe(thunderheadBefore!.startTime);
+  });
 });
 
 describe("BLM: フレアスターとアストラルソウル", () => {


### PR DESCRIPTION
## 概要

黒魔道士のトランスポーズ（transpose）が `thunderhead` バフを付与していた不具合を修正する。実機ではトランスポーズで `thunderhead` は付与されず、ファイア／ブリザド系命中時のみ付与される（旧簡易実装の踏襲）。

## 変更点

- `src/client/data/blm-skills.ts`: `transpose` / `transpose-to-ub1` / `transpose-to-af1` の `buffApplications` から `thunderhead` を削除し、コメントで実機仕様を明記
- `src/client/logic/__tests__/blm-af-ub.test.ts`: トランスポーズが `thunderhead` を付与・再付与しないことを検証するユニットテストを 3 ケース追加（無極性 / AF→UB / UB→AF）。AF/UB 経由のケースは `thunderhead.startTime` がトランス前後で変化しないことで非再付与を検証

## テスト

- `npm test` 全 115 ケース PASS（既存 112 + 新規 3）
- `npx tsc --noEmit` エラーなし
- 既存の「マナフォントが thunderhead を付与する」テスト（`blm-af-ub.test.ts:168`）は無関係（`manafont` 自体の `buffApplications` には触れていない）

closes #219