### PR TITLE
feat: worktree から main repo パスを Edit/Write した時の警告 hook を追加 #246

### DIFF
--- a/.claude/hooks/__tests__/validate-edit-path.test.sh
+++ b/.claude/hooks/__tests__/validate-edit-path.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Manual test for ../validate-edit-path.cjs
+#
+# Run: bash .claude/hooks/__tests__/validate-edit-path.test.sh
+#
+# These tests invoke the .cjs script directly (NOT the .sh wrapper) and inject
+# the worktree list / project dir via env vars, so no real git worktree setup
+# is required. A tmpdir sandbox is created to exercise the "twin file exists in
+# worktree" condition.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+JS="$HOOK_DIR/validate-edit-path.cjs"
+
+if [[ ! -f "$JS" ]]; then
+  printf 'cjs not found: %s\n' "$JS" >&2
+  exit 1
+fi
+
+# Sandbox: <TMPROOT>/main is the "main repo", with a registered worktree
+# under .claude/worktrees/wt1 and another sibling worktree wt2.
+TMPROOT_RAW=$(mktemp -d 2>/dev/null) || TMPROOT_RAW="${TMPDIR:-/tmp}/validate-edit-path-test-$$"
+mkdir -p "$TMPROOT_RAW"
+trap 'rm -rf "$TMPROOT_RAW"' EXIT
+# On Git Bash / MSYS, env vars containing a single path are auto-translated to
+# Windows form when handed to a native binary like node.exe — but multi-line
+# values (CLAUDE_HOOK_WT_LIST) are not, so the .cjs would see a mix of forms.
+# Convert TMPROOT to a Windows-style absolute path up-front so all derived
+# paths are consistent. Falls through unchanged on Linux/macOS where cygpath
+# does not exist.
+if command -v cygpath >/dev/null 2>&1; then
+  TMPROOT=$(cygpath -m "$TMPROOT_RAW")
+else
+  TMPROOT="$TMPROOT_RAW"
+fi
+
+MAIN="$TMPROOT/main"
+WT="$MAIN/.claude/worktrees/wt1"
+WT2="$MAIN/.claude/worktrees/wt2"
+mkdir -p "$WT/src" "$WT2"
+echo "shared" > "$MAIN/shared.txt"
+echo "shared" > "$WT/shared.txt"
+echo "main-only" > "$MAIN/main-only.txt"
+
+WT_LIST="$MAIN
+$WT
+$WT2"
+
+pass=0
+fail=0
+
+build_payload() {
+  # $1 = tool_name, $2 = file_path
+  node -e 'process.stdout.write(JSON.stringify({tool_name:process.argv[1], tool_input:{file_path:process.argv[2]}}))' "$1" "$2"
+}
+
+run_case() {
+  # $1=name $2=expected_exit $3=tool_name $4=file_path $5=proj_dir
+  #   [optional env via prefix vars: ALLOW=1 / WT_LIST_OVERRIDE="..."]
+  local name="$1" expected="$2" tool_name="$3" file_path="$4" proj_dir="$5"
+  local allow="${ALLOW:-0}"
+  local wt_override="${WT_LIST_OVERRIDE-}"
+  local payload exit_code
+  payload=$(build_payload "$tool_name" "$file_path")
+  local effective_wt
+  if [[ -n "${wt_override:-}" ]] || [[ -n "${WT_LIST_OVERRIDE+x}" ]]; then
+    effective_wt="$wt_override"
+  else
+    effective_wt="$WT_LIST"
+  fi
+  set +e
+  CLAUDE_HOOK_PROJ_DIR="$proj_dir" \
+    CLAUDE_HOOK_WT_LIST="$effective_wt" \
+    CLAUDE_ALLOW_MAIN_REPO_EDIT="$allow" \
+    node "$JS" >/dev/null 2>&1 <<<"$payload"
+  exit_code=$?
+  set -e
+  if [[ "$exit_code" == "$expected" ]]; then
+    printf '  [PASS] %s (exit=%d)\n' "$name" "$exit_code"
+    pass=$((pass+1))
+  else
+    printf '  [FAIL] %s (expected exit=%s, got %d)\n' "$name" "$expected" "$exit_code"
+    fail=$((fail+1))
+  fi
+}
+
+printf -- '--- validate-edit-path.cjs tests ---\n'
+
+# 1) Non-target tool → ignored
+run_case "Bash tool ignored" 0 "Bash" "$MAIN/shared.txt" "$WT"
+
+# 2) Empty file_path → ignored
+run_case "empty file_path ignored" 0 "Edit" "" "$WT"
+
+# 3) Working in main repo (proj_dir == main, not a worktree match) → no warn
+run_case "working in main repo (no warn)" 0 "Edit" "$MAIN/shared.txt" "$MAIN"
+
+# 4) Working in worktree, file_path INSIDE worktree → correct usage, no warn
+run_case "file_path inside current worktree" 0 "Edit" "$WT/shared.txt" "$WT"
+
+# 5) Main-only file (no twin in worktree) → no warn (intentional main-only edit)
+run_case "main-only file (no twin)" 0 "Edit" "$MAIN/main-only.txt" "$WT"
+
+# 6) PRIMARY: file_path inside main, twin EXISTS in current worktree → warn
+run_case "PRIMARY: main path with twin in worktree (warn)" 1 "Edit" "$MAIN/shared.txt" "$WT"
+
+# 7) PRIMARY repeated for the Write tool
+run_case "PRIMARY (Write tool)" 1 "Write" "$MAIN/shared.txt" "$WT"
+
+# 8) file_path lives inside another registered worktree (.claude/worktrees/<other>/) → out of scope
+run_case "another worktree path (out of scope)" 0 "Edit" "$MAIN/.claude/worktrees/wt2/foo.txt" "$WT"
+
+# 9) Unrelated path on a different filesystem prefix → out of scope
+run_case "unrelated path (out of scope)" 0 "Edit" "/some/other/path/foo.txt" "$WT"
+
+# 10) Opt-out env var → no warn even for the primary case
+ALLOW=1 run_case "opt-out via CLAUDE_ALLOW_MAIN_REPO_EDIT=1" 0 "Edit" "$MAIN/shared.txt" "$WT"
+
+# 11) Backslash-style file_path (Windows path) → still detected via normalization
+backslash_path=$(printf '%s' "$MAIN/shared.txt" | tr '/' '\\')
+run_case "backslash file_path detected" 1 "Edit" "$backslash_path" "$WT"
+
+# 12) Empty worktree list → exit 0 (defensive: not in a git context)
+WT_LIST_OVERRIDE="" run_case "empty worktree list" 0 "Edit" "$MAIN/shared.txt" "$WT"
+
+# 13) Worktree-only list (no main entry would be the same as main being the only entry)
+#     — single-entry list means the project dir matches main with no extra worktrees,
+#     so even a path inside the only entry is considered "working in main", no warn.
+WT_LIST_OVERRIDE="$MAIN" run_case "single-entry worktree list = main only" 0 "Edit" "$MAIN/shared.txt" "$MAIN"
+
+# 14) Mixed-case file_path on Windows: file_path uses the same path with different case
+#     — should still detect because comparison is case-insensitive
+mixed_path=$(printf '%s' "$MAIN/Shared.txt")
+# Only meaningful when the actual file exists case-insensitively (Windows). On case-sensitive FS,
+# fs.accessSync would fail and we'd exit 0 silently. Skip strict assertion.
+set +e
+CLAUDE_HOOK_PROJ_DIR="$WT" CLAUDE_HOOK_WT_LIST="$WT_LIST" \
+  node "$JS" >/dev/null 2>&1 <<<"$(build_payload "Edit" "$mixed_path")"
+mixed_exit=$?
+set -e
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if [[ "$mixed_exit" == "1" ]]; then
+      printf '  [PASS] mixed-case path detected on Windows (exit=%d)\n' "$mixed_exit"
+      pass=$((pass+1))
+    else
+      printf '  [FAIL] mixed-case path detection on Windows (expected exit=1, got %d)\n' "$mixed_exit"
+      fail=$((fail+1))
+    fi
+    ;;
+  *)
+    # Case-sensitive FS (Linux/Mac): twin lookup fails → exit 0 is acceptable
+    printf '  [SKIP] mixed-case path test (case-sensitive FS, exit=%d)\n' "$mixed_exit"
+    ;;
+esac
+
+printf '\nResults: %d pass, %d fail\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/.claude/hooks/validate-edit-path.cjs
+++ b/.claude/hooks/validate-edit-path.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Detection logic for the validate-edit-path PreToolUse hook.
+// Invoked by validate-edit-path.sh, which gathers the worktree list via git
+// and forwards it through env vars so this script stays free of git/IO concerns
+// (and is easy to test by overriding the env vars directly).
+//
+// Inputs:
+//   stdin                       Claude Code hook JSON payload
+//   env CLAUDE_HOOK_PROJ_DIR    project dir from CLAUDE_PROJECT_DIR (or pwd fallback)
+//   env CLAUDE_HOOK_WT_LIST     newline-joined worktree paths from `git worktree list --porcelain`
+//                               (first line = main repo, remainder = registered worktrees)
+//   env CLAUDE_ALLOW_MAIN_REPO_EDIT  '1' to opt out (warning suppressed)
+//
+// Exit codes:
+//   0 = OK / opt-out / out of scope
+//   1 = warning emitted to stderr (does NOT block the tool; user-facing)
+//
+// Audience: Claude Code's hook protocol only forwards stderr to the assistant
+// when exit code is 2 (block). Exit 1 surfaces the warning to the human
+// operator's terminal only — the assistant itself does NOT see it. This is
+// deliberate per Issue #246 ("警告のみ、ブロックしない"): the human notices
+// and intervenes; the assistant will continue thinking the Edit succeeded.
+// Switch to exit 2 if/when blocking-with-retry is preferred.
+
+'use strict';
+
+const fs = require('fs');
+
+function normalize(p) {
+  if (!p) return '';
+  let q = p.replace(/\\/g, '/').replace(/\/+$/, '');
+  // MSYS-style "/d/foo" -> "d:/foo"
+  q = q.replace(/^\/([a-zA-Z])(\/|$)/, (_, drive, rest) => drive.toLowerCase() + ':' + rest);
+  return q;
+}
+
+function ci(s) {
+  return s.toLowerCase();
+}
+
+function main() {
+  if (process.env.CLAUDE_ALLOW_MAIN_REPO_EDIT === '1') {
+    process.exit(0);
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(0, 'utf8');
+  } catch {
+    process.exit(0);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = payload && payload.tool_name;
+  const filePath = payload && payload.tool_input && payload.tool_input.file_path;
+  if (toolName !== 'Edit' && toolName !== 'Write') process.exit(0);
+  if (!filePath || typeof filePath !== 'string') process.exit(0);
+
+  const projDir = process.env.CLAUDE_HOOK_PROJ_DIR || process.cwd();
+  const wtListRaw = process.env.CLAUDE_HOOK_WT_LIST || '';
+  const wtList = wtListRaw.split('\n').map((s) => s.trim()).filter(Boolean);
+  if (wtList.length === 0) process.exit(0);
+
+  const mainRepo = wtList[0];
+  const worktrees = wtList.slice(1);
+
+  const nProj = ci(normalize(projDir));
+  const nMain = ci(normalize(mainRepo));
+
+  // Find the current worktree (must NOT be the main repo).
+  let currentWt = null;
+  for (const wt of worktrees) {
+    if (ci(normalize(wt)) === nProj) {
+      currentWt = wt;
+      break;
+    }
+  }
+  if (!currentWt) process.exit(0); // working in main repo or non-worktree context
+
+  const nCurWt = ci(normalize(currentWt));
+  const nFile = ci(normalize(filePath));
+
+  // file_path under the current worktree → correct usage.
+  if (nFile === nCurWt || nFile.startsWith(nCurWt + '/')) process.exit(0);
+
+  // file_path NOT under main repo prefix → out of scope (different drive, /tmp, etc.).
+  if (nFile !== nMain && !nFile.startsWith(nMain + '/')) process.exit(0);
+
+  // Compute relative path from main repo (case-insensitive prefix match).
+  const relFromMain = nFile === nMain ? '' : nFile.slice(nMain.length + 1);
+  if (!relFromMain) process.exit(0); // file_path == main repo root, ignore
+
+  // file_path inside another registered worktree (.claude/worktrees/<other>/) → out of scope.
+  if (relFromMain.startsWith('.claude/worktrees/')) process.exit(0);
+
+  // Build candidate path inside the current worktree using ORIGINAL casing of the relative part.
+  const origNormFile = normalize(filePath);
+  const origNormMain = normalize(mainRepo);
+  const prefixLen =
+    ci(origNormFile) === ci(origNormMain) ? origNormFile.length : origNormMain.length + 1;
+  const relPath = origNormFile.slice(prefixLen);
+  const candidate = normalize(currentWt) + (relPath ? '/' + relPath : '');
+
+  // Final condition: corresponding file/dir must exist in the worktree to count as a likely mistake.
+  let exists = false;
+  try {
+    fs.accessSync(candidate);
+    exists = true;
+  } catch {
+    /* ignore */
+  }
+  if (!exists) process.exit(0); // intentional main-only edit (e.g. shared file absent in worktree)
+
+  const lines = [
+    '[hook:validate-edit-path] WARNING: file_path points to the MAIN REPO while you are working in a registered worktree.',
+    '',
+    '  Tool:      ' + toolName,
+    '  file_path: ' + filePath,
+    '  Worktree:  ' + currentWt,
+    '  Hint:      ' + candidate,
+    '',
+    'The Edit/Write will succeed against the main repo, but subsequent bash commands run against the',
+    'worktree (CLAUDE_PROJECT_DIR: ' + projDir + '). This silent path-mismatch caused the bug in PR #241',
+    '/ Issue #243.',
+    '',
+    'NOTE: this warning is for the human operator — Claude Code does not forward exit-1 stderr',
+    'to the assistant, so the assistant will continue thinking the Edit succeeded. If you (human)',
+    'see this and the path is wrong, interrupt and have the assistant retry with the worktree path.',
+    '',
+    'If this is intentional (e.g. updating shared settings from a worktree), set',
+    'CLAUDE_ALLOW_MAIN_REPO_EDIT=1 to suppress this warning.',
+    '',
+  ];
+  process.stderr.write(lines.join('\n'));
+  process.exit(1);
+}
+
+main();

--- a/.claude/hooks/validate-edit-path.sh
+++ b/.claude/hooks/validate-edit-path.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Edit / Write tools.
+# Warns (exit 1, stderr) when the supplied file_path points to the MAIN REPO
+# while Claude is currently working in a registered git worktree. This catches
+# the silent path-mismatch pattern documented in PR #241 / Issue #243 / #246
+# where the Edit succeeds against the main repo but pwd-relative bash commands
+# run against the worktree, leading to confusing "edited but not reflected"
+# failures.
+#
+# Opt-out: set CLAUDE_ALLOW_MAIN_REPO_EDIT=1 to suppress entirely.
+#
+# This wrapper is intentionally thin: it gathers the worktree list via git and
+# delegates path normalization / detection to validate-edit-path.cjs. Tests can
+# invoke the .cjs directly with mock env vars (no git dependency).
+# The .cjs extension forces CommonJS even though the project's package.json
+# declares "type": "module".
+#
+# Exit codes:
+#   0 = OK / opt-out / outside detection scope
+#   1 = warning surfaced to user (does NOT block; tool proceeds)
+#
+# Audience: per the Claude Code hook protocol, stderr from exit-1 hooks is
+# shown to the human operator only — the assistant does not receive it.
+# This warning is intended for the human in the loop. See header comment in
+# validate-edit-path.cjs for design rationale.
+
+set -euo pipefail
+
+if [[ "${CLAUDE_ALLOW_MAIN_REPO_EDIT:-0}" == "1" ]]; then
+  exit 0
+fi
+
+proj_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# `git worktree list --porcelain` first line per entry is `worktree <abs-path>`.
+# First entry is the main worktree; the rest are registered linked worktrees.
+wt_list=$(git -C "$proj_dir" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2}' || true)
+
+if [[ -z "$wt_list" ]]; then
+  exit 0
+fi
+
+exec env \
+  CLAUDE_HOOK_PROJ_DIR="$proj_dir" \
+  CLAUDE_HOOK_WT_LIST="$wt_list" \
+  node "$(dirname "$0")/validate-edit-path.cjs"

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -108,3 +108,7 @@ test: ローテーションエンジンのユニットテスト追加 #8
 ## 自動検証
 
 `.claude/hooks/validate-branch-name.sh` と `.claude/hooks/validate-commit-message.sh` が PreToolUse hook として `git checkout -b` / `git switch -c` / `git commit` の規約違反をブロックする。
+
+加えて `.claude/hooks/validate-edit-path.sh` が `Edit` / `Write` の PreToolUse hook として、登録済み worktree で作業中に `file_path` がメインリポ側絶対パスを指し（かつ同じ相対パスのファイルが worktree 側にも存在する）場合に **警告のみ（exit 1、ブロックなし）** を出す。検出ロジックは `.claude/hooks/validate-edit-path.cjs` に実装。意図的にメインリポ側を編集したい場合は環境変数 `CLAUDE_ALLOW_MAIN_REPO_EDIT=1` で抑制できる。
+
+> **警告の受け手は人間**: Claude Code の hook 仕様では exit 1 の stderr は **人間のターミナルにだけ** 表示され、アシスタント（Claude）には届かない（届くのは exit 2 の場合）。Claude は Edit が成功したと思って続行するため、警告に気付くのは人間側。気付いたら手動で介入する（パス取り違えを Claude に伝え直す等）。将来、ブロック方式に切り替えたい場合は exit 2 へ変更する。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,6 +96,15 @@
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/validate-commit-message.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/validate-edit-path.sh"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/.claude/skills/issue-start/phases/01-issue-analysis.md
+++ b/.claude/skills/issue-start/phases/01-issue-analysis.md
@@ -17,7 +17,7 @@ git worktree list
 | pwd の状態 | 扱い |
 |---|---|
 | `git rev-parse --show-toplevel` と一致 | **メインリポ作業**: 通常通り |
-| `git worktree list` の登録 worktree と一致 | **真の worktree 作業**: **Edit/Write の `file_path` は必ずこの worktree のパスを使う。メインリポ側のパスで指定すると pwd 基準の bash 実行と乖離して『編集したはずなのに反映されない』無音失敗を起こす（PR #241 で実例）** |
+| `git worktree list` の登録 worktree と一致 | **真の worktree 作業**: **Edit/Write の `file_path` は必ずこの worktree のパスを使う。メインリポ側のパスで指定すると pwd 基準の bash 実行と乖離して『編集したはずなのに反映されない』無音失敗を起こす（PR #241 で実例）。** PreToolUse hook `.claude/hooks/validate-edit-path.sh` が同条件を検知して警告（exit 1、ブロックなし）を出す。意図的にメインリポ側を触りたい場合は `CLAUDE_ALLOW_MAIN_REPO_EDIT=1` で抑制 |
 | `.claude/worktrees/<name>/` 配下なのに **登録 worktree でない** | **亡霊 worktree モード**: 以降のすべての Edit/Write/bash 相対パスをメインリポ絶対パス基準に切り替える |
 
 ### 亡霊 worktree モードでの作業ガイド


### PR DESCRIPTION
## 概要

登録済み worktree で作業中に `Edit` / `Write` の `file_path` をメインリポ側絶対パスで誤指定する『無音失敗』（PR #241 / Issue #243 で実例）を、PreToolUse hook で検知して警告するようにした。Issue #246 の DoD をすべて満たす。

## 変更点

### 新規ファイル

- `.claude/hooks/validate-edit-path.sh`: bash ラッパー
  - `CLAUDE_ALLOW_MAIN_REPO_EDIT=1` の早期返却 / `git -C ... worktree list --porcelain` で worktree 一覧を収集 / `exec env ... node validate-edit-path.cjs` に委譲
- `.claude/hooks/validate-edit-path.cjs`: 検出ロジック（Node.js / CommonJS）
  - 拡張子は `.cjs`（`package.json` の `"type": "module"` 下で CommonJS を強制）
  - パス正規化: バックスラッシュ→スラッシュ、MSYS `/c/foo`→`c:/foo`、大文字小文字無視比較
  - 警告条件: (1) `CLAUDE_PROJECT_DIR` が登録済み worktree（メイン以外）と一致 (2) `file_path` がメインリポ側絶対パス（worktree prefix を含まない）(3) 同じ相対パスのファイルが現在の worktree にも存在
  - 3 条件すべて満たす場合のみ exit 1 + stderr に警告
- `.claude/hooks/__tests__/validate-edit-path.test.sh`: 14 ケースのユニットテスト
  - 主要パス（PRIMARY warn）、Edit/Write 両方、各種スキップ条件（非対象ツール / 空 file_path / メインリポで作業中 / worktree 内 file_path / twin なし main-only ファイル / 別 worktree path / 関係ない drive / 空 worktree list / single-entry list）、opt-out env var、バックスラッシュ path、Windows での大文字小文字違い

### 変更ファイル

- `.claude/settings.json`: `Edit|Write` matcher に hook を登録
- `.claude/rules/git-conventions.md`: 「自動検証」節に新 hook の参照と「警告の受け手は人間」note を追加
- `.claude/skills/issue-start/phases/01-issue-analysis.md`: 「真の worktree 作業」行から新 hook を相互参照

## 設計判断

### exit code = 1（仕様通り、ブロックしない）

Issue 本文の指定通り `exit 1` を採用。Claude Code の hook 仕様では exit 1 の stderr は **人間のターミナルにだけ** 表示され、アシスタント（Claude）には届かない（届くのは exit 2 ブロック時のみ）。Claude は Edit 成功と思って続行するため、警告の受け手は人間。この設計意図を `validate-edit-path.cjs` / `validate-edit-path.sh` / `git-conventions.md` に明記した。将来ブロック方式に切り替えたい場合は exit 2 へ変更可能（出口は 1 箇所）。

### `.cjs` 別ファイル化

既存 hook (`validate-branch-name.sh` 等) は bash + `node -e` パターンだが、本 hook は path 正規化・twin file 存在チェック等で Node.js ロジックが比較的長くなる。可読性とテスト容易性（`.cjs` を直接 mock env var で起動可能）のため `.sh` ラッパー + `.cjs` 本体に分割した。`.sh` 側は git 呼び出しと env 引き渡しに専念。

### Opt-out

意図的にメインリポ側を編集したい場合（共有設定の更新等）は `CLAUDE_ALLOW_MAIN_REPO_EDIT=1` を設定すれば hook 全体がスキップされる。

## テスト

ローカルで以下を実行し、すべて pass を確認：

```bash
bash .claude/hooks/__tests__/validate-edit-path.test.sh
# → 14 pass, 0 fail
bash .claude/hooks/__tests__/validate-branch-name.test.sh   # 既存テスト regression check
# → 12 pass, 0 fail
bash .claude/hooks/__tests__/validate-commit-message.test.sh # 既存テスト regression check
# → 8 pass, 0 fail
```

加えて、本番と同じ起動経路（`bash validate-edit-path.sh` を実 worktree 環境で実行）で 4 ケース（PRIMARY warn / worktree 内 file / opt-out / Bash ツール）を手動検証済み。

closes #246