### PR TITLE
fix: 黒魔道士のトランスポーズが無極性時に UB1 を付与する不具合を修正 #218

### DIFF
--- a/src/client/data/blm-skills.ts
+++ b/src/client/data/blm-skills.ts
@@ -486,9 +486,8 @@ export const BLM_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 5,
     acquiredLevel: 4,
-    // 無極性時の簡易フォールバック（実機では無極性時は何も起きないが、現行ツールの簡易挙動を維持）
-    // 実機ではトランスでサンダーヘッドは付与されない（ファイア／ブリザド系命中時のみ付与）
-    buffApplications: ["umbral-ice-1"],
+    // 無極性時は何もしない（cooldown 消費のみ）。AF/UB 中は autoTransform で隠しスキルに切替 (Issue #218)
+    buffApplications: [],
     // AF 中は UB1 へ、UB 中は AF1 へ切替
     autoTransform: [
       { buffId: "astral-fire-3", skillId: "transpose-to-ub1" },

--- a/src/client/logic/__tests__/blm-af-ub.test.ts
+++ b/src/client/logic/__tests__/blm-af-ub.test.ts
@@ -502,6 +502,21 @@ describe("BLM: トランスポーズの逆状態切替", () => {
     expect(result.entries[0].activeBuffs.some((ab) => ab.buffId === "thunderhead")).toBe(false);
   });
 
+  // 実機では無極性（AF/UB 非アクティブ）でトランスを使っても何も起きない（Issue #218）。
+  // 現行実装は UB1 を付与していたが、これを撤廃する。
+  it("無極性時のトランスは UB1 を付与しない（何も起きない）", () => {
+    const result = resolveTimeline(
+      [entry("transpose")],
+      skillMap,
+      BLM_RESOURCES,
+      undefined,
+      BLM_BUFFS,
+    );
+
+    expect(result.entries[0].activeBuffs.some((ab) => ab.buffId === "umbral-ice-1")).toBe(false);
+    expect(result.entries[0].activeBuffs.some((ab) => ab.buffId === "astral-fire-1")).toBe(false);
+  });
+
   it("AF 中のトランス（→UB1）はサンダーヘッドを再付与しない", () => {
     const result = resolveTimeline(
       [entry("fire-3"), entry("transpose")],


### PR DESCRIPTION
## 概要

黒魔道士のトランスポーズ (`transpose`) が無極性（AF/UB 非アクティブ）状態で使用された場合に `umbral-ice-1` を誤って付与していた不具合を修正する。実機では無極性時のトランスは何も起きず cooldown のみ消費されるのが正しい挙動。AF/UB 中の `autoTransform` による逆状態（UB1/AF1）への切替は既存通り維持。

## 変更点

- `src/client/data/blm-skills.ts`: `transpose` の `buffApplications` を `["umbral-ice-1"]` から `[]` に変更し、無極性時は no-op になるよう修正。コメントを「無極性時は何もしない（cooldown 消費のみ）」と「なぜそうしたか」が分かる文言に更新。
- `src/client/logic/__tests__/blm-af-ub.test.ts`: 「無極性時のトランスは UB1 を付与しない（何も起きない）」テストを追加。`umbral-ice-1` および `astral-fire-1` がいずれも非付与であることを検証。

## テスト

- `npm test --run` 全121テスト通過（新規1件含む）
- `npx tsc --noEmit` 型エラーなし
- 既存テスト「無極性時のトランスはサンダーヘッドを付与しない」(#219 由来) と独立した期待値で衝突なし
- AF/UB 中の `autoTransform` 経路（`transpose-to-ub1` / `transpose-to-af1`）は `resolve-timeline.ts` の autoTransform 処理が `buffApplications` に依存しないため影響なし

closes #218
