### PR TITLE
fix: ブリザラ・ハイブリザラの mp +400 ハードコードを削除し UB バフ機構に委譲 #217

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -266,9 +266,6 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     castTime: 3.0,
     acquiredLevel: 12,
-    resourceChanges: [
-      { resourceId: "mp", amount: 400 },
-    ],
     buffApplications: ["umbral-ice-3", "thunderhead"],
   },
   {
@@ -283,9 +280,6 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     castTime: 3.0,
     acquiredLevel: 45,
     replacesSkillId: "blizzard-2",
-    resourceChanges: [
-      { resourceId: "mp", amount: 400 },
-    ],
     buffApplications: ["umbral-ice-3", "thunderhead"],
   },
   {

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -356,7 +356,7 @@ describe("BLM: UB 中の他ブリザド系スキルの MP 回復", () => {
     expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
   });
 
-  it("UB1 中の AOE ブリザド系（ブリザラ）も UB バフの MP 回復が発動する", () => {
+  it("UB1 中の AOE ブリザド系（ブリザラ）は UB バフの MP 回復 +2500 が発動する", () => {
     const result = resolveTimeline(
       [entry("fire-3"), entry("despair"), entry("transpose"), entry("blizzard-2")],
       skillMap,
@@ -365,11 +365,99 @@ describe("BLM: UB 中の他ブリザド系スキルの MP 回復", () => {
       BLM_BUFFS,
     );
     // entries[2] = UB1, MP 0 / entries[3] = blizzard-2（UB1 中→ UB3 直接付与、resourceGainOnSkill +2500）
-    // blizzard-2 は元定義に MP +400（旧簡易実装）、UB1 の resourceCostMultiplier ×0 は正の変動には作用しないので残る
     const before = result.entries[2].resourceSnapshot["mp"];
     const after = result.entries[3].resourceSnapshot["mp"];
-    expect(after - before).toBe(400 + 2500);
+    expect(after - before).toBe(2500);
     expect(result.entries[3].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB2 中のブリザラは UB バフの MP 回復 +5000 が発動する", () => {
+    // fire-3 → despair で MP を 0 にしてから transpose → blizzard で UB2 へ進める
+    const result = resolveTimeline(
+      [
+        entry("fire-3"),
+        entry("despair"),
+        entry("transpose"),
+        entry("blizzard"),
+        entry("blizzard-2"),
+      ],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    // entries[3] = blizzard で UB1→UB2、MP +2500（=2500）
+    // entries[4] = blizzard-2 で UB2 中→ UB3 直接付与、resourceGainOnSkill +5000
+    const before = result.entries[3].resourceSnapshot["mp"];
+    const after = result.entries[4].resourceSnapshot["mp"];
+    expect(after - before).toBe(5000);
+    expect(result.entries[4].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB3 中のブリザラは UB バフの MP 回復 +10000 が発動する（上限キャップ）", () => {
+    // blizzard-3 で UB3 を直接付与してから blizzard-2 を撃つ
+    const result = resolveTimeline(
+      [entry("blizzard-3"), entry("blizzard-2")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    const before = result.entries[0].resourceSnapshot["mp"];
+    const after = result.entries[1].resourceSnapshot["mp"];
+    // resourceGainOnSkill +10000 が適用されるが、MP 上限 10000 にキャップ
+    expect(before).toBeLessThan(10000);
+    expect(after).toBe(10000);
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB1 中のハイブリザラは UB バフの MP 回復 +2500 が発動する", () => {
+    const result = resolveTimeline(
+      [entry("fire-3"), entry("despair"), entry("transpose"), entry("high-blizzard-2")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    const before = result.entries[2].resourceSnapshot["mp"];
+    const after = result.entries[3].resourceSnapshot["mp"];
+    expect(after - before).toBe(2500);
+    expect(result.entries[3].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB2 中のハイブリザラは UB バフの MP 回復 +5000 が発動する", () => {
+    const result = resolveTimeline(
+      [
+        entry("fire-3"),
+        entry("despair"),
+        entry("transpose"),
+        entry("blizzard"),
+        entry("high-blizzard-2"),
+      ],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    const before = result.entries[3].resourceSnapshot["mp"];
+    const after = result.entries[4].resourceSnapshot["mp"];
+    expect(after - before).toBe(5000);
+    expect(result.entries[4].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
+  });
+
+  it("UB3 中のハイブリザラは UB バフの MP 回復 +10000 が発動する（上限キャップ）", () => {
+    const result = resolveTimeline(
+      [entry("blizzard-3"), entry("high-blizzard-2")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+    const before = result.entries[0].resourceSnapshot["mp"];
+    const after = result.entries[1].resourceSnapshot["mp"];
+    expect(before).toBeLessThan(10000);
+    expect(after).toBe(10000);
+    expect(result.entries[1].activeBuffs.some((ab) => ab.buffId === "umbral-ice-3")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 概要

ブリザラ（`blizzard-2`）／ハイブリザラ（`high-blizzard-2`）の `resourceChanges` にハードコードされていた `{ resourceId: "mp", amount: 400 }` を削除し、UB バフの `resourceGainOnSkill` 機構（UB1: +2500 / UB2: +5000 / UB3: +10000）に MP 回復の責務を委譲する。

通常ブリザド（`blizzard`）の同じハードコードは PR #213（Issue #210）で削除済み。本 PR は AOE 系を同じ整合性に揃える。

## 変更点

- `src/client/data/blm-skills.ts`
  - `blizzard-2` の `resourceChanges: [{ resourceId: "mp", amount: 400 }]` を削除
  - `high-blizzard-2` の `resourceChanges: [{ resourceId: "mp", amount: 400 }]` を削除
- `src/client/logic/__tests__/blm-af-ub.test.ts`
  - 既存「UB1 中の AOE ブリザド系（ブリザラ）も UB バフの MP 回復が発動する」テストを `+2500` のみに修正（旧コメント `mp +400（旧簡易実装）` も除去）
  - UB1 / UB2 / UB3 中の `blizzard-2` で正しい MP 回復量（+2500 / +5000 / +10000）になることを検証するテストを追加（既存 1 個の修正＋新規 2 個）
  - UB1 / UB2 / UB3 中の `high-blizzard-2` で正しい MP 回復量になることを検証するテストを追加（新規 3 個）
  - UB3 テストは MP 上限 10000 にキャップされる仕様を `before < 10000 && after === 10000` で検証

## テスト

- `npm test`: 117 / 117 passed（`blm-af-ub.test.ts` は 36 / 36 passed、新規追加 5 件含む）
- `npx tsc --noEmit`: エラーなし

## 補足

- `BLM_BLIZZARD_FAMILY_IDS` に `blizzard-2` / `high-blizzard-2` が既に含まれているため、`resourceChanges` を削除するだけで UB バフの `resourceGainOnSkill` が自動的に作用する
- やらないこと（Issue 本文より）: ブリザラ／ハイブリザラの威力・キャストタイム・他リソース変動の変更／AOE 系の段階進行ロジック追加

closes #217
