### PR TITLE
fix: 自スキル付与の potency バフが SkillDetailPanel 内訳に出る不具合を修正 #263

### DIFF
--- a/src/client/logic/__tests__/self-applied-buff-snapshot.test.ts
+++ b/src/client/logic/__tests__/self-applied-buff-snapshot.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import { getBuffContributions } from "../buff-contribution";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+// Issue #263: スキル自身が付与する potency バフが、そのスキルの内訳 (SkillDetailPanel) に出現しないこと。
+// 集約 buffMultiplier は Issue #78 で既に修正済み (バフ適用前の状態で計算)。
+// 本テストは activeBuffsAtUse スナップショットも同じタイミングで取られ、内訳と集約が整合することを保証する。
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+const powerSurgeLike: BuffDefinition = {
+  id: "power-surge",
+  name: "竜槍",
+  shortName: "竜槍",
+  icon: "",
+  duration: 30,
+  effects: [{ type: "potency", value: 1.1 }],
+  color: "#ff5722",
+};
+
+describe("自スキル付与の potency バフは activeBuffsAtUse に含まれない (#263)", () => {
+  it("comboBuffApplications で付与する potency バフが、付与スキル自身の activeBuffsAtUse / 内訳に含まれない", () => {
+    const trueThrust = makeSkill({ id: "true-thrust" });
+    const spiralBlow = makeSkill({
+      id: "spiral-blow",
+      potency: 300,
+      nonComboPotency: 140,
+      comboFrom: ["true-thrust"],
+      comboBuffApplications: ["power-surge"],
+    });
+    const skillMap = new Map([
+      [trueThrust.id, trueThrust],
+      [spiralBlow.id, spiralBlow],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry(trueThrust.id), makeEntry(spiralBlow.id)],
+      skillMap,
+      [],
+      undefined,
+      [powerSurgeLike],
+      []
+    );
+
+    const spiralEntry = result.entries[1];
+
+    // 1. 集約倍率: 自スキル付与のため power-surge は含まれず ×1.0
+    expect(spiralEntry.buffMultiplier).toBe(1);
+
+    // 2. activeBuffsAtUse (内訳の入力): power-surge を含まない
+    expect(spiralEntry.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(false);
+
+    // 3. SkillDetailPanel の内訳: power-surge が現れない (集約 ×1.0 と整合)
+    const buffDefMap = new Map([[powerSurgeLike.id, powerSurgeLike]]);
+    const contributions = getBuffContributions(
+      spiralEntry.activeBuffsAtUse,
+      buffDefMap,
+      spiralEntry.resolvedSkillId
+    );
+    expect(contributions.some((c) => c.buffId === "power-surge")).toBe(false);
+  });
+
+  it("buffApplications で付与する potency バフも、付与スキル自身の activeBuffsAtUse に含まれない", () => {
+    const buffSelfApply = makeSkill({
+      id: "self-buff-attack",
+      potency: 200,
+      buffApplications: ["power-surge"],
+    });
+    const skillMap = new Map([[buffSelfApply.id, buffSelfApply]]);
+
+    const result = resolveTimeline(
+      [makeEntry(buffSelfApply.id)],
+      skillMap,
+      [],
+      undefined,
+      [powerSurgeLike],
+      []
+    );
+
+    const entry = result.entries[0];
+    expect(entry.buffMultiplier).toBe(1);
+    expect(entry.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(false);
+  });
+
+  it("前のコンボで付与された竜槍は、次のスパイラルブロウの activeBuffsAtUse / 内訳に含まれる (回帰確認)", () => {
+    const trueThrust = makeSkill({ id: "true-thrust" });
+    const spiralBlow = makeSkill({
+      id: "spiral-blow",
+      potency: 300,
+      nonComboPotency: 140,
+      comboFrom: ["true-thrust"],
+      comboBuffApplications: ["power-surge"],
+    });
+    const skillMap = new Map([
+      [trueThrust.id, trueThrust],
+      [spiralBlow.id, spiralBlow],
+    ]);
+
+    // true-thrust → spiral-blow (1周目: 竜槍付与) → true-thrust → spiral-blow (2周目: 前回の竜槍が乗る)
+    const result = resolveTimeline(
+      [
+        makeEntry(trueThrust.id),
+        makeEntry(spiralBlow.id),
+        makeEntry(trueThrust.id),
+        makeEntry(spiralBlow.id),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [powerSurgeLike],
+      []
+    );
+
+    const firstSpiral = result.entries[1];
+    const secondSpiral = result.entries[3];
+
+    // 1周目: 自スキル付与のため power-surge なし
+    expect(firstSpiral.buffMultiplier).toBe(1);
+    expect(firstSpiral.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(false);
+
+    // 2周目: 前回の竜槍が残っており、+10% 適用される
+    expect(secondSpiral.buffMultiplier).toBeCloseTo(1.1, 5);
+    expect(secondSpiral.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(true);
+  });
+
+  it("ディセムボウル (comboBuffApplications: [power-surge]) も同じ性質を持つ", () => {
+    const trueThrust = makeSkill({ id: "true-thrust" });
+    const disembowel = makeSkill({
+      id: "disembowel",
+      potency: 210,
+      nonComboPotency: 100,
+      comboFrom: ["true-thrust"],
+      comboBuffApplications: ["power-surge"],
+    });
+    const skillMap = new Map([
+      [trueThrust.id, trueThrust],
+      [disembowel.id, disembowel],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry(trueThrust.id), makeEntry(disembowel.id)],
+      skillMap,
+      [],
+      undefined,
+      [powerSurgeLike],
+      []
+    );
+
+    const disembowelEntry = result.entries[1];
+    expect(disembowelEntry.buffMultiplier).toBe(1);
+    expect(disembowelEntry.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(false);
+  });
+
+  it("コンボ不成立で comboBuffApplications が走らないケースでは付与もされない", () => {
+    const spiralBlow = makeSkill({
+      id: "spiral-blow",
+      potency: 300,
+      nonComboPotency: 140,
+      comboFrom: ["true-thrust"],
+      comboBuffApplications: ["power-surge"],
+    });
+    const skillMap = new Map([[spiralBlow.id, spiralBlow]]);
+
+    // true-thrust なしで spiral-blow を単独実行 → wsComboError で comboBuffApplications はスキップ
+    const result = resolveTimeline(
+      [makeEntry(spiralBlow.id)],
+      skillMap,
+      [],
+      undefined,
+      [powerSurgeLike],
+      []
+    );
+
+    const entry = result.entries[0];
+    expect(entry.wsComboError).toBe(true);
+    // activeBuffs (post-everything) にも power-surge は付与されない
+    expect(entry.activeBuffs.some((ab) => ab.buffId === "power-surge")).toBe(false);
+    expect(entry.activeBuffsAtUse.some((ab) => ab.buffId === "power-surge")).toBe(false);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -1012,6 +1012,13 @@ export function resolveTimeline(
     // 直接ダメージ用: guaranteedDhの場合は100%に上書き
     const dhRateBonusBeforeApply = guaranteedDhBeforeApply ? 1 : baseDhRateBonus;
 
+    // 詳細パネル等で「このスキルの威力に寄与したバフ」を表示するためのスナップショット。
+    // buffMultiplierBeforeApply / *BeforeApply と同じタイミングで取得することで、
+    // スキル自身が付与する potency バフが内訳に含まれない（集約倍率との整合）。
+    // 後段で buffApplications/comboBuffApplications/buffConsumptions/guaranteedCrit 消費等が走るが、
+    // それらは「このスキルが実行された結果」であり、寄与判定の入力には含めない。
+    const activeBuffsAtUse: ActiveBuff[] = [...currentActiveBuffs];
+
     if (!hasError) {
       const onResourceApplied = (def: ResourceDefinition) => {
         // リソースが最大未満になったら自動生成タイマーを開始
@@ -1320,11 +1327,6 @@ export function resolveTimeline(
     const guaranteedCrit = guaranteedCritBeforeApply;
     const critRateBonus = critRateBonusBeforeApply;
     const dhRateBonus = dhRateBonusBeforeApply;
-
-    // 消費が走る前のアクティブバフを退避（詳細パネル等の表示用途）。
-    // 以降の consumeGuaranteedCritBuffs / consumeBuffTargets で `currentActiveBuffs` が
-    // ミューテートされるため、この行は消費前である必要がある。
-    const activeBuffsAtUse: ActiveBuff[] = [...currentActiveBuffs];
 
     // buffConsumptionsで既に消費されたバフIDを収集（二重消費防止）
     const consumedByBuffConsumptions = new Set(


### PR DESCRIPTION
## 概要

スパイラルブロウ等の `comboBuffApplications: ["power-surge"]` を持つスキルで、自スキルが付与する竜槍バフが SkillDetailPanel（#174）の内訳に「竜槍 ×1.10」として表示され、集約 `buffMultiplier` ×1.0 と乖離していたバグを修正。

## 原因

- 集約 `buffMultiplier` は Issue #78 で既にバフ適用前のタイミング（`resolve-timeline.ts:1004`）で計算されており、計算自体は正しい。
- ただし `activeBuffsAtUse` スナップショットは消費前・適用**後**のタイミング（旧 L1327）で取られており、`comboBuffApplications` / `buffApplications` で自スキルが付与したバフを含んでいた。
- SkillDetailPanel は内訳生成に `getBuffContributions(entry.activeBuffsAtUse, ...)` を使うため、集約倍率に寄与していないバフが内訳に並ぶ表示バグとなっていた。

## 変更点

- `src/client/logic/resolve-timeline.ts` — `activeBuffsAtUse` スナップショットを `buffMultiplierBeforeApply` 計算直後（バフ適用前）で取得するように移動。
- `src/client/logic/__tests__/self-applied-buff-snapshot.test.ts` — 新規。spiral-blow / disembowel / `buffApplications` / 2 周目（前回バフが残る）/ コンボ不成立の 5 ケースを検証。

## テスト

- 新規テスト 5 ケース pass
- 全 189 件 vitest 通過
- `tsc --noEmit` エラーなし

## 影響範囲

- DRG の `comboBuffApplications: ["power-surge"]` を持つ disembowel / sonic-thrust / spiral-blow すべてに同じ修正効果。
- 他ジョブで同じ「自スキルが potency / critRate / dhRate を上げるバフを付与する」パターンも同様に修正される（汎用ロジックのため）。
- 集約 `buffMultiplier` 値や `entry.activeBuffs`（post-everything）には変更なし。

## DoD 対応

- [x] スパイラルブロウ自身が付与する竜槍バフが、スパイラルブロウの威力計算に含まれていない（#78 で達成済み・回帰なし）
- [x] 前回コンボの竜槍バフが残っている場合は、正しく +10% が適用される（テスト「2周目」で検証）
- [x] UI 上でバフの適用状態が誤解を招かない表示になっている（内訳と集約が一致）
- [x] ディセムボウルも同様に問題がないことを確認済み（テストで検証）
- [x] 既存のテストが通る

closes #263