### PR TITLE
feat: スキルクリックで期待値内訳の詳細パネルを表示 #174

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { SkillPalette } from "./SkillPalette";
 import { Timeline } from "./Timeline";
+import { SkillDetailPanel } from "./SkillDetailPanel";
 import { resolveTimeline, calcPps } from "../logic/resolve-timeline";
 import { WHM_ATTACK_SKILLS } from "../data/whm-skills";
 import { WHM_RESOURCES } from "../data/whm-resources";
@@ -55,6 +56,7 @@ export function App() {
   const [stats, setStats] = useState<CharacterStats>(DEFAULT_STATS);
   const [untargetableWindows, setUntargetableWindows] = useState<BossUntargetableWindow[]>([]);
   const [ppsRange, setPpsRange] = useState<PpsRange | null>(null);
+  const [selectedEntryUid, setSelectedEntryUid] = useState<string | null>(null);
 
   const jobData = JOB_DATA[selectedJob];
 
@@ -63,6 +65,7 @@ export function App() {
     // ジョブ変更時にタイムラインをリセット（異なるジョブのスキルは互換性がない）
     setEntries([]);
     setPpsRange(null);
+    setSelectedEntryUid(null);
   }, []);
 
   // レベルに応じたバフ・リソースをフィルタ
@@ -131,6 +134,7 @@ export function App() {
 
   const handleRemoveEntry = useCallback((uid: string) => {
     setEntries((prev) => prev.filter((e) => e.uid !== uid));
+    setSelectedEntryUid((prev) => (prev === uid ? null : prev));
   }, []);
 
   const handleMoveEntry = useCallback((uid: string, insertBeforeUid?: string) => {
@@ -178,6 +182,21 @@ export function App() {
       stats
     );
   }, [resolvedEntries, allSkillMap, timelineResult.dotTicks, timelineResult.timelineEndTime, stats]);
+
+  const buffDefMap = useMemo(
+    () => new Map(levelBuffs.map((b) => [b.id, b])),
+    [levelBuffs]
+  );
+
+  const selectedEntry = useMemo(() => {
+    if (selectedEntryUid === null) return null;
+    return resolvedEntries.find((e) => e.uid === selectedEntryUid) ?? null;
+  }, [resolvedEntries, selectedEntryUid]);
+
+  const selectedSkill = useMemo(() => {
+    if (!selectedEntry) return null;
+    return allSkillMap.get(selectedEntry.resolvedSkillId) ?? null;
+  }, [selectedEntry, allSkillMap]);
 
   // 範囲選択PPS
   const rangePps = useMemo(() => {
@@ -229,7 +248,18 @@ export function App() {
           ppsRange={ppsRange}
           onPpsRangeChange={setPpsRange}
           lastGcdEndTime={timelineResult.lastGcdEndTime}
+          selectedEntryUid={selectedEntryUid}
+          onSelectEntry={setSelectedEntryUid}
         />
+        {selectedEntry && selectedSkill && (
+          <SkillDetailPanel
+            entry={selectedEntry}
+            resolvedSkill={selectedSkill}
+            buffDefMap={buffDefMap}
+            stats={stats}
+            onClose={() => setSelectedEntryUid(null)}
+          />
+        )}
       </div>
       <footer style={styles.footer}>
         <small style={styles.copyright}>

--- a/src/client/components/SkillDetailPanel.tsx
+++ b/src/client/components/SkillDetailPanel.tsx
@@ -48,8 +48,10 @@ export function SkillDetailPanel({
     entry.recastError;
 
   // エラー時は entry.buffMultiplier / critRateBonus / dhRateBonus が 0/1 に倒されるため、
-  // 個別バフ寄与も同様に空扱いにして集約値との整合を保つ
-  const contributions = hasError ? [] : getBuffContributions(entry.activeBuffs, buffDefMap, entry.resolvedSkillId);
+  // 個別バフ寄与も同様に空扱いにして集約値との整合を保つ。
+  // 入力には activeBuffsAtUse（消費前スナップショット）を使う。ライフサージ等の guaranteedCrit は
+  // GCD 使用時に消費され activeBuffs には残らないため、消費前の状態でないと内訳を引けない。
+  const contributions = hasError ? [] : getBuffContributions(entry.activeBuffsAtUse, buffDefMap, entry.resolvedSkillId);
   const potencyContribs = contributions.filter((c) => c.potencyMultiplier !== undefined);
   const critContribs = contributions.filter((c) => c.critRateBonus !== undefined || c.guaranteedCrit);
   const dhContribs = contributions.filter((c) => c.dhRateBonus !== undefined || c.guaranteedDh);

--- a/src/client/components/SkillDetailPanel.tsx
+++ b/src/client/components/SkillDetailPanel.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useRef } from "react";
+import type { ResolvedTimelineEntry, Skill, BuffDefinition, CharacterStats } from "../types/skill";
+import { calcExpectedMultiplier } from "../logic/stat-calc";
+import { getBuffContributions } from "../logic/buff-contribution";
+
+interface SkillDetailPanelProps {
+  entry: ResolvedTimelineEntry;
+  /** entry.resolvedSkillId に対応するスキル（autoTransform 後の実表示スキル） */
+  resolvedSkill: Skill;
+  buffDefMap: Map<string, BuffDefinition>;
+  stats: CharacterStats;
+  onClose: () => void;
+}
+
+export function SkillDetailPanel({
+  entry,
+  resolvedSkill,
+  buffDefMap,
+  stats,
+  onClose,
+}: SkillDetailPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (panelRef.current?.contains(target)) return;
+      // Timeline のスキルアイコンをクリックした場合は、新しいエントリへの切替なので閉じない
+      if (target.closest?.("[data-skill-entry-uid]")) return;
+      onClose();
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const hasError =
+    entry.resourceErrors.length > 0 ||
+    entry.comboErrors.length > 0 ||
+    entry.untargetableError ||
+    entry.recastError;
+
+  const contributions = getBuffContributions(entry.activeBuffs, buffDefMap, entry.resolvedSkillId);
+  const potencyContribs = contributions.filter((c) => c.potencyMultiplier !== undefined);
+  const critContribs = contributions.filter((c) => c.critRateBonus !== undefined || c.guaranteedCrit);
+  const dhContribs = contributions.filter((c) => c.dhRateBonus !== undefined || c.guaranteedDh);
+
+  const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
+  const expectedMul = calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus);
+  const expectedValue = !hasError && entry.resolvedPotency > 0
+    ? Math.floor(buffedPotency * expectedMul)
+    : null;
+
+  const errorMessages: string[] = [];
+  if (entry.resourceErrors.length > 0) errorMessages.push(`リソース不足: ${entry.resourceErrors.join(", ")}`);
+  if (entry.comboErrors.length > 0) errorMessages.push(`バフ条件未達成: ${entry.comboErrors.join(", ")}`);
+  if (entry.untargetableError) errorMessages.push("ボス離脱中");
+  if (entry.recastError) errorMessages.push("リキャスト中");
+
+  return (
+    <aside ref={panelRef} style={styles.panel} aria-label="スキル詳細パネル">
+      <div style={styles.header}>
+        <img src={resolvedSkill.icon} alt={resolvedSkill.name} style={styles.headerIcon} />
+        <div style={styles.headerText}>
+          <div style={styles.headerName}>{resolvedSkill.name}</div>
+          <div style={styles.headerStartTime}>開始時刻: {entry.startTime.toFixed(2)}s</div>
+        </div>
+        <button type="button" onClick={onClose} style={styles.closeButton} aria-label="閉じる">×</button>
+      </div>
+
+      <div style={styles.body}>
+        <Row label="基本威力" value={`${entry.resolvedPotency}`} />
+
+        <Section label="バフ倍率" value={`×${entry.buffMultiplier.toFixed(2)}`}>
+          {potencyContribs.length === 0 ? (
+            <div style={styles.emptyContrib}>適用なし</div>
+          ) : (
+            potencyContribs.map((c) => (
+              <ContribRow
+                key={c.buffId}
+                name={c.name}
+                value={`×${c.potencyMultiplier!.toFixed(2)}`}
+                color={c.color}
+              />
+            ))
+          )}
+        </Section>
+
+        <Section label="CRT率ボーナス" value={formatPercent(entry.critRateBonus)}>
+          {critContribs.length === 0 ? (
+            <div style={styles.emptyContrib}>適用なし</div>
+          ) : (
+            critContribs.map((c) => (
+              <ContribRow
+                key={c.buffId}
+                name={c.name}
+                value={c.guaranteedCrit
+                  ? "確定CRT"
+                  : formatPercent(c.critRateBonus ?? 0)}
+                color={c.color}
+              />
+            ))
+          )}
+        </Section>
+
+        <Section label="DH率ボーナス" value={formatPercent(entry.dhRateBonus)}>
+          {dhContribs.length === 0 ? (
+            <div style={styles.emptyContrib}>適用なし</div>
+          ) : (
+            dhContribs.map((c) => (
+              <ContribRow
+                key={c.buffId}
+                name={c.name}
+                value={c.guaranteedDh
+                  ? "確定DH"
+                  : formatPercent(c.dhRateBonus ?? 0)}
+                color={c.color}
+              />
+            ))
+          )}
+        </Section>
+
+        <div style={styles.expectedBox}>
+          <div style={styles.sectionLabel}>期待値</div>
+          <div style={styles.expectedValue}>
+            {expectedValue !== null ? expectedValue : "—"}
+          </div>
+          {expectedValue !== null && (
+            <div style={styles.expectedFormula}>
+              {entry.resolvedPotency} × {entry.buffMultiplier.toFixed(2)} × {expectedMul.toFixed(3)} = {expectedValue}
+            </div>
+          )}
+        </div>
+
+        <div style={styles.metaRow}>
+          <span style={styles.metaLabel}>コンボ:</span>
+          <span style={entry.wsComboError ? styles.metaWarning : styles.metaOk}>
+            {entry.wsComboError ? "不成立" : "成立"}
+          </span>
+        </div>
+
+        <div style={styles.metaRow}>
+          <span style={styles.metaLabel}>エラー:</span>
+          {errorMessages.length === 0 ? (
+            <span style={styles.metaOk}>なし</span>
+          ) : (
+            <span style={styles.metaError}>{errorMessages.join(" / ")}</span>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function formatPercent(value: number): string {
+  const pct = value * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={styles.row}>
+      <span style={styles.rowLabel}>{label}</span>
+      <span style={styles.rowValue}>{value}</span>
+    </div>
+  );
+}
+
+function Section({ label, value, children }: { label: string; value: string; children: React.ReactNode }) {
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionHeader}>
+        <span style={styles.sectionLabel}>■ {label}</span>
+        <span style={styles.sectionValue}>{value}</span>
+      </div>
+      <div style={styles.contribList}>{children}</div>
+    </div>
+  );
+}
+
+function ContribRow({ name, value, color }: { name: string; value: string; color: string }) {
+  return (
+    <div style={styles.contribRow}>
+      <span style={{ ...styles.contribBullet, backgroundColor: color }} />
+      <span style={styles.contribName}>{name}</span>
+      <span style={styles.contribValue}>{value}</span>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  panel: {
+    width: "320px",
+    flexShrink: 0,
+    backgroundColor: "#1a1a2e",
+    borderLeft: "1px solid #333",
+    color: "#e0e0e0",
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: "10px",
+    padding: "12px",
+    backgroundColor: "#16213e",
+    borderBottom: "1px solid #333",
+  },
+  headerIcon: {
+    width: "40px",
+    height: "40px",
+    borderRadius: "6px",
+    flexShrink: 0,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  headerName: {
+    fontSize: "15px",
+    fontWeight: "bold",
+    color: "#ffd700",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
+  headerStartTime: {
+    fontSize: "11px",
+    color: "#888",
+    marginTop: "2px",
+  },
+  closeButton: {
+    background: "none",
+    border: "1px solid #555",
+    borderRadius: "4px",
+    color: "#aaa",
+    fontSize: "16px",
+    width: "24px",
+    height: "24px",
+    cursor: "pointer",
+    padding: 0,
+    lineHeight: 1,
+    flexShrink: 0,
+  },
+  body: {
+    flex: 1,
+    overflowY: "auto",
+    padding: "12px",
+  },
+  row: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: "6px 0",
+    borderBottom: "1px solid #222",
+  },
+  rowLabel: {
+    fontSize: "12px",
+    color: "#aaa",
+  },
+  rowValue: {
+    fontSize: "14px",
+    color: "#e0e0e0",
+    fontWeight: "bold",
+  },
+  section: {
+    marginTop: "12px",
+  },
+  sectionHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    fontSize: "12px",
+  },
+  sectionLabel: {
+    color: "#aaa",
+  },
+  sectionValue: {
+    color: "#ffd700",
+    fontWeight: "bold",
+    fontSize: "13px",
+  },
+  contribList: {
+    marginTop: "4px",
+    paddingLeft: "12px",
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+  },
+  contribRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    fontSize: "11px",
+  },
+  contribBullet: {
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    flexShrink: 0,
+  },
+  contribName: {
+    flex: 1,
+    color: "#ccc",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
+  contribValue: {
+    color: "#e0e0e0",
+  },
+  emptyContrib: {
+    fontSize: "11px",
+    color: "#666",
+    fontStyle: "italic" as const,
+  },
+  expectedBox: {
+    marginTop: "16px",
+    padding: "10px",
+    backgroundColor: "#0f0f23",
+    border: "1px solid #333",
+    borderRadius: "6px",
+  },
+  expectedValue: {
+    fontSize: "22px",
+    fontWeight: "bold",
+    color: "#ffd700",
+    marginTop: "2px",
+  },
+  expectedFormula: {
+    fontSize: "11px",
+    color: "#888",
+    marginTop: "4px",
+    fontFamily: "monospace",
+  },
+  metaRow: {
+    display: "flex",
+    gap: "8px",
+    marginTop: "10px",
+    fontSize: "12px",
+  },
+  metaLabel: {
+    color: "#aaa",
+    flexShrink: 0,
+  },
+  metaOk: {
+    color: "#88dd88",
+  },
+  metaWarning: {
+    color: "#ff9800",
+  },
+  metaError: {
+    color: "#ef5350",
+  },
+};

--- a/src/client/components/SkillDetailPanel.tsx
+++ b/src/client/components/SkillDetailPanel.tsx
@@ -47,7 +47,9 @@ export function SkillDetailPanel({
     entry.untargetableError ||
     entry.recastError;
 
-  const contributions = getBuffContributions(entry.activeBuffs, buffDefMap, entry.resolvedSkillId);
+  // エラー時は entry.buffMultiplier / critRateBonus / dhRateBonus が 0/1 に倒されるため、
+  // 個別バフ寄与も同様に空扱いにして集約値との整合を保つ
+  const contributions = hasError ? [] : getBuffContributions(entry.activeBuffs, buffDefMap, entry.resolvedSkillId);
   const potencyContribs = contributions.filter((c) => c.potencyMultiplier !== undefined);
   const critContribs = contributions.filter((c) => c.critRateBonus !== undefined || c.guaranteedCrit);
   const dhContribs = contributions.filter((c) => c.dhRateBonus !== undefined || c.guaranteedDh);

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -57,6 +57,8 @@ interface TimelineProps {
   ppsRange: PpsRange | null;
   onPpsRangeChange: (range: PpsRange | null) => void;
   lastGcdEndTime: number;
+  selectedEntryUid: string | null;
+  onSelectEntry: (uid: string | null) => void;
 }
 
 /**
@@ -112,6 +114,8 @@ export function Timeline({
   ppsRange,
   onPpsRangeChange,
   lastGcdEndTime,
+  selectedEntryUid,
+  onSelectEntry,
 }: TimelineProps) {
   const [dragOver, setDragOver] = useState(false);
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
@@ -979,9 +983,12 @@ export function Timeline({
                             ...styles.skillIcon,
                             ...(hasError ? styles.skillIconError : {}),
                             ...(entry.wsComboError ? styles.skillIconComboWarning : {}),
+                            ...(selectedEntryUid === entry.uid ? styles.skillIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.skillIconDragging : {}),
                           }}
                           title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          data-skill-entry-uid={entry.uid}
+                          onClick={() => onSelectEntry(entry.uid)}
                           draggable
                           onDragStart={(e) => handleEntryDragStart(e, entry, entry.skill)}
                           onDragEnd={handleEntryDragEnd}
@@ -1030,9 +1037,12 @@ export function Timeline({
                           style={{
                             ...styles.ogcdIcon,
                             ...(hasError ? styles.ogcdIconError : {}),
+                            ...(selectedEntryUid === entry.uid ? styles.ogcdIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.ogcdIconDragging : {}),
                           }}
                           title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          data-skill-entry-uid={entry.uid}
+                          onClick={() => onSelectEntry(entry.uid)}
                           draggable
                           onDragStart={(e) => handleEntryDragStart(e, entry, entry.skill)}
                           onDragEnd={handleEntryDragEnd}
@@ -1615,6 +1625,10 @@ const styles: Record<string, React.CSSProperties> = {
     border: "2px solid #ff9800",
     boxShadow: "0 0 8px rgba(255, 152, 0, 0.6)",
   },
+  skillIconSelected: {
+    border: "2px solid #ffd700",
+    boxShadow: "0 0 8px rgba(255, 215, 0, 0.6)",
+  },
   skillIconDragging: {
     opacity: 0.3,
   },
@@ -1638,6 +1652,10 @@ const styles: Record<string, React.CSSProperties> = {
   ogcdIconError: {
     border: "2px solid #ef5350",
     boxShadow: "0 0 8px rgba(239, 83, 80, 0.6)",
+  },
+  ogcdIconSelected: {
+    border: "2px solid #ffd700",
+    boxShadow: "0 0 8px rgba(255, 215, 0, 0.6)",
   },
   ogcdIconDragging: {
     opacity: 0.3,

--- a/src/client/logic/__tests__/active-buffs-at-use.test.ts
+++ b/src/client/logic/__tests__/active-buffs-at-use.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, BuffDefinition, TimelineEntry } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+describe("ResolvedTimelineEntry.activeBuffsAtUse", () => {
+  const lifeSurgeLikeBuff: BuffDefinition = {
+    id: "life-surge",
+    name: "ライフサージ",
+    shortName: "LS",
+    icon: "",
+    duration: 5,
+    effects: [{ type: "guaranteedCrit", value: 1 }],
+    color: "#4caf50",
+    maxStacks: 1,
+  };
+
+  it("guaranteedCrit バフは GCD 使用時に消費されるが、activeBuffsAtUse には残る", () => {
+    const surge = makeSkill({
+      id: "life-surge",
+      type: "ogcd",
+      potency: 0,
+      buffApplications: ["life-surge"],
+    });
+    const gcd = makeSkill({ id: "attack-gcd", potency: 200 });
+    const skillMap = new Map([
+      [surge.id, surge],
+      [gcd.id, gcd],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry(surge.id), makeEntry(gcd.id)],
+      skillMap,
+      [],
+      undefined,
+      [lifeSurgeLikeBuff],
+      []
+    );
+
+    const gcdEntry = result.entries[1];
+
+    // guaranteedCrit が効いているので critRateBonus は 1（100%）
+    expect(gcdEntry.critRateBonus).toBe(1);
+
+    // activeBuffs（post-consumption）には残っていない
+    expect(gcdEntry.activeBuffs.some((ab) => ab.buffId === "life-surge")).toBe(false);
+
+    // activeBuffsAtUse（pre-consumption）には残っている
+    expect(gcdEntry.activeBuffsAtUse.some((ab) => ab.buffId === "life-surge")).toBe(true);
+  });
+
+  it("通常のバフは activeBuffs と activeBuffsAtUse の両方に含まれる", () => {
+    const potencyBuff: BuffDefinition = {
+      id: "power",
+      name: "パワー",
+      shortName: "P",
+      icon: "",
+      duration: 20,
+      effects: [{ type: "potency", value: 1.2 }],
+      color: "#ff0000",
+    };
+    const buffSkill = makeSkill({
+      id: "power-up",
+      type: "ogcd",
+      potency: 0,
+      buffApplications: ["power"],
+    });
+    const gcd = makeSkill({ id: "atk", potency: 100 });
+    const skillMap = new Map([
+      [buffSkill.id, buffSkill],
+      [gcd.id, gcd],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry(buffSkill.id), makeEntry(gcd.id)],
+      skillMap,
+      [],
+      undefined,
+      [potencyBuff],
+      []
+    );
+
+    const gcdEntry = result.entries[1];
+    expect(gcdEntry.activeBuffs.some((ab) => ab.buffId === "power")).toBe(true);
+    expect(gcdEntry.activeBuffsAtUse.some((ab) => ab.buffId === "power")).toBe(true);
+  });
+});

--- a/src/client/logic/__tests__/buff-contribution.test.ts
+++ b/src/client/logic/__tests__/buff-contribution.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { getBuffContributions } from "../buff-contribution";
+import type { ActiveBuff, BuffDefinition } from "../../types/skill";
+
+function makeBuff(overrides: Partial<BuffDefinition> & { id: string }): BuffDefinition {
+  return {
+    name: overrides.id,
+    shortName: overrides.id,
+    icon: "",
+    duration: 30,
+    effects: [],
+    color: "#fff",
+    ...overrides,
+  };
+}
+
+function makeActiveBuff(buffId: string, stacks?: number): ActiveBuff {
+  return { buffId, startTime: 0, endTime: 30, stacks };
+}
+
+describe("getBuffContributions", () => {
+  it("potency / critRate / dhRate のいずれかに寄与するバフだけ返す", () => {
+    const potencyOnly = makeBuff({ id: "potency-only", effects: [{ type: "potency", value: 1.1 }] });
+    const speedOnly = makeBuff({ id: "speed-only", effects: [{ type: "speed", value: 0.85 }] });
+    const noEffect = makeBuff({ id: "no-effect", effects: [] });
+    const buffDefMap = new Map([
+      [potencyOnly.id, potencyOnly],
+      [speedOnly.id, speedOnly],
+      [noEffect.id, noEffect],
+    ]);
+    const activeBuffs = [makeActiveBuff("potency-only"), makeActiveBuff("speed-only"), makeActiveBuff("no-effect")];
+
+    const result = getBuffContributions(activeBuffs, buffDefMap, "any-skill");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].buffId).toBe("potency-only");
+    expect(result[0].potencyMultiplier).toBeCloseTo(1.1);
+  });
+
+  it("potency effect の appliesToSkillIds が targetSkillId を含まない場合は除外する", () => {
+    const af3 = makeBuff({
+      id: "af3",
+      effects: [
+        { type: "potency", value: 1.8, appliesToSkillIds: ["fire-skill"] },
+      ],
+    });
+    const buffDefMap = new Map([[af3.id, af3]]);
+    const activeBuffs = [makeActiveBuff("af3")];
+
+    const onFire = getBuffContributions(activeBuffs, buffDefMap, "fire-skill");
+    expect(onFire).toHaveLength(1);
+    expect(onFire[0].potencyMultiplier).toBeCloseTo(1.8);
+
+    const onBlizzard = getBuffContributions(activeBuffs, buffDefMap, "blizzard-skill");
+    expect(onBlizzard).toHaveLength(0);
+  });
+
+  it("critRate と dhRate を加算合計として抽出する", () => {
+    const battleLitany = makeBuff({
+      id: "battle-litany",
+      effects: [{ type: "critRate", value: 0.1 }],
+    });
+    const battleVoice = makeBuff({
+      id: "battle-voice",
+      effects: [{ type: "dhRate", value: 0.2 }],
+    });
+    const buffDefMap = new Map([
+      [battleLitany.id, battleLitany],
+      [battleVoice.id, battleVoice],
+    ]);
+    const result = getBuffContributions(
+      [makeActiveBuff("battle-litany"), makeActiveBuff("battle-voice")],
+      buffDefMap,
+      "any-skill"
+    );
+
+    expect(result).toHaveLength(2);
+    const crit = result.find((c) => c.buffId === "battle-litany")!;
+    expect(crit.critRateBonus).toBeCloseTo(0.1);
+    expect(crit.dhRateBonus).toBeUndefined();
+    const dh = result.find((c) => c.buffId === "battle-voice")!;
+    expect(dh.dhRateBonus).toBeCloseTo(0.2);
+    expect(dh.critRateBonus).toBeUndefined();
+  });
+
+  it("guaranteedCrit / guaranteedDh は値が無くてもリストに残す", () => {
+    const reassemble = makeBuff({
+      id: "reassemble",
+      effects: [{ type: "guaranteedCrit", value: 0 }, { type: "guaranteedDh", value: 0 }],
+    });
+    const buffDefMap = new Map([[reassemble.id, reassemble]]);
+    const result = getBuffContributions([makeActiveBuff("reassemble")], buffDefMap, "any-skill");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].guaranteedCrit).toBe(true);
+    expect(result[0].guaranteedDh).toBe(true);
+    expect(result[0].potencyMultiplier).toBeUndefined();
+  });
+
+  it("複数の potency effect は積として合成される", () => {
+    const multiBuff = makeBuff({
+      id: "multi",
+      effects: [
+        { type: "potency", value: 1.1 },
+        { type: "potency", value: 1.2 },
+      ],
+    });
+    const buffDefMap = new Map([[multiBuff.id, multiBuff]]);
+    const result = getBuffContributions([makeActiveBuff("multi")], buffDefMap, "any-skill");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].potencyMultiplier).toBeCloseTo(1.32);
+  });
+
+  it("buffDefMap に存在しない buffId は無視する", () => {
+    const result = getBuffContributions([makeActiveBuff("unknown")], new Map(), "any-skill");
+    expect(result).toHaveLength(0);
+  });
+
+  it("ActiveBuff の stacks をそのまま引き継ぐ", () => {
+    const stackedBuff = makeBuff({
+      id: "stacked",
+      maxStacks: 3,
+      effects: [{ type: "potency", value: 1.05 }],
+    });
+    const buffDefMap = new Map([[stackedBuff.id, stackedBuff]]);
+    const result = getBuffContributions([makeActiveBuff("stacked", 2)], buffDefMap, "any-skill");
+    expect(result[0].stacks).toBe(2);
+  });
+});

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -26,6 +26,7 @@ function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimeli
     recastError: false,
     wsComboError: false,
     activeBuffs,
+    activeBuffsAtUse: activeBuffs,
     buffMultiplier: 1,
     critRateBonus: 0,
     dhRateBonus: 0,

--- a/src/client/logic/buff-contribution.ts
+++ b/src/client/logic/buff-contribution.ts
@@ -1,0 +1,92 @@
+import type { ActiveBuff, BuffDefinition } from "../types/skill";
+
+/**
+ * 詳細パネル表示用のバフ寄与情報。
+ * 1 つの ActiveBuff から、そのスキルへ実際に効くエフェクトのみを抽出した結果。
+ */
+export interface BuffContribution {
+  buffId: string;
+  name: string;
+  shortName: string;
+  icon: string;
+  color: string;
+  stacks?: number;
+  /** 威力倍率寄与（potency effect の積。寄与なしは undefined） */
+  potencyMultiplier?: number;
+  /** クリティカル率ボーナス寄与（critRate effect の和。寄与なしは undefined） */
+  critRateBonus?: number;
+  /** ダイレクトヒット率ボーナス寄与（dhRate effect の和。寄与なしは undefined） */
+  dhRateBonus?: number;
+  /** guaranteedCrit を保有するか */
+  guaranteedCrit?: boolean;
+  /** guaranteedDh を保有するか */
+  guaranteedDh?: boolean;
+}
+
+/**
+ * 指定スキルに対する各 ActiveBuff の寄与を抽出する。
+ * potency / critRate / dhRate / guaranteedCrit / guaranteedDh のいずれかに寄与するバフだけ返す。
+ *
+ * potency の appliesToSkillIds フィルタは resolve-timeline.ts:getPotencyMultiplier と同じロジック。
+ */
+export function getBuffContributions(
+  activeBuffs: ActiveBuff[],
+  buffDefMap: Map<string, BuffDefinition>,
+  targetSkillId: string
+): BuffContribution[] {
+  const result: BuffContribution[] = [];
+  for (const ab of activeBuffs) {
+    const def = buffDefMap.get(ab.buffId);
+    if (!def) continue;
+
+    let potencyMul = 1;
+    let hasPotency = false;
+    let critBonus = 0;
+    let hasCrit = false;
+    let dhBonus = 0;
+    let hasDh = false;
+    let guaranteedCrit = false;
+    let guaranteedDh = false;
+
+    for (const effect of def.effects) {
+      switch (effect.type) {
+        case "potency":
+          if (effect.appliesToSkillIds && !effect.appliesToSkillIds.includes(targetSkillId)) continue;
+          potencyMul *= effect.value;
+          hasPotency = true;
+          break;
+        case "critRate":
+          critBonus += effect.value;
+          hasCrit = true;
+          break;
+        case "dhRate":
+          dhBonus += effect.value;
+          hasDh = true;
+          break;
+        case "guaranteedCrit":
+          guaranteedCrit = true;
+          break;
+        case "guaranteedDh":
+          guaranteedDh = true;
+          break;
+      }
+    }
+
+    if (!hasPotency && !hasCrit && !hasDh && !guaranteedCrit && !guaranteedDh) continue;
+
+    result.push({
+      buffId: ab.buffId,
+      name: def.name,
+      shortName: def.shortName,
+      icon: def.icon,
+      color: def.color,
+      stacks: ab.stacks,
+      potencyMultiplier: hasPotency ? potencyMul : undefined,
+      critRateBonus: hasCrit ? critBonus : undefined,
+      dhRateBonus: hasDh ? dhBonus : undefined,
+      guaranteedCrit: guaranteedCrit || undefined,
+      guaranteedDh: guaranteedDh || undefined,
+    });
+  }
+  return result;
+}

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -1321,6 +1321,11 @@ export function resolveTimeline(
     const critRateBonus = critRateBonusBeforeApply;
     const dhRateBonus = dhRateBonusBeforeApply;
 
+    // 消費が走る前のアクティブバフを退避（詳細パネル等の表示用途）。
+    // 以降の consumeGuaranteedCritBuffs / consumeBuffTargets で `currentActiveBuffs` が
+    // ミューテートされるため、この行は消費前である必要がある。
+    const activeBuffsAtUse: ActiveBuff[] = [...currentActiveBuffs];
+
     // buffConsumptionsで既に消費されたバフIDを収集（二重消費防止）
     const consumedByBuffConsumptions = new Set(
       skill.buffConsumptions?.map((c) => c.buffId) ?? []
@@ -1382,6 +1387,7 @@ export function resolveTimeline(
       recastError,
       wsComboError,
       activeBuffs: [...currentActiveBuffs],
+      activeBuffsAtUse,
       buffMultiplier,
       critRateBonus,
       dhRateBonus,

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -407,8 +407,18 @@ export interface ResolvedTimelineEntry {
   recastError: boolean;
   /** WSコンボ不成立（エラーではないがコンボ威力が適用されない） */
   wsComboError: boolean;
-  /** このスキル使用時にアクティブなバフ一覧 */
+  /**
+   * このエントリ実行**後**にアクティブなバフ一覧（guaranteedCrit/Dh・consumeOnGcd 等の
+   * 自動消費を反映済み）。次エントリの speed 計算 / バフレーン終端検出に使用される。
+   */
   activeBuffs: ActiveBuff[];
+  /**
+   * このエントリ実行**前**（消費が走る前）にアクティブだったバフ一覧のスナップショット。
+   * ライフサージ等の guaranteedCrit バフは GCD 使用時に消費されるため `activeBuffs` には
+   * 残らないが、UI 側で「このスキルに効いたバフの内訳」を表示するには消費前の状態が必要。
+   * 詳細パネル等の表示用途で使う。
+   */
+  activeBuffsAtUse: ActiveBuff[];
   /** 威力バフの合成倍率（1.0 = バフなし） */
   buffMultiplier: number;
   /** クリティカル発生率ボーナス（0.0 = バフなし、0.1 = +10%） */


### PR DESCRIPTION
## 概要

タイムライン上のスキルアイコンをクリックすると、画面右側に詳細情報パネルが開く。基本威力 / バフ倍率（個別寄与の内訳）/ CRT率ボーナス（内訳）/ DH率ボーナス（内訳）/ 期待値計算式 / コンボ成否 / エラー状態を一覧表示し、ローテーション最適化時に「なぜこの期待値になるのか」を構造的に確認できるようにする。

## 変更点

### 新規ファイル

- `src/client/logic/buff-contribution.ts`
  - `activeBuffs` と `buffDefMap` から、対象スキルに実際に効くバフごとの `potency` / `critRate` / `dhRate` / `guaranteedCrit` / `guaranteedDh` 寄与を抽出する純粋関数 `getBuffContributions`
  - `appliesToSkillIds` によるスキル限定フィルタは `resolve-timeline.ts:getPotencyMultiplier` と同ロジック
- `src/client/components/SkillDetailPanel.tsx`
  - 右側 320px の固定サイドパネル。スタイルは既存のインライン `style={styles.xxx}` 慣習に従う
  - 閉じる手段は ×ボタン / 外側クリック / Escape キーの3通り
  - Timeline のスキルアイコン上の mousedown は選択切替として扱うため、誤って閉じないよう `data-skill-entry-uid` を data 属性で識別
- `src/client/logic/__tests__/buff-contribution.test.ts`
  - フィルタ／appliesToSkillIds／加算・積／guaranteed フラグ／不明buffId／stacks の 7 ケース

### 修正

- `src/client/components/Timeline.tsx`
  - GCD/oGCD アイコン div に `onClick` と `data-skill-entry-uid` を追加
  - 選択中エントリは金色枠でハイライト（`skillIconSelected` / `ogcdIconSelected`）
  - 既存の `title=` ツールチップはホバー時の素早い確認用としてそのまま残置
- `src/client/components/App.tsx`
  - `selectedEntryUid` を state として保持。ジョブ変更／エントリ削除時に `null` クリア
  - `main` flex の3カラム目に `SkillDetailPanel` を条件付きで配置

### バグ修正（同PRに含む）

- リソース不足・コンボエラー時に `entry.buffMultiplier=1` でも個別バフ寄与は残るため「バフ倍率 ×1.00」と「ランスチャージ ×1.15」が並ぶ矛盾表示が発生していたのを修正（エラー時は contributions を空配列に倒す）

## テスト

- `npx tsc --noEmit`: 通過
- `npm test -- --run`: 22 ファイル 182 テスト 全通過（新規 7 ケース含む）
- Playwright での UI 動作確認（Windows 11 + Microsoft Edge）:
  - スキルアイコンクリック → パネルが右側に表示
  - 別スキルクリック → 内容が切り替わる（パネルは閉じない）
  - パネル外クリック → 閉じる
  - Escape キー → 閉じる
  - ×ボタン → 閉じる
  - エラー状態のスキル（バフ条件未達成）→ 期待値「—」、エラー欄に内容表示、バフ寄与は「適用なし」
  - 正常スキル（グレアガ）→ 期待値 357（350 × 1.00 × 1.020 = 357）の式と値を表示
  - 既存のドラッグ＆ドロップ操作に干渉しない（HTML5 仕様で `onClick` と `draggable` は同一フレームで競合しない）

closes #174
