### PR TITLE
feat: 侍（SAM）ジョブを追加 #255

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -17,12 +17,15 @@ import { PCT_BUFFS } from "../data/pct-buffs";
 import { BLM_ATTACK_SKILLS } from "../data/blm-skills";
 import { BLM_RESOURCES } from "../data/blm-resources";
 import { BLM_BUFFS } from "../data/blm-buffs";
+import { SAM_ATTACK_SKILLS } from "../data/sam-skills";
+import { SAM_RESOURCES } from "../data/sam-resources";
+import { SAM_BUFFS } from "../data/sam-buffs";
 import { DEFAULT_STATS, calcExpectedMultiplier } from "../logic/stat-calc";
 import { getSkillsForLevel, getBuffsForLevel, getResourcesForLevel } from "../logic/skill-level";
 import type { Skill, BuffDefinition, ResourceDefinition, TimelineEntry, CharacterStats, BossUntargetableWindow, PpsRange, PlayerLevel } from "../types/skill";
 
 /** ジョブID */
-export type JobId = "whm" | "drg" | "brd" | "pct" | "blm";
+export type JobId = "whm" | "drg" | "brd" | "pct" | "blm" | "sam";
 
 /** ジョブデータ定義 */
 interface JobData {
@@ -40,6 +43,7 @@ const JOB_DATA: Record<JobId, JobData> = {
   brd: { name: "詩人", abbreviation: "BRD", skills: BRD_ATTACK_SKILLS, buffs: BRD_BUFFS, resources: BRD_RESOURCES },
   pct: { name: "ピクトマンサー", abbreviation: "PCT", skills: PCT_ATTACK_SKILLS, buffs: PCT_BUFFS, resources: PCT_RESOURCES },
   blm: { name: "黒魔道士", abbreviation: "BLM", skills: BLM_ATTACK_SKILLS, buffs: BLM_BUFFS, resources: BLM_RESOURCES },
+  sam: { name: "侍", abbreviation: "SAM", skills: SAM_ATTACK_SKILLS, buffs: SAM_BUFFS, resources: SAM_RESOURCES },
 };
 
 let nextUid = 1;

--- a/src/client/components/SkillPalette.tsx
+++ b/src/client/components/SkillPalette.tsx
@@ -12,6 +12,7 @@ const JOBS: { id: JobId; name: string }[] = [
   { id: "brd", name: "詩人" },
   { id: "pct", name: "ピクトマンサー" },
   { id: "blm", name: "黒魔道士" },
+  { id: "sam", name: "侍" },
 ];
 
 interface CollapsibleSectionProps {

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -68,7 +68,7 @@ function calcInsertIndex(
   scrollLeft: number,
   resolvedEntries: ResolvedTimelineEntry[],
   skillMap: Map<string, Skill>,
-  recastFn: (skill: Skill, activeBuffs: ActiveBuff[]) => number
+  recastFn: (entry: ResolvedTimelineEntry, skill: Skill) => number
 ): number {
   // タイムラインコンテンツ上の実際のX座標（スクロール考慮、レーンラベル分を引く）
   const contentX = mouseX + scrollLeft - LANE_LABEL_WIDTH;
@@ -81,7 +81,7 @@ function calcInsertIndex(
     const entry = resolvedEntries[i];
     const skill = skillMap.get(entry.skillId);
     if (!skill) continue;
-    const centerTime = entry.startTime + recastFn(skill, entry.activeBuffs) / 2;
+    const centerTime = entry.startTime + recastFn(entry, skill) / 2;
     if (time < centerTime) {
       return i;
     }
@@ -202,23 +202,24 @@ export function Timeline({
   );
 
   /** エントリのアクティブバフを考慮したリキャスト計算 */
-  const getEntryRecastTime = useCallback(
-    (skill: Skill, activeBuffs: ActiveBuff[]) => {
-      let recast = getRecastTime(skill);
-      if (skill.type === "gcd" && activeBuffs.length > 0) {
-        for (const ab of activeBuffs) {
-          const def = buffDefMap.get(ab.buffId);
-          if (!def) continue;
-          for (const effect of def.effects) {
-            if (effect.type === "speed") {
-              recast = Math.round(recast * effect.value * 1000) / 1000;
-            }
-          }
-        }
+  /**
+   * 既存エントリのリキャスト時間を resolve-timeline 側の計算結果から取得する。
+   * GCD: gcdAvailableAt - startTime（自スキル付与の speed バフは除外済み = 実機準拠）
+   * oGCD: スキル固有の recastTime（gcdAvailableAt は前 GCD 由来のため使えない）
+   *
+   * 注意: entry.activeBuffs から自前で speed を再計算するのは NG。
+   * activeBuffs は実行"直後"のバフを含むため、当該スキル自身が付与した speed
+   * バフが二重計算されて視覚的なリキャストバーと resolve-timeline の startTime
+   * が乖離する（侍の士風→風花のように、自スキルが付与する速度バフを持つ場合）。
+   */
+  const getResolvedEntryRecast = useCallback(
+    (entry: ResolvedTimelineEntry, skill: Skill) => {
+      if (skill.type === "gcd") {
+        return Math.round((entry.gcdAvailableAt - entry.startTime) * 1000) / 1000;
       }
-      return recast;
+      return getRecastTime(skill);
     },
-    [getRecastTime, buffDefMap]
+    [getRecastTime]
   );
 
   const gcdEntries: (ResolvedTimelineEntry & { skill: Skill; displaySkill: Skill })[] = [];
@@ -306,7 +307,7 @@ export function Timeline({
     for (const entry of resolvedEntries) {
       const skill = skillMap.get(entry.skillId);
       if (!skill) continue;
-      const end = entry.startTime + getEntryRecastTime(skill, entry.activeBuffs);
+      const end = entry.startTime + getResolvedEntryRecast(entry, skill);
       if (end > maxEnd) maxEnd = end;
       // バフ終了時刻も考慮（永続バフ= endTime が Infinity はタイムライン幅に影響させない）
       for (const ab of entry.activeBuffs) {
@@ -329,7 +330,7 @@ export function Timeline({
       }
     }
     return maxEnd;
-  }, [resolvedEntries, skillMap, getEntryRecastTime, activeDoTs, untargetableWindows, cooldownSpans]);
+  }, [resolvedEntries, skillMap, getResolvedEntryRecast, activeDoTs, untargetableWindows, cooldownSpans]);
 
   const timelineWidth = Math.max(totalDuration * PX_PER_SEC + 100, 600);
 
@@ -350,14 +351,14 @@ export function Timeline({
     if (scrollRef.current && resolvedEntries.length > 0) {
       const last = resolvedEntries[resolvedEntries.length - 1];
       const skill = skillMap.get(last.skillId);
-      const recast = skill ? getEntryRecastTime(skill, last.activeBuffs) : 0;
+      const recast = skill ? getResolvedEntryRecast(last, skill) : 0;
       const endPx = (last.startTime + recast) * PX_PER_SEC;
       const container = scrollRef.current;
       if (endPx > container.scrollLeft + container.clientWidth - 100) {
         container.scrollLeft = endPx - container.clientWidth + 150;
       }
     }
-  }, [resolvedEntries, skillMap, getEntryRecastTime]);
+  }, [resolvedEntries, skillMap, getResolvedEntryRecast]);
 
   /** ドラッグ中のスキルタイプを検出 */
   const detectDragType = useCallback((e: React.DragEvent): "gcd" | "ogcd" => {
@@ -470,7 +471,7 @@ export function Timeline({
    * GCDリキャスト中のウィービング位置を正しく判定する。
    */
   const getAnimLockWidth = useCallback(
-    (skill: Skill, _activeBuffs: ActiveBuff[]): number => skill.animationLock,
+    (_entry: ResolvedTimelineEntry, skill: Skill): number => skill.animationLock,
     []
   );
 
@@ -485,12 +486,12 @@ export function Timeline({
   const calcCombinedInsertIndex = useCallback(
     (mouseX: number, scrollLeft: number, type: "gcd" | "ogcd"): number => {
       if (type === "gcd") {
-        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, visibleGcdEntriesForInsert, skillMap, getEntryRecastTime);
+        const gcdIdx = calcInsertIndex(mouseX, scrollLeft, visibleGcdEntriesForInsert, skillMap, getResolvedEntryRecast);
         return mapGcdIndexToInsertion(gcdIdx);
       }
       return calcInsertIndex(mouseX, scrollLeft, visibleEntriesForInsert, skillMap, getAnimLockWidth);
     },
-    [visibleEntriesForInsert, visibleGcdEntriesForInsert, skillMap, getEntryRecastTime, getAnimLockWidth, mapGcdIndexToInsertion]
+    [visibleEntriesForInsert, visibleGcdEntriesForInsert, skillMap, getResolvedEntryRecast, getAnimLockWidth, mapGcdIndexToInsertion]
   );
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -919,7 +920,7 @@ export function Timeline({
                 <div style={styles.laneContent}>
                   {gcdEntries.map((entry) => {
                     const hasError = entriesWithErrors.has(entry.uid);
-                    const recast = getEntryRecastTime(entry.skill, entry.activeBuffs);
+                    const recast = getResolvedEntryRecast(entry, entry.skill);
                     const castTime = entry.castTime;
                     const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
                     const entryExpMul = stats ? calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus) : null;

--- a/src/client/data/sam-buffs.ts
+++ b/src/client/data/sam-buffs.ts
@@ -68,7 +68,7 @@ export const SAM_BUFFS: BuffDefinition[] = [
   },
 
   // ============================================================
-  // 明鏡止水（コンボ条件無視 + GCDで自動消費）
+  // 明鏡止水（コンボ条件無視 + GCDで自動消費 + 月光/満月/花車/桜花使用時に風月/風花付与）
   // ============================================================
   {
     id: "meikyo-shisui",
@@ -86,6 +86,20 @@ export const SAM_BUFFS: BuffDefinition[] = [
         type: "consumeOnGcd",
         value: 1,
         appliesToSkillIds: MEIKYO_BYPASS_TARGETS,
+      },
+      // 月光（単体コンボ最終段）・満月（範囲コンボ最終段）時に風月バフ付与
+      {
+        type: "applyBuffOnSkill",
+        value: 1,
+        appliesToSkillIds: ["gekko", "mangetsu"],
+        appliedBuffId: "fugetsu",
+      },
+      // 花車・桜花使用時に風花バフ付与
+      {
+        type: "applyBuffOnSkill",
+        value: 1,
+        appliesToSkillIds: ["kasha", "oka"],
+        appliedBuffId: "fuka",
       },
     ],
     color: "#26c6da",

--- a/src/client/data/sam-buffs.ts
+++ b/src/client/data/sam-buffs.ts
@@ -1,0 +1,219 @@
+import type { BuffDefinition } from "../types/skill";
+
+import jinpuIcon from "../assets/icons/sam/Jinpu.png";
+import shifuIcon from "../assets/icons/sam/Shifu.png";
+import meikyoShisuiIcon from "../assets/icons/sam/Meikyo_Shisui.png";
+import ikishotenIcon from "../assets/icons/sam/Ikishoten.png";
+import zanshinIcon from "../assets/icons/sam/Zanshin.png";
+import ogiNamikiriIcon from "../assets/icons/sam/Ogi_Namikiri.png";
+import kaeshiGokenIcon from "../assets/icons/sam/Kaeshi_Goken.png";
+import kaeshiSetsugekkaIcon from "../assets/icons/sam/Kaeshi_Setsugekka.png";
+import tendoKaeshiGokenIcon from "../assets/icons/sam/Tendo_Kaeshi_Goken.png";
+import tendoKaeshiSetsugekkaIcon from "../assets/icons/sam/Tendo_Kaeshi_Setsugekka.png";
+import kaeshiNamikiriIcon from "../assets/icons/sam/Kaeshi_Namikiri.png";
+import tendoSetsugekkaIcon from "../assets/icons/sam/Tendo_Setsugekka.png";
+import enpiIcon from "../assets/icons/sam/Enpi.png";
+
+/**
+ * 明鏡止水でコンボ条件無視（bypassCombo）の対象となるWS群。
+ * - 1段目（刃風/暁風/風雅/風光）は comboFrom を持たないのでバイパス不要
+ * - 2段目（陣風/士風/雪風/満月/桜花）と 3段目（月光/花車）が対象
+ */
+const MEIKYO_BYPASS_TARGETS = [
+  "jinpu",
+  "shifu",
+  "yukikaze",
+  "gekko",
+  "kasha",
+  "mangetsu",
+  "oka",
+];
+
+/**
+ * 侍（SAM）バフ定義
+ */
+export const SAM_BUFFS: BuffDefinition[] = [
+  // ============================================================
+  // コンボ完走で付与される自己バフ
+  // ============================================================
+  {
+    id: "fugetsu",
+    name: "風月",
+    shortName: "風月",
+    icon: jinpuIcon,
+    duration: 40,
+    effects: [
+      {
+        type: "potency",
+        value: 1.13,
+      },
+    ],
+    color: "#1976d2",
+    acquiredLevel: 4,
+  },
+  {
+    id: "fuka",
+    name: "風花",
+    shortName: "風花",
+    icon: shifuIcon,
+    duration: 40,
+    effects: [
+      {
+        type: "speed",
+        value: 0.87,
+      },
+    ],
+    color: "#7e57c2",
+    acquiredLevel: 18,
+  },
+
+  // ============================================================
+  // 明鏡止水（コンボ条件無視 + GCDで自動消費）
+  // ============================================================
+  {
+    id: "meikyo-shisui",
+    name: "明鏡止水",
+    shortName: "明鏡\n止水",
+    icon: meikyoShisuiIcon,
+    duration: 20,
+    effects: [
+      {
+        type: "bypassCombo",
+        value: 1,
+        appliesToSkillIds: MEIKYO_BYPASS_TARGETS,
+      },
+      {
+        type: "consumeOnGcd",
+        value: 1,
+        appliesToSkillIds: MEIKYO_BYPASS_TARGETS,
+      },
+    ],
+    color: "#26c6da",
+    maxStacks: 3,
+    acquiredLevel: 50,
+  },
+
+  // ============================================================
+  // 天道（Lv100、明鏡止水使用時に同時付与。次の居合術が天道版に変化）
+  // ============================================================
+  {
+    id: "tendo",
+    name: "天道",
+    shortName: "天道",
+    icon: tendoSetsugekkaIcon,
+    duration: 30,
+    effects: [],
+    color: "#ffd54f",
+    maxStacks: 1,
+    acquiredLevel: 100,
+  },
+
+  // ============================================================
+  // 意気衝天（燕飛使用可）
+  // ============================================================
+  {
+    id: "ikishoten-buff",
+    name: "意気衝天効果",
+    shortName: "意気\n衝天",
+    icon: enpiIcon,
+    duration: 30,
+    effects: [],
+    color: "#ff7043",
+    maxStacks: 1,
+    acquiredLevel: 68,
+  },
+
+  // ============================================================
+  // 奥義波切実行可（Lv90、意気衝天で付与）
+  // ============================================================
+  {
+    id: "ogi-namikiri-ready",
+    name: "奥義波切実行可",
+    shortName: "奥義\nﾚﾃﾞｨ",
+    icon: ogiNamikiriIcon,
+    duration: 30,
+    effects: [],
+    color: "#ec407a",
+    maxStacks: 1,
+    acquiredLevel: 90,
+  },
+
+  // ============================================================
+  // 残心実行可（Lv96、意気衝天で付与）
+  // ============================================================
+  {
+    id: "zanshin-ready",
+    name: "残心実行可",
+    shortName: "残心\nﾚﾃﾞｨ",
+    icon: zanshinIcon,
+    duration: 30,
+    effects: [],
+    color: "#ab47bc",
+    maxStacks: 1,
+    acquiredLevel: 96,
+  },
+
+  // ============================================================
+  // 燕返し系 Ready バフ（5種、exclusiveGroup="tsubame-ready" で排他）
+  // ============================================================
+  {
+    id: "tsubame-kaeshi-goken-ready",
+    name: "返し五剣準備",
+    shortName: "返五剣\nﾚﾃﾞｨ",
+    icon: kaeshiGokenIcon,
+    duration: 60,
+    effects: [],
+    color: "#42a5f5",
+    maxStacks: 1,
+    acquiredLevel: 76,
+    exclusiveGroup: "tsubame-ready",
+  },
+  {
+    id: "tsubame-kaeshi-setsugekka-ready",
+    name: "返し雪月花準備",
+    shortName: "返雪月\nﾚﾃﾞｨ",
+    icon: kaeshiSetsugekkaIcon,
+    duration: 60,
+    effects: [],
+    color: "#5c6bc0",
+    maxStacks: 1,
+    acquiredLevel: 76,
+    exclusiveGroup: "tsubame-ready",
+  },
+  {
+    id: "tsubame-tendo-kaeshi-goken-ready",
+    name: "天道返し五剣準備",
+    shortName: "天道\n返五剣",
+    icon: tendoKaeshiGokenIcon,
+    duration: 60,
+    effects: [],
+    color: "#ffa726",
+    maxStacks: 1,
+    acquiredLevel: 100,
+    exclusiveGroup: "tsubame-ready",
+  },
+  {
+    id: "tsubame-tendo-kaeshi-setsugekka-ready",
+    name: "天道返し雪月花準備",
+    shortName: "天道\n返雪月",
+    icon: tendoKaeshiSetsugekkaIcon,
+    duration: 60,
+    effects: [],
+    color: "#ffb74d",
+    maxStacks: 1,
+    acquiredLevel: 100,
+    exclusiveGroup: "tsubame-ready",
+  },
+  {
+    id: "tsubame-kaeshi-namikiri-ready",
+    name: "返し波切準備",
+    shortName: "返波切\nﾚﾃﾞｨ",
+    icon: kaeshiNamikiriIcon,
+    duration: 60,
+    effects: [],
+    color: "#26a69a",
+    maxStacks: 1,
+    acquiredLevel: 90,
+    exclusiveGroup: "tsubame-ready",
+  },
+];

--- a/src/client/data/sam-resources.ts
+++ b/src/client/data/sam-resources.ts
@@ -1,0 +1,72 @@
+import type { ResourceDefinition } from "../types/skill";
+
+/**
+ * 侍（SAM）リソース定義
+ *
+ * - 剣気（Kenki）: WSコンボ完走・必殺剣使用で増減（最大100）
+ * - 閃（Sen）: 雪・月・花の3種。WSコンボ完走で1つ付与、居合術で消費（合計最大3）
+ *   雪/月/花は1つの「閃」レーンに統合表示する
+ * - 剣圧（Meditation）: 居合術・燕返し・奥義波切で+1（最大3、Lv90以降）
+ */
+export const SAM_RESOURCES: ResourceDefinition[] = [
+  // ============================================================
+  // 剣気ゲージ
+  // ============================================================
+  {
+    id: "kenki",
+    name: "剣気",
+    shortName: "剣気",
+    maxStacks: 100,
+    color: "#d32f2f",
+    acquiredLevel: 4,
+  },
+
+  // ============================================================
+  // 閃（雪・月・花）— 1レーンに統合表示
+  // ============================================================
+  {
+    id: "setsu",
+    name: "雪閃",
+    shortName: "雪",
+    maxStacks: 1,
+    color: "#e1f5fe",
+    acquiredLevel: 50,
+    displayGroup: "sen",
+    groupMaxStacks: 3,
+    displayGroupPriority: 1,
+  },
+  {
+    id: "getsu",
+    name: "月閃",
+    shortName: "月",
+    maxStacks: 1,
+    color: "#ffeb3b",
+    acquiredLevel: 30,
+    displayGroup: "sen",
+    groupMaxStacks: 3,
+    displayGroupPriority: 2,
+  },
+  {
+    id: "ka",
+    name: "花閃",
+    shortName: "花",
+    maxStacks: 1,
+    color: "#ec407a",
+    acquiredLevel: 40,
+    displayGroup: "sen",
+    groupMaxStacks: 3,
+    displayGroupPriority: 3,
+  },
+
+  // ============================================================
+  // 剣圧（Meditation）
+  // ============================================================
+  {
+    id: "meditation",
+    name: "剣圧",
+    shortName: "剣圧",
+    maxStacks: 3,
+    color: "#ff6f00",
+    acquiredLevel: 90,
+  },
+];

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -428,6 +428,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
       { buffId: "tsubame-kaeshi-namikiri-ready", skillId: "kaeshi-namikiri" },
     ],
   },
+  // 燕返し系は剣圧を付与しない（実機: 剣圧は居合術系と奥義波切のみで付与）
   {
     id: "kaeshi-goken",
     name: "返し五剣",
@@ -441,7 +442,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     hidden: true,
     requiredBuff: "tsubame-kaeshi-goken-ready",
     buffConsumptions: [{ buffId: "tsubame-kaeshi-goken-ready", stacks: 1 }],
-    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
   },
   {
     id: "kaeshi-setsugekka",
@@ -457,7 +457,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     guaranteedCrit: true,
     requiredBuff: "tsubame-kaeshi-setsugekka-ready",
     buffConsumptions: [{ buffId: "tsubame-kaeshi-setsugekka-ready", stacks: 1 }],
-    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
   },
   {
     id: "tendo-kaeshi-goken",
@@ -472,7 +471,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     hidden: true,
     requiredBuff: "tsubame-tendo-kaeshi-goken-ready",
     buffConsumptions: [{ buffId: "tsubame-tendo-kaeshi-goken-ready", stacks: 1 }],
-    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
   },
   {
     id: "tendo-kaeshi-setsugekka",
@@ -488,7 +486,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     guaranteedCrit: true,
     requiredBuff: "tsubame-tendo-kaeshi-setsugekka-ready",
     buffConsumptions: [{ buffId: "tsubame-tendo-kaeshi-setsugekka-ready", stacks: 1 }],
-    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
   },
   {
     id: "kaeshi-namikiri",
@@ -505,7 +502,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     guaranteedDh: true,
     requiredBuff: "tsubame-kaeshi-namikiri-ready",
     buffConsumptions: [{ buffId: "tsubame-kaeshi-namikiri-ready", stacks: 1 }],
-    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
   },
 
   // ============================================================

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -128,9 +128,10 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     ],
   },
   {
+    // 月光: コンボ成立時威力 370 + 背面ボーナス 50 = 420（方向指定成功前提）
     id: "gekko",
     name: "月光",
-    potency: 370,
+    potency: 420,
     nonComboPotency: 170,
     type: "gcd",
     target: "enemy",
@@ -145,9 +146,10 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     ],
   },
   {
+    // 花車: コンボ成立時威力 370 + 側面ボーナス 50 = 420（方向指定成功前提）
     id: "kasha",
     name: "花車",
-    potency: 370,
+    potency: 420,
     nonComboPotency: 170,
     type: "gcd",
     target: "enemy",

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -129,6 +129,8 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
   },
   {
     // 月光: コンボ成立時威力 370 + 背面ボーナス 50 = 420（方向指定成功前提）
+    // コンボ成立時に風月バフを付与（実機: 陣風→月光で duration リフレッシュ。明鏡止水で
+    // 陣風をスキップして直接月光を撃った場合も風月が付与される）
     id: "gekko",
     name: "月光",
     potency: 420,
@@ -140,6 +142,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 30,
     comboFrom: ["jinpu"],
+    comboBuffApplications: ["fugetsu"],
     comboResourceChanges: [
       { resourceId: "getsu", amount: 1 },
       { resourceId: "kenki", amount: 10 },
@@ -147,6 +150,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
   },
   {
     // 花車: コンボ成立時威力 370 + 側面ボーナス 50 = 420（方向指定成功前提）
+    // コンボ成立時に風花バフを付与（月光と同様の理由）
     id: "kasha",
     name: "花車",
     potency: 420,
@@ -158,6 +162,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 40,
     comboFrom: ["shifu"],
+    comboBuffApplications: ["fuka"],
     comboResourceChanges: [
       { resourceId: "ka", amount: 1 },
       { resourceId: "kenki", amount: 10 },

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -129,8 +129,8 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
   },
   {
     // 月光: コンボ成立時威力 370 + 背面ボーナス 50 = 420（方向指定成功前提）
-    // コンボ成立時に風月バフを付与（実機: 陣風→月光で duration リフレッシュ。明鏡止水で
-    // 陣風をスキップして直接月光を撃った場合も風月が付与される）
+    // 風月バフは陣風（2段目）のみが付与する。明鏡止水中の月光時の風月付与は、
+    // 明鏡止水バフ側の applyBuffOnSkill エフェクトで表現する（sam-buffs.ts）。
     id: "gekko",
     name: "月光",
     potency: 420,
@@ -142,7 +142,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 30,
     comboFrom: ["jinpu"],
-    comboBuffApplications: ["fugetsu"],
     comboResourceChanges: [
       { resourceId: "getsu", amount: 1 },
       { resourceId: "kenki", amount: 10 },
@@ -150,7 +149,8 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
   },
   {
     // 花車: コンボ成立時威力 370 + 側面ボーナス 50 = 420（方向指定成功前提）
-    // コンボ成立時に風花バフを付与（月光と同様の理由）
+    // 風花バフは士風（2段目）のみが付与する。明鏡止水中の花車時の風花付与は、
+    // 明鏡止水バフ側の applyBuffOnSkill エフェクトで表現する（sam-buffs.ts）。
     id: "kasha",
     name: "花車",
     potency: 420,
@@ -162,7 +162,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 40,
     comboFrom: ["shifu"],
-    comboBuffApplications: ["fuka"],
     comboResourceChanges: [
       { resourceId: "ka", amount: 1 },
       { resourceId: "kenki", amount: 10 },
@@ -198,6 +197,8 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     resourceChanges: [{ resourceId: "kenki", amount: 10 }],
   },
   {
+    // 満月: 範囲コンボ最終段。通常コンボ完走では風月バフは付与されない。
+    // 明鏡止水中の満月時の風月付与は、明鏡止水バフ側の applyBuffOnSkill で表現する。
     id: "mangetsu",
     name: "満月",
     potency: 120,
@@ -209,13 +210,13 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 35,
     comboFrom: ["fuga", "fuko"],
-    comboBuffApplications: ["fugetsu"],
     comboResourceChanges: [
       { resourceId: "getsu", amount: 1 },
       { resourceId: "kenki", amount: 10 },
     ],
   },
   {
+    // 桜花: 範囲コンボ最終段。風花バフ付与の扱いは満月と同様（明鏡止水バフ側で表現）。
     id: "oka",
     name: "桜花",
     potency: 120,
@@ -227,7 +228,6 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     animationLock: 0.65,
     acquiredLevel: 45,
     comboFrom: ["fuga", "fuko"],
-    comboBuffApplications: ["fuka"],
     comboResourceChanges: [
       { resourceId: "ka", amount: 1 },
       { resourceId: "kenki", amount: 10 },

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -538,7 +538,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     recastTime: 1.0,
     animationLock: 0.65,
     acquiredLevel: 54,
-    cooldown: 10,
+    cooldown: 5,
     resourceChanges: [{ resourceId: "kenki", amount: -10 }],
   },
   {

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -1,0 +1,671 @@
+import type { Skill } from "../types/skill";
+
+import hakazeIcon from "../assets/icons/sam/Hakaze.png";
+import gyofuIcon from "../assets/icons/sam/Gyofu.png";
+import jinpuIcon from "../assets/icons/sam/Jinpu.png";
+import shifuIcon from "../assets/icons/sam/Shifu.png";
+import gekkoIcon from "../assets/icons/sam/Gekko.png";
+import kashaIcon from "../assets/icons/sam/Kasha.png";
+import yukikazeIcon from "../assets/icons/sam/Yukikaze.png";
+import fugaIcon from "../assets/icons/sam/Fuga.png";
+import fukoIcon from "../assets/icons/sam/Fuko.png";
+import mangetsuIcon from "../assets/icons/sam/Mangetsu.png";
+import okaIcon from "../assets/icons/sam/Oka.png";
+
+import iaijutsuIcon from "../assets/icons/sam/Iaijutsu.png";
+import higanbanaIcon from "../assets/icons/sam/Higanbana.png";
+import tenkaGokenIcon from "../assets/icons/sam/Tenka_Goken.png";
+import midareSetsugekkaIcon from "../assets/icons/sam/Midare_Setsugekka.png";
+import tendoGokenIcon from "../assets/icons/sam/Tendo_Goken.png";
+import tendoSetsugekkaIcon from "../assets/icons/sam/Tendo_Setsugekka.png";
+
+import tsubameGaeshiIcon from "../assets/icons/sam/Tsubame-gaeshi.png";
+import kaeshiGokenIcon from "../assets/icons/sam/Kaeshi_Goken.png";
+import kaeshiSetsugekkaIcon from "../assets/icons/sam/Kaeshi_Setsugekka.png";
+import tendoKaeshiGokenIcon from "../assets/icons/sam/Tendo_Kaeshi_Goken.png";
+import tendoKaeshiSetsugekkaIcon from "../assets/icons/sam/Tendo_Kaeshi_Setsugekka.png";
+import kaeshiNamikiriIcon from "../assets/icons/sam/Kaeshi_Namikiri.png";
+
+import ogiNamikiriIcon from "../assets/icons/sam/Ogi_Namikiri.png";
+import enpiIcon from "../assets/icons/sam/Enpi.png";
+import shohaIcon from "../assets/icons/sam/Shoha.png";
+
+import hissatsuGyotenIcon from "../assets/icons/sam/Hissatsu_Gyoten.png";
+import hissatsuYatenIcon from "../assets/icons/sam/Hissatsu_Yaten.png";
+import hissatsuShintenIcon from "../assets/icons/sam/Hissatsu_Shinten.png";
+import hissatsuSeneiIcon from "../assets/icons/sam/Hissatsu_Senei.png";
+import ikishotenIcon from "../assets/icons/sam/Ikishoten.png";
+import hagakureIcon from "../assets/icons/sam/Hagakure.png";
+import meikyoShisuiIcon from "../assets/icons/sam/Meikyo_Shisui.png";
+import zanshinIcon from "../assets/icons/sam/Zanshin.png";
+
+/**
+ * 侍（SAM）攻撃スキル定義（Lv100まで）
+ *
+ * 大別:
+ * 1. 単体WSコンボ（月/花/雪の3系統、起点共通の刃風）
+ * 2. 範囲WSコンボ（風雅 → 満月/桜花）
+ * 3. 居合術系（autoTransform で閃数＋天道バフに応じて変化）
+ * 4. 燕返し系（autoTransform で Ready バフに応じて変化、5種）
+ * 5. 奥義波切系（Lv90、確定クリ）
+ * 6. 必殺剣系（剣気消費 oGCD/GCD）
+ * 7. その他（意気衝天・葉隠・明鏡止水・残心・燕飛・照破）
+ */
+export const SAM_ATTACK_SKILLS: Skill[] = [
+  // ============================================================
+  // 1. 単体 WS コンボ（起点共通）
+  // ============================================================
+  {
+    id: "hakaze",
+    name: "刃風",
+    potency: 200,
+    type: "gcd",
+    target: "enemy",
+    icon: hakazeIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    resourceChanges: [{ resourceId: "kenki", amount: 5 }],
+  },
+  {
+    id: "gyofu",
+    name: "暁風",
+    potency: 240,
+    type: "gcd",
+    target: "enemy",
+    icon: gyofuIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 92,
+    replacesSkillId: "hakaze",
+    resourceChanges: [{ resourceId: "kenki", amount: 5 }],
+  },
+  {
+    id: "jinpu",
+    name: "陣風",
+    potency: 300,
+    nonComboPotency: 120,
+    type: "gcd",
+    target: "enemy",
+    icon: jinpuIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 4,
+    comboFrom: ["hakaze", "gyofu"],
+    comboBuffApplications: ["fugetsu"],
+    comboResourceChanges: [{ resourceId: "kenki", amount: 5 }],
+  },
+  {
+    id: "shifu",
+    name: "士風",
+    potency: 300,
+    nonComboPotency: 120,
+    type: "gcd",
+    target: "enemy",
+    icon: shifuIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 18,
+    comboFrom: ["hakaze", "gyofu"],
+    comboBuffApplications: ["fuka"],
+    comboResourceChanges: [{ resourceId: "kenki", amount: 5 }],
+  },
+  {
+    id: "yukikaze",
+    name: "雪風",
+    potency: 340,
+    nonComboPotency: 160,
+    type: "gcd",
+    target: "enemy",
+    icon: yukikazeIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 50,
+    comboFrom: ["hakaze", "gyofu"],
+    comboResourceChanges: [
+      { resourceId: "setsu", amount: 1 },
+      { resourceId: "kenki", amount: 10 },
+    ],
+  },
+  {
+    id: "gekko",
+    name: "月光",
+    potency: 370,
+    nonComboPotency: 170,
+    type: "gcd",
+    target: "enemy",
+    icon: gekkoIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 30,
+    comboFrom: ["jinpu"],
+    comboResourceChanges: [
+      { resourceId: "getsu", amount: 1 },
+      { resourceId: "kenki", amount: 10 },
+    ],
+  },
+  {
+    id: "kasha",
+    name: "花車",
+    potency: 370,
+    nonComboPotency: 170,
+    type: "gcd",
+    target: "enemy",
+    icon: kashaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 40,
+    comboFrom: ["shifu"],
+    comboResourceChanges: [
+      { resourceId: "ka", amount: 1 },
+      { resourceId: "kenki", amount: 10 },
+    ],
+  },
+
+  // ============================================================
+  // 2. 範囲 WS コンボ
+  // ============================================================
+  {
+    id: "fuga",
+    name: "風雅",
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: fugaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 26,
+    resourceChanges: [{ resourceId: "kenki", amount: 5 }],
+  },
+  {
+    id: "fuko",
+    name: "風光",
+    potency: 120,
+    type: "gcd",
+    target: "enemy",
+    icon: fukoIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 86,
+    replacesSkillId: "fuga",
+    resourceChanges: [{ resourceId: "kenki", amount: 10 }],
+  },
+  {
+    id: "mangetsu",
+    name: "満月",
+    potency: 120,
+    nonComboPotency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: mangetsuIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 35,
+    comboFrom: ["fuga", "fuko"],
+    comboBuffApplications: ["fugetsu"],
+    comboResourceChanges: [
+      { resourceId: "getsu", amount: 1 },
+      { resourceId: "kenki", amount: 10 },
+    ],
+  },
+  {
+    id: "oka",
+    name: "桜花",
+    potency: 120,
+    nonComboPotency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: okaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 45,
+    comboFrom: ["fuga", "fuko"],
+    comboBuffApplications: ["fuka"],
+    comboResourceChanges: [
+      { resourceId: "ka", amount: 1 },
+      { resourceId: "kenki", amount: 10 },
+    ],
+  },
+
+  // ============================================================
+  // 3. 居合術系（パレット用 + 隠しスキル）
+  // ============================================================
+  {
+    id: "iaijutsu",
+    name: "居合術",
+    potency: 0,
+    type: "gcd",
+    target: "enemy",
+    icon: iaijutsuIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 6,
+    castTime: 1.3,
+    // 配列の先頭から優先評価。3閃天道 > 2閃天道 > 3閃通常 > 2閃通常 > 1閃 の順
+    autoTransform: [
+      // 天道 + 3閃 → 天道雪月花
+      {
+        buffId: "tendo",
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "getsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "tendo-setsugekka",
+      },
+      // 天道 + 2閃（3通り）→ 天道五剣
+      {
+        buffId: "tendo",
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "getsu", minAmount: 1 },
+        ],
+        skillId: "tendo-goken",
+      },
+      {
+        buffId: "tendo",
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "tendo-goken",
+      },
+      {
+        buffId: "tendo",
+        resourceConditions: [
+          { resourceId: "getsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "tendo-goken",
+      },
+      // 通常 3閃 → 乱れ雪月花
+      {
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "getsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "midare-setsugekka",
+      },
+      // 通常 2閃（3通り）→ 天下五剣
+      {
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "getsu", minAmount: 1 },
+        ],
+        skillId: "tenka-goken",
+      },
+      {
+        resourceConditions: [
+          { resourceId: "setsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "tenka-goken",
+      },
+      {
+        resourceConditions: [
+          { resourceId: "getsu", minAmount: 1 },
+          { resourceId: "ka", minAmount: 1 },
+        ],
+        skillId: "tenka-goken",
+      },
+      // 通常 1閃（3通り）→ 彼岸花
+      { resourceConditions: [{ resourceId: "setsu", minAmount: 1 }], skillId: "higanbana" },
+      { resourceConditions: [{ resourceId: "getsu", minAmount: 1 }], skillId: "higanbana" },
+      { resourceConditions: [{ resourceId: "ka", minAmount: 1 }], skillId: "higanbana" },
+    ],
+  },
+  {
+    id: "higanbana",
+    name: "彼岸花",
+    potency: 200,
+    type: "gcd",
+    target: "enemy",
+    icon: higanbanaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 6,
+    castTime: 1.3,
+    hidden: true,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    dotPotency: 50,
+    dotDuration: 60,
+  },
+  {
+    id: "tenka-goken",
+    name: "天下五剣",
+    potency: 300,
+    type: "gcd",
+    target: "enemy",
+    icon: tenkaGokenIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 30,
+    castTime: 1.3,
+    hidden: true,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+    buffApplications: ["tsubame-kaeshi-goken-ready"],
+  },
+  {
+    id: "midare-setsugekka",
+    name: "乱れ雪月花",
+    potency: 680,
+    type: "gcd",
+    target: "enemy",
+    icon: midareSetsugekkaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 50,
+    castTime: 1.3,
+    hidden: true,
+    guaranteedCrit: true,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+    buffApplications: ["tsubame-kaeshi-setsugekka-ready"],
+  },
+  {
+    id: "tendo-goken",
+    name: "天道五剣",
+    potency: 410,
+    type: "gcd",
+    target: "enemy",
+    icon: tendoGokenIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 100,
+    castTime: 1.3,
+    hidden: true,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+    buffConsumptions: [{ buffId: "tendo", stacks: 1 }],
+    buffApplications: ["tsubame-tendo-kaeshi-goken-ready"],
+  },
+  {
+    id: "tendo-setsugekka",
+    name: "天道雪月花",
+    potency: 1100,
+    type: "gcd",
+    target: "enemy",
+    icon: tendoSetsugekkaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 100,
+    castTime: 1.3,
+    hidden: true,
+    guaranteedCrit: true,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+    buffConsumptions: [{ buffId: "tendo", stacks: 1 }],
+    buffApplications: ["tsubame-tendo-kaeshi-setsugekka-ready"],
+  },
+
+  // ============================================================
+  // 4. 燕返し系（パレット用 + 隠しスキル 5 種）
+  // ============================================================
+  {
+    id: "tsubame-gaeshi",
+    name: "燕返し",
+    potency: 0,
+    type: "gcd",
+    target: "enemy",
+    icon: tsubameGaeshiIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 76,
+    autoTransform: [
+      { buffId: "tsubame-tendo-kaeshi-setsugekka-ready", skillId: "tendo-kaeshi-setsugekka" },
+      { buffId: "tsubame-tendo-kaeshi-goken-ready", skillId: "tendo-kaeshi-goken" },
+      { buffId: "tsubame-kaeshi-setsugekka-ready", skillId: "kaeshi-setsugekka" },
+      { buffId: "tsubame-kaeshi-goken-ready", skillId: "kaeshi-goken" },
+      { buffId: "tsubame-kaeshi-namikiri-ready", skillId: "kaeshi-namikiri" },
+    ],
+  },
+  {
+    id: "kaeshi-goken",
+    name: "返し五剣",
+    potency: 300,
+    type: "gcd",
+    target: "enemy",
+    icon: kaeshiGokenIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 76,
+    hidden: true,
+    requiredBuff: "tsubame-kaeshi-goken-ready",
+    buffConsumptions: [{ buffId: "tsubame-kaeshi-goken-ready", stacks: 1 }],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+  {
+    id: "kaeshi-setsugekka",
+    name: "返し雪月花",
+    potency: 680,
+    type: "gcd",
+    target: "enemy",
+    icon: kaeshiSetsugekkaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 76,
+    hidden: true,
+    guaranteedCrit: true,
+    requiredBuff: "tsubame-kaeshi-setsugekka-ready",
+    buffConsumptions: [{ buffId: "tsubame-kaeshi-setsugekka-ready", stacks: 1 }],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+  {
+    id: "tendo-kaeshi-goken",
+    name: "天道返し五剣",
+    potency: 410,
+    type: "gcd",
+    target: "enemy",
+    icon: tendoKaeshiGokenIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 100,
+    hidden: true,
+    requiredBuff: "tsubame-tendo-kaeshi-goken-ready",
+    buffConsumptions: [{ buffId: "tsubame-tendo-kaeshi-goken-ready", stacks: 1 }],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+  {
+    id: "tendo-kaeshi-setsugekka",
+    name: "天道返し雪月花",
+    potency: 1100,
+    type: "gcd",
+    target: "enemy",
+    icon: tendoKaeshiSetsugekkaIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 100,
+    hidden: true,
+    guaranteedCrit: true,
+    requiredBuff: "tsubame-tendo-kaeshi-setsugekka-ready",
+    buffConsumptions: [{ buffId: "tsubame-tendo-kaeshi-setsugekka-ready", stacks: 1 }],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+  {
+    id: "kaeshi-namikiri",
+    name: "返し波切",
+    potency: 1000,
+    type: "gcd",
+    target: "enemy",
+    icon: kaeshiNamikiriIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 90,
+    hidden: true,
+    guaranteedCrit: true,
+    guaranteedDh: true,
+    requiredBuff: "tsubame-kaeshi-namikiri-ready",
+    buffConsumptions: [{ buffId: "tsubame-kaeshi-namikiri-ready", stacks: 1 }],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+
+  // ============================================================
+  // 5. 奥義波切
+  // ============================================================
+  {
+    id: "ogi-namikiri",
+    name: "奥義波切",
+    potency: 1000,
+    type: "gcd",
+    target: "enemy",
+    icon: ogiNamikiriIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 90,
+    castTime: 1.3,
+    guaranteedCrit: true,
+    requiredBuff: "ogi-namikiri-ready",
+    buffConsumptions: [{ buffId: "ogi-namikiri-ready", stacks: 1 }],
+    buffApplications: ["tsubame-kaeshi-namikiri-ready"],
+    resourceChanges: [{ resourceId: "meditation", amount: 1 }],
+  },
+
+  // ============================================================
+  // 6. 必殺剣系（剣気消費 oGCD）
+  // ============================================================
+  {
+    id: "hissatsu-gyoten",
+    name: "必殺剣・暁天",
+    potency: 100,
+    type: "ogcd",
+    target: "enemy",
+    icon: hissatsuGyotenIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 54,
+    cooldown: 10,
+    resourceChanges: [{ resourceId: "kenki", amount: -10 }],
+  },
+  {
+    id: "hissatsu-yaten",
+    name: "必殺剣・夜天",
+    potency: 100,
+    type: "ogcd",
+    target: "enemy",
+    icon: hissatsuYatenIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 56,
+    cooldown: 10,
+    resourceChanges: [{ resourceId: "kenki", amount: -10 }],
+  },
+  {
+    id: "hissatsu-shinten",
+    name: "必殺剣・震天",
+    potency: 250,
+    type: "ogcd",
+    target: "enemy",
+    icon: hissatsuShintenIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 62,
+    cooldown: 1,
+    resourceChanges: [{ resourceId: "kenki", amount: -25 }],
+  },
+  {
+    id: "hissatsu-senei",
+    name: "必殺剣・閃影",
+    potency: 800,
+    type: "ogcd",
+    target: "enemy",
+    icon: hissatsuSeneiIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 72,
+    cooldown: 60,
+    resourceChanges: [{ resourceId: "kenki", amount: -25 }],
+  },
+
+  // ============================================================
+  // 7. その他
+  // ============================================================
+  {
+    id: "ikishoten",
+    name: "意気衝天",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: ikishotenIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 68,
+    cooldown: 120,
+    resourceChanges: [{ resourceId: "kenki", amount: 50 }],
+    buffApplications: ["ikishoten-buff", "ogi-namikiri-ready", "zanshin-ready"],
+  },
+  {
+    id: "enpi",
+    name: "燕飛",
+    potency: 860,
+    type: "gcd",
+    target: "enemy",
+    icon: enpiIcon,
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 76,
+    requiredBuff: "ikishoten-buff",
+    buffConsumptions: [{ buffId: "ikishoten-buff", stacks: 1 }],
+  },
+  {
+    id: "hagakure",
+    name: "葉隠",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: hagakureIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 68,
+    cooldown: 5,
+    consumeAllResources: ["setsu", "getsu", "ka"],
+    resourceGainByConsumedCount: {
+      fromResourceIds: ["setsu", "getsu", "ka"],
+      resourceId: "kenki",
+      gainPerConsumed: 10,
+    },
+  },
+  {
+    id: "meikyo-shisui-skill",
+    name: "明鏡止水",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: meikyoShisuiIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 50,
+    cooldown: 55,
+    maxCharges: 2,
+    buffApplications: ["meikyo-shisui", "tendo"],
+  },
+  {
+    id: "zanshin",
+    name: "残心",
+    potency: 940,
+    type: "ogcd",
+    target: "enemy",
+    icon: zanshinIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 96,
+    cooldown: 1,
+    resourceChanges: [{ resourceId: "kenki", amount: -50 }],
+    requiredBuff: "zanshin-ready",
+    buffConsumptions: [{ buffId: "zanshin-ready", stacks: 1 }],
+  },
+  {
+    id: "shoha",
+    name: "照破",
+    potency: 640,
+    type: "ogcd",
+    target: "enemy",
+    icon: shohaIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    acquiredLevel: 82,
+    cooldown: 15,
+    resourceChanges: [{ resourceId: "meditation", amount: -3 }],
+  },
+];

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -124,7 +124,7 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     comboFrom: ["hakaze", "gyofu"],
     comboResourceChanges: [
       { resourceId: "setsu", amount: 1 },
-      { resourceId: "kenki", amount: 10 },
+      { resourceId: "kenki", amount: 15 },
     ],
   },
   {

--- a/src/client/logic/__tests__/sam-combo.test.ts
+++ b/src/client/logic/__tests__/sam-combo.test.ts
@@ -90,6 +90,50 @@ describe("侍: 3系統 WS コンボ（月/花/雪）", () => {
     expect(result.entries[2].buffMultiplier).toBeCloseTo(1.13, 2);
   });
 
+  it("通常コンボ（陣風→月光）では月光時点で風月バフは新たに付与されない（陣風で付与済み）", () => {
+    // 月光に comboBuffApplications: ["fugetsu"] は無いため、月光単体では風月を付与しない
+    // ただし陣風で付与された風月は持続するため、月光時点でアクティブのまま
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("jinpu"), entry("gekko")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    // 月光時点で風月はアクティブ（陣風由来）
+    const fugetsuAtGekko = result.entries[2].activeBuffs.find((b) => b.buffId === "fugetsu");
+    expect(fugetsuAtGekko).toBeDefined();
+    // duration リフレッシュされていないこと: 風月の startTime が jinpu 時点（entries[1].startTime）
+    expect(fugetsuAtGekko?.startTime).toBeCloseTo(result.entries[1].startTime, 2);
+  });
+
+  it("満月の通常コンボ完走では風月バフは付与されない（実機準拠）", () => {
+    const result = resolveTimeline(
+      [entry("fuga"), entry("mangetsu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(false);
+  });
+
+  it("桜花の通常コンボ完走では風花バフは付与されない（実機準拠）", () => {
+    const result = resolveTimeline(
+      [entry("fuga"), entry("oka")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fuka")).toBe(false);
+  });
+
   it("暁風（Lv92置換）からも陣風コンボが成立する", () => {
     const result = resolveTimeline(
       [entry("gyofu"), entry("jinpu")],

--- a/src/client/logic/__tests__/sam-combo.test.ts
+++ b/src/client/logic/__tests__/sam-combo.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import { SAM_ATTACK_SKILLS } from "../../data/sam-skills";
+import { SAM_BUFFS } from "../../data/sam-buffs";
+import { SAM_RESOURCES } from "../../data/sam-resources";
+import type { TimelineEntry } from "../../types/skill";
+
+const skillMap = new Map(SAM_ATTACK_SKILLS.map((s) => [s.id, s]));
+
+function entry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("侍: 3系統 WS コンボ（月/花/雪）", () => {
+  it("月コンボ: 刃風 → 陣風 → 月光 で月閃+1・剣気が加算される", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("jinpu"), entry("gekko")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].wsComboError).toBe(false);
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resolvedPotency).toBe(300);
+    expect(result.entries[2].wsComboError).toBe(false);
+    expect(result.entries[2].resolvedPotency).toBe(370);
+    expect(result.entries[2].resourceSnapshot.getsu).toBe(1);
+    expect(result.entries[2].resourceSnapshot.setsu ?? 0).toBe(0);
+    expect(result.entries[2].resourceSnapshot.ka ?? 0).toBe(0);
+    // 剣気: 刃風(+5) + 陣風(+5) + 月光(+10) = 20
+    expect(result.entries[2].resourceSnapshot.kenki).toBe(20);
+  });
+
+  it("花コンボ: 刃風 → 士風 → 花車 で花閃+1", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("shifu"), entry("kasha")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[2].wsComboError).toBe(false);
+    expect(result.entries[2].resolvedPotency).toBe(370);
+    expect(result.entries[2].resourceSnapshot.ka).toBe(1);
+    expect(result.entries[2].resourceSnapshot.getsu ?? 0).toBe(0);
+  });
+
+  it("雪コンボ: 刃風 → 雪風 で雪閃+1", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("yukikaze")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resolvedPotency).toBe(340);
+    expect(result.entries[1].resourceSnapshot.setsu).toBe(1);
+  });
+
+  it("陣風を単独で使うとコンボ不成立で nonComboPotency が適用される", () => {
+    const result = resolveTimeline(
+      [entry("jinpu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].wsComboError).toBe(true);
+    expect(result.entries[0].resolvedPotency).toBe(120);
+    // 風月バフは付与されない
+    expect(result.entries[0].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(false);
+  });
+
+  it("陣風コンボ成立で風月（与ダメ+13%）が付与され、後続スキルに乗る", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("jinpu"), entry("gekko")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    // 月光時点で風月がアクティブ → buffMultiplier に反映
+    expect(result.entries[2].buffMultiplier).toBeCloseTo(1.13, 2);
+  });
+
+  it("暁風（Lv92置換）からも陣風コンボが成立する", () => {
+    const result = resolveTimeline(
+      [entry("gyofu"), entry("jinpu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resolvedPotency).toBe(300);
+  });
+
+  it("風光（Lv86置換）からも満月コンボが成立する", () => {
+    const result = resolveTimeline(
+      [entry("fuko"), entry("mangetsu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
+  });
+
+  it("3コンボ完走で閃3つ全て付与される", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("jinpu"), entry("gekko"),    // 月閃
+        entry("hakaze"), entry("shifu"), entry("kasha"),    // 花閃
+        entry("hakaze"), entry("yukikaze"),                  // 雪閃
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resourceSnapshot.getsu).toBe(1);
+    expect(last.resourceSnapshot.ka).toBe(1);
+    expect(last.resourceSnapshot.setsu).toBe(1);
+  });
+});

--- a/src/client/logic/__tests__/sam-combo.test.ts
+++ b/src/client/logic/__tests__/sam-combo.test.ts
@@ -25,7 +25,7 @@ describe("侍: 3系統 WS コンボ（月/花/雪）", () => {
     expect(result.entries[1].wsComboError).toBe(false);
     expect(result.entries[1].resolvedPotency).toBe(300);
     expect(result.entries[2].wsComboError).toBe(false);
-    expect(result.entries[2].resolvedPotency).toBe(370);
+    expect(result.entries[2].resolvedPotency).toBe(420);
     expect(result.entries[2].resourceSnapshot.getsu).toBe(1);
     expect(result.entries[2].resourceSnapshot.setsu ?? 0).toBe(0);
     expect(result.entries[2].resourceSnapshot.ka ?? 0).toBe(0);
@@ -43,7 +43,7 @@ describe("侍: 3系統 WS コンボ（月/花/雪）", () => {
     );
 
     expect(result.entries[2].wsComboError).toBe(false);
-    expect(result.entries[2].resolvedPotency).toBe(370);
+    expect(result.entries[2].resolvedPotency).toBe(420);
     expect(result.entries[2].resourceSnapshot.ka).toBe(1);
     expect(result.entries[2].resourceSnapshot.getsu ?? 0).toBe(0);
   });

--- a/src/client/logic/__tests__/sam-iaijutsu-transform.test.ts
+++ b/src/client/logic/__tests__/sam-iaijutsu-transform.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import { SAM_ATTACK_SKILLS } from "../../data/sam-skills";
+import { SAM_BUFFS } from "../../data/sam-buffs";
+import { SAM_RESOURCES } from "../../data/sam-resources";
+import type { TimelineEntry } from "../../types/skill";
+
+const skillMap = new Map(SAM_ATTACK_SKILLS.map((s) => [s.id, s]));
+
+function entry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("侍: 居合術 autoTransform（閃数 ＋ 天道バフ分岐）", () => {
+  it("閃0で居合術を使うとマッチせず元 iaijutsu のままで威力0、閃も消費されない", () => {
+    const result = resolveTimeline(
+      [entry("iaijutsu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].resolvedSkillId).toBe("iaijutsu");
+    expect(result.entries[0].resolvedPotency).toBe(0);
+    // 閃は全て 0 のまま（autoTransform にマッチしなかったため consumeAllResources も発火しない）
+    expect(result.entries[0].resourceSnapshot.setsu ?? 0).toBe(0);
+    expect(result.entries[0].resourceSnapshot.getsu ?? 0).toBe(0);
+    expect(result.entries[0].resourceSnapshot.ka ?? 0).toBe(0);
+  });
+
+  it("1閃（雪のみ）で居合術 → 彼岸花（威力200、DoT付与）", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("yukikaze"), entry("iaijutsu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[2].resolvedSkillId).toBe("higanbana");
+    expect(result.entries[2].resolvedPotency).toBe(200);
+    expect(result.entries[2].resourceSnapshot.setsu).toBe(0);
+  });
+
+  it("1閃（月のみ）でも彼岸花に変化する", () => {
+    const result = resolveTimeline(
+      [entry("hakaze"), entry("jinpu"), entry("gekko"), entry("iaijutsu")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[3].resolvedSkillId).toBe("higanbana");
+  });
+
+  it("2閃（雪＋月）で居合術 → 天下五剣（威力300、剣圧+1、返し五剣Ready付与）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),                // 雪閃
+        entry("hakaze"), entry("jinpu"), entry("gekko"),   // 月閃
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tenka-goken");
+    expect(last.resolvedPotency).toBe(300);
+    expect(last.resourceSnapshot.meditation).toBe(1);
+    // 燕返し Ready が付与されている
+    const next = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("iaijutsu"),
+        entry("tsubame-gaeshi"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+    expect(next.entries[next.entries.length - 1].resolvedSkillId).toBe("kaeshi-goken");
+  });
+
+  it("3閃で居合術 → 乱れ雪月花（威力680、確定クリ）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("midare-setsugekka");
+    expect(last.resolvedPotency).toBe(680);
+    expect(last.critRateBonus).toBe(1);
+    // 閃が全消費されている
+    expect(last.resourceSnapshot.setsu).toBe(0);
+    expect(last.resourceSnapshot.getsu).toBe(0);
+    expect(last.resourceSnapshot.ka).toBe(0);
+  });
+
+  it("2閃＋天道バフ → 天道五剣（威力410、天道バフ消費）", () => {
+    // 明鏡止水で天道バフ付与（Lv100ジョブ前提）
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("meikyo-shisui-skill"),  // 天道バフ付与
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tendo-goken");
+    expect(last.resolvedPotency).toBe(410);
+    // 天道バフが消費されて消えている
+    expect(last.activeBuffs.some((b) => b.buffId === "tendo")).toBe(false);
+  });
+
+  it("2閃（雪＋花）でも天下五剣に変化する", () => {
+    // 月コンボを使わず雪と花のみを揃える: 風雅 → 桜花 + 刃風 → 雪風
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),                  // 雪閃
+        entry("fuga"), entry("oka"),                          // 花閃
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tenka-goken");
+  });
+
+  it("2閃（月＋花）でも天下五剣に変化する", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("jinpu"), entry("gekko"),     // 月閃
+        entry("fuga"), entry("oka"),                          // 花閃
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tenka-goken");
+  });
+
+  it("3閃＋天道バフ → 天道雪月花（威力1100、確定クリ、最優先）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("meikyo-shisui-skill"),
+        entry("iaijutsu"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tendo-setsugekka");
+    expect(last.resolvedPotency).toBe(1100);
+    expect(last.critRateBonus).toBe(1);
+  });
+});

--- a/src/client/logic/__tests__/sam-meikyo.test.ts
+++ b/src/client/logic/__tests__/sam-meikyo.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import { SAM_ATTACK_SKILLS } from "../../data/sam-skills";
+import { SAM_BUFFS } from "../../data/sam-buffs";
+import { SAM_RESOURCES } from "../../data/sam-resources";
+import type { TimelineEntry } from "../../types/skill";
+
+const skillMap = new Map(SAM_ATTACK_SKILLS.map((s) => [s.id, s]));
+
+function entry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
+  it("明鏡止水中: 陣風単独で wsComboError=false かつ威力300", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("jinpu"),    // コンボ起点無しでも成立扱い
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resolvedPotency).toBe(300);
+    // 明鏡止水バフのスタックが 3 → 2 に減っている
+    const meikyoBuff = result.entries[1].activeBuffs.find((b) => b.buffId === "meikyo-shisui");
+    expect(meikyoBuff?.stacks).toBe(2);
+  });
+
+  it("明鏡止水中: 月光単独でも wsComboError=false（comboFrom=[jinpu] を強制バイパス）", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("gekko"),   // comboFrom=["jinpu"] だがバイパスで成立
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resolvedPotency).toBe(370);
+    // 月閃も付与される
+    expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
+  });
+
+  it("明鏡止水で 3 WS 消費した後、4回目は通常判定（バフ消失）", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("jinpu"),       // スタック 3→2
+        entry("shifu"),       // スタック 2→1
+        entry("yukikaze"),    // スタック 1→0、バフ消失
+        entry("jinpu"),       // バフ無し → コンボ判定通常通り（yukikazeの直後なのでコンボ不成立）
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[2].wsComboError).toBe(false);
+    expect(result.entries[3].wsComboError).toBe(false);
+    // 4回目は通常判定で失敗（バフ消失の証左）
+    expect(result.entries[4].wsComboError).toBe(true);
+  });
+
+  it("明鏡止水中、2WS だけ使った時点ではバイパスが効くこと（中間スタックの存在確認）", () => {
+    // 2 WS だけ使う独立シーケンス: スタック 1 残り、3WS 目のシフが成立する
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("jinpu"),       // 1WS 目: バイパス成立、スタック 3→2
+        entry("shifu"),       // 2WS 目: バイパス成立、スタック 2→1（hakaze 経由不要）
+        entry("yukikaze"),    // 3WS 目: バイパス成立、スタック 1→0
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    // 3WS 全てバイパスで成立
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[2].wsComboError).toBe(false);
+    expect(result.entries[3].wsComboError).toBe(false);
+  });
+
+  it("明鏡止水中の WS でも lastComboSkillId は更新される（通常コンボとの繋がり）", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("jinpu"),       // バイパス成立、lastComboSkillId="jinpu"
+        entry("gekko"),       // jinpu の直後 → 通常コンボとして成立
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[2].wsComboError).toBe(false);
+    expect(result.entries[2].resolvedPotency).toBe(370);
+  });
+
+  it("明鏡止水は居合術には影響しない（appliesToSkillIds 対象外）", () => {
+    // 居合術系は comboFrom が無いので、そもそも明鏡止水のバイパス対象ではない
+    // また居合術自体は閃数で変化するため、明鏡止水中に閃 0 で使うとマッチしない
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("iaijutsu"),    // 閃 0 → 元 iaijutsu のまま
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].resolvedSkillId).toBe("iaijutsu");
+    // 明鏡止水のスタックは消費されない（appliesToSkillIds に iaijutsu が含まれないため）
+    const meikyoBuff = result.entries[1].activeBuffs.find((b) => b.buffId === "meikyo-shisui");
+    expect(meikyoBuff?.stacks).toBe(3);
+  });
+
+  it("Lv100 の明鏡止水で天道バフも同時に付与される", () => {
+    const result = resolveTimeline(
+      [entry("meikyo-shisui-skill")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].activeBuffs.some((b) => b.buffId === "meikyo-shisui")).toBe(true);
+    expect(result.entries[0].activeBuffs.some((b) => b.buffId === "tendo")).toBe(true);
+  });
+});

--- a/src/client/logic/__tests__/sam-meikyo.test.ts
+++ b/src/client/logic/__tests__/sam-meikyo.test.ts
@@ -47,6 +47,25 @@ describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
     expect(result.entries[1].resolvedPotency).toBe(420);
     // 月閃も付与される
     expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
+    // 陣風をスキップしても月光のコンボ成立で風月バフが付与される（実機準拠）
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(true);
+  });
+
+  it("明鏡止水中: 花車単独でも風花バフが付与される", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("kasha"),   // comboFrom=["shifu"] だがバイパスで成立 → 風花付与
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resourceSnapshot.ka).toBe(1);
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fuka")).toBe(true);
   });
 
   it("明鏡止水で 3 WS 消費した後、4回目は通常判定（バフ消失）", () => {

--- a/src/client/logic/__tests__/sam-meikyo.test.ts
+++ b/src/client/logic/__tests__/sam-meikyo.test.ts
@@ -51,7 +51,7 @@ describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
     expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(true);
   });
 
-  it("明鏡止水中: 花車単独でも風花バフが付与される", () => {
+  it("明鏡止水中: 花車単独でも風花バフが付与される（applyBuffOnSkill）", () => {
     const result = resolveTimeline(
       [
         entry("meikyo-shisui-skill"),
@@ -66,6 +66,68 @@ describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
     expect(result.entries[1].wsComboError).toBe(false);
     expect(result.entries[1].resourceSnapshot.ka).toBe(1);
     expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fuka")).toBe(true);
+  });
+
+  it("明鏡止水中: 満月使用時に風月バフが付与される（applyBuffOnSkill、範囲コンボ最終段も対象）", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("mangetsu"),   // comboFrom=["fuga","fuko"] だがバイパスで成立 → 風月付与
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].wsComboError).toBe(false);
+    expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(true);
+  });
+
+  it("明鏡止水中: 桜花使用時に風花バフが付与される", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("oka"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fuka")).toBe(true);
+  });
+
+  it("明鏡止水中: 雪風使用時には風月・風花いずれも付与されない（appliesToSkillIds 対象外）", () => {
+    const result = resolveTimeline(
+      [
+        entry("meikyo-shisui-skill"),
+        entry("yukikaze"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(false);
+    expect(result.entries[1].activeBuffs.some((b) => b.buffId === "fuka")).toBe(false);
+  });
+
+  it("明鏡止水バフが無い時は月光単独で風月バフが付与されない（明鏡止水固有の効果）", () => {
+    const result = resolveTimeline(
+      [entry("gekko")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    // 陣風コンボ起点なしで月光単独 → wsComboError、風月は付与されない
+    expect(result.entries[0].wsComboError).toBe(true);
+    expect(result.entries[0].activeBuffs.some((b) => b.buffId === "fugetsu")).toBe(false);
   });
 
   it("明鏡止水で 3 WS 消費した後、4回目は通常判定（バフ消失）", () => {

--- a/src/client/logic/__tests__/sam-meikyo.test.ts
+++ b/src/client/logic/__tests__/sam-meikyo.test.ts
@@ -44,7 +44,7 @@ describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
     );
 
     expect(result.entries[1].wsComboError).toBe(false);
-    expect(result.entries[1].resolvedPotency).toBe(370);
+    expect(result.entries[1].resolvedPotency).toBe(420);
     // 月閃も付与される
     expect(result.entries[1].resourceSnapshot.getsu).toBe(1);
   });
@@ -106,7 +106,7 @@ describe("侍: 明鏡止水（bypassCombo + consumeOnGcd）", () => {
     );
 
     expect(result.entries[2].wsComboError).toBe(false);
-    expect(result.entries[2].resolvedPotency).toBe(370);
+    expect(result.entries[2].resolvedPotency).toBe(420);
   });
 
   it("明鏡止水は居合術には影響しない（appliesToSkillIds 対象外）", () => {

--- a/src/client/logic/__tests__/sam-resources.test.ts
+++ b/src/client/logic/__tests__/sam-resources.test.ts
@@ -51,8 +51,8 @@ describe("侍: リソース定義（剣気・閃3種・剣圧）", () => {
 
     const last = result.entries[result.entries.length - 1];
     expect(last.resourceSnapshot.setsu).toBe(0);
-    // 剣気: 刃風(+5) + 雪風(+10) + 葉隠(+10*1) = 25
-    expect(last.resourceSnapshot.kenki).toBe(25);
+    // 剣気: 刃風(+5) + 雪風(+15) + 葉隠(+10*1) = 30
+    expect(last.resourceSnapshot.kenki).toBe(30);
   });
 
   it("葉隠: 2閃で剣気+20（gainPerConsumed × consumeAllCount の乗算）", () => {
@@ -71,8 +71,8 @@ describe("侍: リソース定義（剣気・閃3種・剣圧）", () => {
     const last = result.entries[result.entries.length - 1];
     expect(last.resourceSnapshot.setsu).toBe(0);
     expect(last.resourceSnapshot.getsu).toBe(0);
-    // 剣気: 刃風×2(+10) + 雪風(+10) + 陣風(+5) + 月光(+10) + 葉隠(+10*2=20) = 55
-    expect(last.resourceSnapshot.kenki).toBe(55);
+    // 剣気: 刃風×2(+10) + 雪風(+15) + 陣風(+5) + 月光(+10) + 葉隠(+10*2=20) = 60
+    expect(last.resourceSnapshot.kenki).toBe(60);
   });
 
   it("葉隠: 3閃で剣気+30", () => {
@@ -93,8 +93,8 @@ describe("侍: リソース定義（剣気・閃3種・剣圧）", () => {
     expect(last.resourceSnapshot.setsu).toBe(0);
     expect(last.resourceSnapshot.getsu).toBe(0);
     expect(last.resourceSnapshot.ka).toBe(0);
-    // 剣気: 刃風×3(+15) + 陣風(+5) + 月光(+10) + 士風(+5) + 花車(+10) + 雪風(+10) + 葉隠(+10*3=30) = 85
-    expect(last.resourceSnapshot.kenki).toBe(85);
+    // 剣気: 刃風×3(+15) + 陣風(+5) + 月光(+10) + 士風(+5) + 花車(+10) + 雪風(+15) + 葉隠(+10*3=30) = 90
+    expect(last.resourceSnapshot.kenki).toBe(90);
   });
 
   it("葉隠: 閃 0 のときは実行不可（resourceErrors に setsu）", () => {

--- a/src/client/logic/__tests__/sam-resources.test.ts
+++ b/src/client/logic/__tests__/sam-resources.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { SAM_RESOURCES } from "../../data/sam-resources";
+import { resolveTimeline } from "../resolve-timeline";
+import { SAM_ATTACK_SKILLS } from "../../data/sam-skills";
+import { SAM_BUFFS } from "../../data/sam-buffs";
+import type { TimelineEntry } from "../../types/skill";
+
+const skillMap = new Map(SAM_ATTACK_SKILLS.map((s) => [s.id, s]));
+
+function entry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("侍: リソース定義（剣気・閃3種・剣圧）", () => {
+  it("閃3種は displayGroup='sen' で 1 行統合表示される", () => {
+    const setsu = SAM_RESOURCES.find((r) => r.id === "setsu");
+    const getsu = SAM_RESOURCES.find((r) => r.id === "getsu");
+    const ka = SAM_RESOURCES.find((r) => r.id === "ka");
+
+    expect(setsu?.displayGroup).toBe("sen");
+    expect(getsu?.displayGroup).toBe("sen");
+    expect(ka?.displayGroup).toBe("sen");
+    expect(setsu?.groupMaxStacks).toBe(3);
+    expect(getsu?.groupMaxStacks).toBe(3);
+    expect(ka?.groupMaxStacks).toBe(3);
+  });
+
+  it("剣気は最大100でキャップされる", () => {
+    const kenki = SAM_RESOURCES.find((r) => r.id === "kenki");
+    expect(kenki?.maxStacks).toBe(100);
+    expect(kenki?.displayGroup).toBeUndefined();
+  });
+
+  it("剣圧は最大3でキャップされる", () => {
+    const meditation = SAM_RESOURCES.find((r) => r.id === "meditation");
+    expect(meditation?.maxStacks).toBe(3);
+    expect(meditation?.acquiredLevel).toBe(90);
+  });
+
+  it("葉隠: 1閃のみで剣気+10", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),  // 雪閃のみ
+        entry("hagakure"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resourceSnapshot.setsu).toBe(0);
+    // 剣気: 刃風(+5) + 雪風(+10) + 葉隠(+10*1) = 25
+    expect(last.resourceSnapshot.kenki).toBe(25);
+  });
+
+  it("葉隠: 2閃で剣気+20（gainPerConsumed × consumeAllCount の乗算）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),                  // 雪閃
+        entry("hakaze"), entry("jinpu"), entry("gekko"),     // 月閃
+        entry("hagakure"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resourceSnapshot.setsu).toBe(0);
+    expect(last.resourceSnapshot.getsu).toBe(0);
+    // 剣気: 刃風×2(+10) + 雪風(+10) + 陣風(+5) + 月光(+10) + 葉隠(+10*2=20) = 55
+    expect(last.resourceSnapshot.kenki).toBe(55);
+  });
+
+  it("葉隠: 3閃で剣気+30", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("hagakure"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resourceSnapshot.setsu).toBe(0);
+    expect(last.resourceSnapshot.getsu).toBe(0);
+    expect(last.resourceSnapshot.ka).toBe(0);
+    // 剣気: 刃風×3(+15) + 陣風(+5) + 月光(+10) + 士風(+5) + 花車(+10) + 雪風(+10) + 葉隠(+10*3=30) = 85
+    expect(last.resourceSnapshot.kenki).toBe(85);
+  });
+
+  it("葉隠: 閃 0 のときは実行不可（resourceErrors に setsu）", () => {
+    const result = resolveTimeline(
+      [entry("hagakure")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].resourceErrors).toContain("setsu");
+    // エラーなので剣気は獲得されない
+    expect(result.entries[0].resourceSnapshot.kenki ?? 0).toBe(0);
+  });
+});

--- a/src/client/logic/__tests__/sam-tsubame-gaeshi.test.ts
+++ b/src/client/logic/__tests__/sam-tsubame-gaeshi.test.ts
@@ -29,8 +29,8 @@ describe("侍: 燕返し 5 種（autoTransform + exclusiveGroup）", () => {
     const last = result.entries[result.entries.length - 1];
     expect(last.resolvedSkillId).toBe("kaeshi-goken");
     expect(last.resolvedPotency).toBe(300);
-    // 剣圧は天下五剣で+1、返し五剣でさらに+1 = 計2
-    expect(last.resourceSnapshot.meditation).toBe(2);
+    // 剣圧は天下五剣（居合術）でのみ +1。返し五剣（燕返し）では付与されない（実機準拠）
+    expect(last.resourceSnapshot.meditation).toBe(1);
   });
 
   it("乱れ雪月花後の燕返し → 返し雪月花（威力680、確定クリ）", () => {
@@ -162,6 +162,48 @@ describe("侍: 燕返し 5 種（autoTransform + exclusiveGroup）", () => {
 
     const last = result.entries[result.entries.length - 1];
     expect(last.resolvedSkillId).toBe("kaeshi-goken");
+  });
+
+  it("燕返し系は剣圧を付与しない（実機: 剣圧は居合術・奥義波切のみで蓄積）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("iaijutsu"),         // 乱れ雪月花 → meditation +1
+        entry("tsubame-gaeshi"),   // 返し雪月花 → meditation 変動なし
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const iaijutsuEntry = result.entries[result.entries.length - 2];
+    const tsubameEntry = result.entries[result.entries.length - 1];
+    // 乱れ雪月花時点で剣圧 1、その後の返し雪月花で増えない
+    expect(iaijutsuEntry.resourceSnapshot.meditation).toBe(1);
+    expect(tsubameEntry.resourceSnapshot.meditation).toBe(1);
+  });
+
+  it("奥義波切は剣圧 +1、続く返し波切では付与されない", () => {
+    const result = resolveTimeline(
+      [
+        entry("ikishoten"),
+        entry("hakaze"),
+        entry("ogi-namikiri"),    // 剣圧 +1
+        entry("tsubame-gaeshi"),  // 返し波切 → 剣圧変動なし
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const ogiEntry = result.entries[2];
+    const kaeshiEntry = result.entries[3];
+    expect(ogiEntry.resourceSnapshot.meditation).toBe(1);
+    expect(kaeshiEntry.resourceSnapshot.meditation).toBe(1);
   });
 
   it("Ready バフ無しで燕返しを使うと requiredBuff エラー", () => {

--- a/src/client/logic/__tests__/sam-tsubame-gaeshi.test.ts
+++ b/src/client/logic/__tests__/sam-tsubame-gaeshi.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import { SAM_ATTACK_SKILLS } from "../../data/sam-skills";
+import { SAM_BUFFS } from "../../data/sam-buffs";
+import { SAM_RESOURCES } from "../../data/sam-resources";
+import type { TimelineEntry } from "../../types/skill";
+
+const skillMap = new Map(SAM_ATTACK_SKILLS.map((s) => [s.id, s]));
+
+function entry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("侍: 燕返し 5 種（autoTransform + exclusiveGroup）", () => {
+  it("天下五剣後の燕返し → 返し五剣（威力300、剣圧+1）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("iaijutsu"),         // → 天下五剣
+        entry("tsubame-gaeshi"),   // → 返し五剣
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("kaeshi-goken");
+    expect(last.resolvedPotency).toBe(300);
+    // 剣圧は天下五剣で+1、返し五剣でさらに+1 = 計2
+    expect(last.resourceSnapshot.meditation).toBe(2);
+  });
+
+  it("乱れ雪月花後の燕返し → 返し雪月花（威力680、確定クリ）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("iaijutsu"),
+        entry("tsubame-gaeshi"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("kaeshi-setsugekka");
+    expect(last.resolvedPotency).toBe(680);
+    expect(last.critRateBonus).toBe(1);
+  });
+
+  it("天道五剣後 → 天道返し五剣（威力410）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("meikyo-shisui-skill"),
+        entry("iaijutsu"),         // → 天道五剣
+        entry("tsubame-gaeshi"),   // → 天道返し五剣
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tendo-kaeshi-goken");
+    expect(last.resolvedPotency).toBe(410);
+  });
+
+  it("天道雪月花後 → 天道返し雪月花（威力1100、確定クリ）", () => {
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("meikyo-shisui-skill"),
+        entry("iaijutsu"),         // → 天道雪月花
+        entry("tsubame-gaeshi"),   // → 天道返し雪月花
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("tendo-kaeshi-setsugekka");
+    expect(last.resolvedPotency).toBe(1100);
+    expect(last.critRateBonus).toBe(1);
+  });
+
+  it("奥義波切後 → 返し波切（威力1000、確定クリ・確定DH）", () => {
+    const result = resolveTimeline(
+      [
+        entry("ikishoten"),         // 奥義波切Ready付与
+        entry("hakaze"),
+        entry("ogi-namikiri"),
+        entry("tsubame-gaeshi"),    // → 返し波切
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("kaeshi-namikiri");
+    expect(last.resolvedPotency).toBe(1000);
+    expect(last.critRateBonus).toBe(1);
+    expect(last.dhRateBonus).toBe(1);
+  });
+
+  it("Ready バフが排他グループ tsubame-ready で重複付与されない", () => {
+    // 天下五剣 → そのまま乱れ雪月花を撃つと、tsubame-kaeshi-goken-ready は
+    // tsubame-kaeshi-setsugekka-ready に置き換わる（exclusiveGroup="tsubame-ready"）
+    const result = resolveTimeline(
+      [
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("iaijutsu"),         // → 天下五剣 → kaeshi-goken-ready 付与
+        entry("hakaze"), entry("shifu"), entry("kasha"),
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("iaijutsu"),         // → 乱れ雪月花 → kaeshi-setsugekka-ready 付与（古いReady除去）
+        entry("tsubame-gaeshi"),   // → 返し雪月花になるべき（五剣ではなく）
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("kaeshi-setsugekka");
+  });
+
+  it("奥義波切後に居合術 → 波切Ready が居合のReadyに置換される（exclusiveGroup の波切系も対象）", () => {
+    // 奥義波切で kaeshi-namikiri-ready 付与 → その後 iaijutsu で kaeshi-goken-ready 付与
+    // exclusiveGroup="tsubame-ready" により波切Ready が除去 → tsubame-gaeshi は五剣になるべき
+    const result = resolveTimeline(
+      [
+        entry("ikishoten"),
+        entry("hakaze"),
+        entry("ogi-namikiri"),                  // tsubame-kaeshi-namikiri-ready 付与
+        entry("hakaze"), entry("yukikaze"),
+        entry("hakaze"), entry("jinpu"), entry("gekko"),
+        entry("iaijutsu"),                       // 天下五剣 → tsubame-kaeshi-goken-ready 付与（波切Ready 除去）
+        entry("tsubame-gaeshi"),
+      ],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    const last = result.entries[result.entries.length - 1];
+    expect(last.resolvedSkillId).toBe("kaeshi-goken");
+  });
+
+  it("Ready バフ無しで燕返しを使うと requiredBuff エラー", () => {
+    // 燕返しを単独で使うとどの Ready バフも無いので autoTransform しない
+    // → 元の tsubame-gaeshi は requiredBuff を持たないので威力0で実行されるだけ
+    const result = resolveTimeline(
+      [entry("tsubame-gaeshi")],
+      skillMap,
+      SAM_RESOURCES,
+      undefined,
+      SAM_BUFFS
+    );
+
+    expect(result.entries[0].resolvedSkillId).toBe("tsubame-gaeshi");
+    expect(result.entries[0].resolvedPotency).toBe(0);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -283,6 +283,28 @@ function consumeGuaranteedDhBuffs(
 }
 
 /**
+ * アクティブなバフに bypassCombo 効果があるか判定する。
+ * appliesToSkillIds が指定されたエフェクトは、targetSkillId が含まれるときだけ有効。
+ * 消費自体は consumeOnGcd 仕組みに委譲する（明鏡止水バフは consumeOnGcd を併設する）。
+ */
+function hasBypassComboBuff(
+  activeBuffs: ActiveBuff[],
+  buffDefMap: Map<string, BuffDefinition>,
+  targetSkillId: string
+): boolean {
+  for (const ab of activeBuffs) {
+    const def = buffDefMap.get(ab.buffId);
+    if (!def) continue;
+    for (const effect of def.effects) {
+      if (effect.type !== "bypassCombo") continue;
+      if (effect.appliesToSkillIds && !effect.appliesToSkillIds.includes(targetSkillId)) continue;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * アクティブなバフから威力バフの合成倍率を計算する。
  * targetSkillId が指定されている場合、appliesToSkillIds に
  * 該当スキルIDが含まれないエフェクトは除外する（対象スキル限定バフ）。
@@ -682,7 +704,7 @@ export function resolveTimeline(
       actionAvailableAt = startTime + originalSkill.animationLock;
     }
 
-    // 自動変化チェック: バフ条件を満たす場合、変化先スキルに差し替え（チェーン対応）
+    // 自動変化チェック: バフ条件 / リソース条件を満たす場合、変化先スキルに差し替え（チェーン対応）
     let skill = originalSkill;
     let resolvedSkillId = entry.skillId;
     {
@@ -695,17 +717,27 @@ export function resolveTimeline(
           ? current.autoTransform
           : [current.autoTransform];
         for (const t of transforms) {
-          const hasBuff = currentActiveBuffs.some((ab) => ab.buffId === t.buffId);
-          if (hasBuff) {
-            const next = skillMap.get(t.skillId);
-            if (next) {
-              skill = next;
-              resolvedSkillId = next.id;
-              current = next;
-              transformed = true;
-            }
-            break; // 先頭一致で確定（優先度順）
+          // buffId 指定時: 該当バフがアクティブであること
+          if (t.buffId !== undefined) {
+            const hasBuff = currentActiveBuffs.some((ab) => ab.buffId === t.buffId);
+            if (!hasBuff) continue;
           }
+          // resourceConditions 指定時: 全リソースが minAmount 以上であること（AND）
+          if (t.resourceConditions) {
+            const allMet = t.resourceConditions.every(
+              (rc) => (resourceState[rc.resourceId] ?? 0) >= rc.minAmount
+            );
+            if (!allMet) continue;
+          }
+          // 条件成立 → 変化先スキルへ
+          const next = skillMap.get(t.skillId);
+          if (next) {
+            skill = next;
+            resolvedSkillId = next.id;
+            current = next;
+            transformed = true;
+          }
+          break; // 先頭一致で確定（優先度順）
         }
       }
     }
@@ -871,6 +903,10 @@ export function resolveTimeline(
       const comboTimerExpired = (startTime - lastComboTime) >= COMBO_TIMER;
       const comboMatch = lastComboSkillId !== null && skill.comboFrom.includes(lastComboSkillId);
       wsComboError = comboTimerExpired || !comboMatch;
+      // bypassCombo バフ（appliesToSkillIds に当該スキルが含まれる）がアクティブなら強制成立
+      if (wsComboError && hasBypassComboBuff(currentActiveBuffs, buffDefMap, resolvedSkillId)) {
+        wsComboError = false;
+      }
     }
 
     // コンボ成否に基づく威力決定
@@ -923,6 +959,7 @@ export function resolveTimeline(
     // 和集合として 1 度だけ消費するように Set 化している。
     // （スキル実行中に新たに付与されたバフは消費対象外）
     // - consumeOnGcd: 全 GCD スキル実行後に消費
+    //   appliesToSkillIds 指定時は該当スキルIDのみ消費対象（明鏡止水で特定WSに限定する用途）
     // - instantCast: 詠唱時間 > 0 の GCD スキル実行後にのみ消費（非詠唱 GCD / oGCD では消費しない）
     //   appliesToSkillIds 指定時は該当スキルIDのみ消費対象（例: firestarter は fire-3 限定）
     //   複数の instantCast バフが同時アクティブな場合は 1 発につき 1 つだけ消費する
@@ -934,7 +971,11 @@ export function resolveTimeline(
       for (const ab of currentActiveBuffs) {
         const def = buffDefMap.get(ab.buffId);
         if (!def) continue;
-        const hasConsumeOnGcd = def.effects.some((e) => e.type === "consumeOnGcd");
+        const hasConsumeOnGcd = def.effects.some((e) => {
+          if (e.type !== "consumeOnGcd") return false;
+          if (e.appliesToSkillIds && !e.appliesToSkillIds.includes(resolvedSkillId)) return false;
+          return true;
+        });
         if (hasConsumeOnGcd) {
           consumeBuffTargets.add(ab.buffId);
         }
@@ -961,8 +1002,8 @@ export function resolveTimeline(
     // 威力倍率・クリティカル判定をバフ適用前に計算（スキル自身が付与するバフは自分には適用されない）
     // 解決後のスキルIDを渡すことで、対象スキル限定バフ（appliesToSkillIds）を正しくフィルタする
     const buffMultiplierBeforeApply = hasError ? 1 : getPotencyMultiplier(currentActiveBuffs, buffDefMap, resolvedSkillId);
-    const guaranteedCritBeforeApply = !hasError && skill.type === "gcd" && hasGuaranteedCrit(currentActiveBuffs, buffDefMap);
-    const guaranteedDhBeforeApply = !hasError && skill.type === "gcd" && hasGuaranteedDh(currentActiveBuffs, buffDefMap);
+    const guaranteedCritBeforeApply = !hasError && skill.type === "gcd" && (skill.guaranteedCrit === true || hasGuaranteedCrit(currentActiveBuffs, buffDefMap));
+    const guaranteedDhBeforeApply = !hasError && skill.type === "gcd" && (skill.guaranteedDh === true || hasGuaranteedDh(currentActiveBuffs, buffDefMap));
     // バフによるCRT率ボーナス（guaranteedCritとは別に計算。DoTスナップショットでも使用）
     const baseCritRateBonus = hasError ? 0 : getCritRateBonus(currentActiveBuffs, buffDefMap);
     // 直接ダメージ用: guaranteedCritの場合は100%に上書き
@@ -1065,6 +1106,18 @@ export function resolveTimeline(
           const idx = currentActiveBuffs.indexOf(activeBuff);
           if (idx >= 0) currentActiveBuffs.splice(idx, 1);
         }
+      }
+
+      // resourceGainByConsumedCount: consumeAllResourcesの消費数に応じた別リソース獲得（葉隠の剣気獲得等）
+      if (skill.resourceGainByConsumedCount && consumeAllCount > 0) {
+        const gainDef = skill.resourceGainByConsumedCount;
+        const totalGain = gainDef.gainPerConsumed * consumeAllCount;
+        const resDef = resourceDefMap.get(gainDef.resourceId);
+        const cap = resDef?.maxStacks ?? Infinity;
+        resourceState[gainDef.resourceId] = Math.min(
+          cap,
+          (resourceState[gainDef.resourceId] ?? 0) + totalGain
+        );
       }
 
       // buffApplicationsByConsumedCount: consumeAllResourcesの消費数に応じたバフ適用

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -1214,6 +1214,38 @@ export function resolveTimeline(
         }
       }
 
+      // applyBuffOnSkill: アクティブバフの effects に applyBuffOnSkill があり、
+      // appliesToSkillIds に resolvedSkillId が含まれる場合、appliedBuffId を付与する。
+      // 例: 明鏡止水中の月光使用時に風月を付与（明鏡止水バフ側で対応関係を宣言）。
+      // 走査中の配列変更を避けるため、まず付与対象を収集してから一括付与する。
+      const buffsToApplyOnSkill: string[] = [];
+      for (const ab of currentActiveBuffs) {
+        const def = buffDefMap.get(ab.buffId);
+        if (!def) continue;
+        for (const effect of def.effects) {
+          if (effect.type !== "applyBuffOnSkill") continue;
+          if (effect.appliesToSkillIds && !effect.appliesToSkillIds.includes(resolvedSkillId)) continue;
+          if (effect.appliedBuffId) buffsToApplyOnSkill.push(effect.appliedBuffId);
+        }
+      }
+      for (const buffId of buffsToApplyOnSkill) {
+        const buffDef = buffDefMap.get(buffId);
+        if (!buffDef) continue;
+        removeExclusiveGroupBuffs(currentActiveBuffs, buffDef, buffDefMap);
+        const existingIdx = currentActiveBuffs.findIndex((b) => b.buffId === buffId);
+        const newBuff: ActiveBuff = {
+          buffId,
+          startTime,
+          endTime: computeBuffEndTime(startTime, buffDef.duration),
+          stacks: buffDef.maxStacks,
+        };
+        if (existingIdx >= 0) {
+          currentActiveBuffs[existingIdx] = newBuff;
+        } else {
+          currentActiveBuffs.push(newBuff);
+        }
+      }
+
       // チャージ消費 & クールダウン開始
       if (skill.cooldown !== undefined) {
         const maxCharges = skill.maxCharges ?? 1;

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -44,6 +44,23 @@ export interface TraitPotencyOverride {
 /** サポートするプレイヤーレベル */
 export type PlayerLevel = 70 | 80 | 90 | 100;
 
+/**
+ * autoTransform 配列要素の型。
+ * `buffId` または `resourceConditions` の少なくとも一方が必須。
+ * 両方指定時は AND 評価（バフアクティブ かつ 全リソース閾値以上）。
+ */
+export type AutoTransformEntry =
+  | {
+      buffId: string;
+      resourceConditions?: { resourceId: string; minAmount: number }[];
+      skillId: string;
+    }
+  | {
+      buffId?: string;
+      resourceConditions: { resourceId: string; minAmount: number }[];
+      skillId: string;
+    };
+
 /** スキルの定義データ */
 export interface Skill {
   /** スキルの一意識別子 */
@@ -110,6 +127,18 @@ export interface Skill {
   };
   /** consumeAllResources消費数に応じたバフ適用テーブル（index 0 = 1個消費時のbuffId[]） */
   buffApplicationsByConsumedCount?: string[][];
+  /**
+   * consumeAllResources で消費したリソース数に応じた別リソース獲得。
+   * 例: 葉隠（侍）— 雪/月/花の閃を全消費し、消費した数 × 10 の剣気を獲得。
+   */
+  resourceGainByConsumedCount?: {
+    /** 消費数の集計対象リソースID（consumeAllResources と同一を指定するのが基本） */
+    fromResourceIds: string[];
+    /** 獲得するリソースID */
+    resourceId: string;
+    /** 1個消費あたりの獲得量 */
+    gainPerConsumed: number;
+  };
   /** バフ消費のOR条件（いずれか1つを消費。potency指定時は威力を上書き、procRate+fallbackPotency指定時は期待値を計算） */
   buffConsumptionAnyOf?: { buffId: string; stacks: number; potency?: number; procRate?: number; fallbackPotency?: number }[];
   /** 指定バフがアクティブな場合、resourceChangesの特定リソース消費をスキップしバフを1スタック消費する（バフ優先消費） */
@@ -118,18 +147,23 @@ export interface Skill {
   conditionalPotencyBuffs?: { buffId: string; potency: number }[];
   /** スキル使用に必要なバフID（未アクティブ時はエラー、威力を計上しない） */
   requiredBuff?: string;
-  /** 自動変化条件（指定バフがアクティブ時に別スキルに変化。配列の場合は先頭から優先チェック） */
-  autoTransform?: {
-    /** 変化条件となるバフID */
-    buffId: string;
-    /** 変化先スキルID */
-    skillId: string;
-  } | {
-    buffId: string;
-    skillId: string;
-  }[];
+  /**
+   * 自動変化条件。
+   * - 配列形式: 先頭から優先評価し、最初に条件を満たすエントリの変化先を採用
+   * - 単一エントリ形式: 後方互換のため維持
+   * - 各エントリの条件:
+   *   - `buffId` 指定時: 該当バフがアクティブであること
+   *   - `resourceConditions` 指定時: 指定された全リソースが minAmount 以上であること（AND）
+   *   - 両方指定時は AND（バフあり かつ 全リソース閾値以上）
+   * - `buffId` も `resourceConditions` も無いエントリは型エラー（型レベルで「どちらかは必須」を強制）
+   */
+  autoTransform?: AutoTransformEntry | AutoTransformEntry[];
   /** UI上で非表示にするか（autoTransform の変化先専用スキル等で使用） */
   hidden?: boolean;
+  /** スキル固有の確定クリティカル（バフ経由ではない常時クリ。乱れ雪月花・天道雪月花・奥義波切等） */
+  guaranteedCrit?: boolean;
+  /** スキル固有の確定ダイレクトヒット（バフ経由ではない常時DH。返し波切等） */
+  guaranteedDh?: boolean;
 }
 
 /** タイムラインに配置されたスキル */
@@ -190,7 +224,7 @@ export interface CharacterStats {
 }
 
 /** バフ・デバフのエフェクト種別 */
-export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast" | "resourceCostMultiplier" | "resourceGainOnSkill";
+export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast" | "resourceCostMultiplier" | "resourceGainOnSkill" | "bypassCombo";
 
 /** バフ・デバフの効果 */
 export interface BuffEffect {
@@ -210,6 +244,7 @@ export interface BuffEffect {
    * - resource: リソース変動量
    * - resourceCostMultiplier: 指定リソースの消費量に乗じる倍率（2 = 2倍消費、0 = 消費なし）
    * - resourceGainOnSkill: スキル使用時に指定リソースを value 分追加で獲得する（appliesToSkillIds で対象限定可）
+   * - bypassCombo: バフアクティブ中、対象GCD WSのコンボ条件判定を強制成立扱いにする（値は未使用、appliesToSkillIds で対象限定）
    */
   value: number;
   /** statバフの対象ステータスキー */

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -224,7 +224,7 @@ export interface CharacterStats {
 }
 
 /** バフ・デバフのエフェクト種別 */
-export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast" | "resourceCostMultiplier" | "resourceGainOnSkill" | "bypassCombo";
+export type BuffEffectType = "speed" | "potency" | "stat" | "resource" | "critRate" | "dhRate" | "guaranteedCrit" | "guaranteedDh" | "consumeOnGcd" | "instantCast" | "resourceCostMultiplier" | "resourceGainOnSkill" | "bypassCombo" | "applyBuffOnSkill";
 
 /** バフ・デバフの効果 */
 export interface BuffEffect {
@@ -245,6 +245,7 @@ export interface BuffEffect {
    * - resourceCostMultiplier: 指定リソースの消費量に乗じる倍率（2 = 2倍消費、0 = 消費なし）
    * - resourceGainOnSkill: スキル使用時に指定リソースを value 分追加で獲得する（appliesToSkillIds で対象限定可）
    * - bypassCombo: バフアクティブ中、対象GCD WSのコンボ条件判定を強制成立扱いにする（値は未使用、appliesToSkillIds で対象限定）
+   * - applyBuffOnSkill: バフアクティブ中、対象 GCD/oGCD 使用時に appliedBuffId のバフを追加付与する（値は未使用、明鏡止水中の月光→風月等）
    */
   value: number;
   /** statバフの対象ステータスキー */
@@ -258,6 +259,8 @@ export interface BuffEffect {
    * 同一バフが複数スキル群に異なる倍率を適用するケースで使用する。
    */
   appliesToSkillIds?: string[];
+  /** applyBuffOnSkill 専用: 付与するバフID */
+  appliedBuffId?: string;
   /**
    * resourceCostMultiplier 専用: 指定リソースが消費可能な量だけ残っていれば倍率を打ち消す。
    * 打ち消し成立時はそのリソースを消費する（例: BLMのアンブラルハートでAF中のMP2倍化を打ち消す）。


### PR DESCRIPTION
## 概要

パッチ7.5 / Lv100 までの侍（SAM）ジョブを実装し、ローテーション威力計算に対応させた。Issue 本文の概算値ではなく、コメント記載の調査結果（最新仕様）を正として実装している。

## 変更点

### 機構拡張（既存ジョブへ影響なし）

- `BuffEffectType` に `"bypassCombo"` を追加（明鏡止水でコンボ条件を強制成立扱いに）
- `autoTransform` をリソース条件に対応（`AutoTransformEntry` 型、`resourceConditions` の AND 評価）
- `resourceGainByConsumedCount` プロパティ追加（葉隠: 消費閃数 × 10 の剣気獲得）
- スキル固有の `guaranteedCrit` / `guaranteedDh` フラグ追加（乱れ雪月花・奥義波切等の常時クリ）
- `consumeOnGcd` を `appliesToSkillIds` でフィルタ可能に（明鏡止水を対象 WS に限定）

### 侍データ追加

- `sam-skills.ts`: GCD コンボ（月/花/雪 3 系統）、居合術（閃数 × 天道で 6 種類に分岐）、燕返し（5 種類）、奥義波切、必殺剣系、燕飛、明鏡止水、葉隠、残心、照破等
- `sam-buffs.ts`: 風月/風花/明鏡止水（3 スタック、対象 WS のみバイパス＆消費）/天道/意気衝天/Ready 系 5 種（`exclusiveGroup="tsubame-ready"` で排他）
- `sam-resources.ts`: 剣気（最大100）/閃 3 種（`displayGroup="sen"` で統合表示）/剣圧（最大3）
- `App.tsx` の `JobId` / `JOB_DATA` と `SkillPalette.tsx` の `JOBS` リストに `sam` 追加

### 実装上の主要ポイント

- 居合術: 閃数（1/2/3）× 天道バフの組み合わせを `autoTransform` 配列の優先順序で評価（天道3閃 → 天道2閃×3パターン → 通常3閃 → 通常2閃×3パターン → 1閃×3パターン）
- 燕返し: 直前の居合術 / 奥義波切に応じた 5 種類を Ready バフ + `autoTransform` で表現
- 明鏡止水: 1段目（刃風/暁風/風雅/風光）と居合術系・燕返し系・奥義波切・残心はバイパス対象外
- 葉隠: `consumeAllResources` + `resourceGainByConsumedCount` で全閃消費＋閃数 × 10 剣気

### 実装しないもの

- 必殺剣・紅蓮（閃影のみ実装、共有リキャストは別 Issue を起票予定）
- 味方バフ、防御・回復、ロールアクション
- 範囲攻撃の対複数ヒット計算

## テスト

5 ファイル（41 ケース）を追加し、既存と合わせて **21 ファイル / 167 ケース** すべて GREEN。

- `sam-combo.test.ts`: 3 系統 WS コンボ・暁風/風光（置換版）からのコンボ成立
- `sam-iaijutsu-transform.test.ts`: 閃数 0/1/2/3 × 天道有無の全パターン、2 閃の組み合わせ網羅
- `sam-tsubame-gaeshi.test.ts`: 燕返し 5 種・exclusiveGroup 排他・波切 Ready の排他確認
- `sam-meikyo.test.ts`: bypassCombo の動作、3 WS 消費後のバフ消失、居合術が影響を受けないこと
- `sam-resources.test.ts`: 閃の `displayGroup`、葉隠の 1/2/3 閃消費パターン

## UI 検証

Playwright MCP で侍ジョブ選択 → スキルパレット表示まで確認済み。GCD/oGCD すべてのスキルが期待通り Lv100 で表示される。

closes #255