### PR TITLE
docs: ドキュメント運用方針を documentation-policy.md に明文化 #249

### DIFF
--- a/.claude/rules/documentation-policy.md
+++ b/.claude/rules/documentation-policy.md
@@ -1,0 +1,36 @@
+# ドキュメント運用方針
+
+このファイルは CLAUDE.md から `@.claude/rules/documentation-policy.md` でインポートされる。
+
+## 基本方針
+
+- **`CLAUDE.md` は索引・コア原則のみに保つ**: プロジェクトの中核となる開発方針（Issue駆動開発、1 Issue = 1 PR、推測しない、思考よりも対話、中間報告など）と、詳細規約ファイルへの索引（Memory Imports）だけを置く場所
+- **詳細規約は `.claude/rules/*.md` に分離する**: 個別領域ごとの具体的な規約・運用手順・リファレンスは `.claude/rules/` 配下に配置し、`@.claude/rules/<name>.md` 形式で CLAUDE.md から Memory Imports する
+- **新規規約を追加するときは原則 `.claude/rules/*.md` 側を作成・更新する**: コア原則そのものの再定義でなければ、CLAUDE.md 本文を直接膨らませず、対応する rules ファイル（既存 or 新規）を編集する。CLAUDE.md 側の更新は Memory Imports リストへの 1 行追加で済むのが理想
+
+## 既存 rules ファイルとスコープ
+
+| ファイル | スコープ |
+|---------|---------|
+| `git-conventions.md` | ブランチ・コミット・PR・Issue 規約 |
+| `coding-standards.md` | TypeScript・命名・ディレクトリ構成・コメント方針 |
+| `tech-stack.md` | 技術スタック・開発環境・npm スクリプト |
+| `context-efficiency.md` | コンテキスト効率・ファイル読解ルール |
+| `mcp-setup.md` | MCP サーバー設定・API キー管理 |
+| `playwright-mcp.md` | Playwright MCP 利用ガイド |
+| `workflow-feedback.md` | ワークフロー改善知見ボード（#195）運用 |
+| `documentation-policy.md` | ドキュメント運用方針（このファイル） |
+
+## 新規 rules ファイル追加時のチェック
+
+1. スコープが既存 rules と重複しないか確認（重複するなら既存ファイルへの追記を選ぶ）
+2. 冒頭に `このファイルは CLAUDE.md から @.claude/rules/<name>.md でインポートされる` を記載
+3. CLAUDE.md の「## 詳細規約（Memory Imports）」見出し直下のリストに `@.claude/rules/<name>.md` を追加
+
+## 「CLAUDE.md にも追記」と書きたくなったら
+
+実装中・Issue 本文で「CLAUDE.md にも追記する」のような表現が出てきたら、まず「索引・コア原則として CLAUDE.md に置くべき内容か」を自問する。次のいずれかに該当しなければ、対応する `.claude/rules/*.md` 側に書く方を選ぶ：
+
+- プロジェクトのコア原則そのもの（既存「## 開発方針」と同等のレイヤー）
+- 全 Phase / 全領域に横断的に効く絶対ルール
+- 詳細規約ファイルが分かれていない領域への新規索引追加

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ FF14（ファイナルファンタジー14）のスキル回し（ローテー�
 
 ## 詳細規約（Memory Imports）
 
-具体的な規約は以下のファイルにモジュール分割している。Claude Code は起動時にこれらを自動的に読み込む。
+具体的な規約は以下のファイルにモジュール分割している。Claude Code は起動時にこれらを自動的に読み込む。**`CLAUDE.md` は索引・コア原則のみに保ち、詳細規約は `.claude/rules/*.md` 側に書く**（運用方針は `@.claude/rules/documentation-policy.md` 参照）。
 
 @.claude/rules/git-conventions.md
 @.claude/rules/coding-standards.md
@@ -25,6 +25,7 @@ FF14（ファイナルファンタジー14）のスキル回し（ローテー�
 @.claude/rules/mcp-setup.md
 @.claude/rules/playwright-mcp.md
 @.claude/rules/workflow-feedback.md
+@.claude/rules/documentation-policy.md
 
 ## 開発フロー
 


### PR DESCRIPTION
## 概要

「`CLAUDE.md` は索引・コア原則のみとし、詳細規約は `.claude/rules/*.md` に分離する」という暗黙ルールを `.claude/rules/documentation-policy.md` として明文化した。これにより、新規規約を追加する場面で Claude が「索引にふさわしいか」を自問でき、ユーザー判断負担が減る。

## 変更点

- 新規 `.claude/rules/documentation-policy.md` を追加
  - `CLAUDE.md` は索引・コア原則のみに保つ
  - 詳細規約は `.claude/rules/*.md` に分離する（Memory Imports で読み込まれる）
  - 新規規約を追加するときは原則 `.claude/rules/*.md` 側を作成・更新する
  - 既存 rules ファイルとスコープの一覧、新規 rules ファイル追加時のチェック手順、「CLAUDE.md にも追記」と書きたくなったときの自問項目を整理
- `CLAUDE.md` の「## 詳細規約（Memory Imports）」見出し直下に方針への 1 行参照を追加し、Memory Imports リストに `@.claude/rules/documentation-policy.md` を追記

## テスト

- 内容のみのドキュメント変更のため、コード側のテストには影響しない
- 既存 `.claude/rules/*.md` を Grep して「CLAUDE.md にも追記」に類する誤誘導表現がないことを確認済（該当なし）
- `CLAUDE.md` 本文は大幅削減せず、コア原則は保ったまま（Issue「やらないこと」遵守）

closes #249
