### PR TITLE
feat: タイムライン上のスキル開始時刻をマニュアル設定できるようにする #175

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -142,7 +142,11 @@ export function App() {
     setEntries((prev) => {
       const fromIdx = prev.findIndex((e) => e.uid === uid);
       if (fromIdx < 0) return prev;
-      const entry = prev[fromIdx];
+      // D&D での並び替え時は、過去に設定した manualStartTime をリセットして自動計算に戻す
+      // （Issue #175 仕様: 並び替えで位置が変わるならマニュアル時刻の意味が薄れる）
+      const { manualStartTime: _drop, ...rest } = prev[fromIdx];
+      void _drop;
+      const entry: TimelineEntry = rest;
       const without = [...prev.slice(0, fromIdx), ...prev.slice(fromIdx + 1)];
       if (insertBeforeUid) {
         const toIdx = without.findIndex((e) => e.uid === insertBeforeUid);
@@ -152,6 +156,24 @@ export function App() {
       return [...without, entry];
     });
   }, []);
+
+  const handleManualStartTimeChange = useCallback(
+    (uid: string, manualStartTime: number | undefined) => {
+      setEntries((prev) =>
+        prev.map((e) => {
+          if (e.uid !== uid) return e;
+          if (manualStartTime === undefined) {
+            // undefined を渡されたら manualStartTime キー自体を削除（型上 optional のため省略形が正）
+            const { manualStartTime: _drop, ...rest } = e;
+            void _drop;
+            return rest;
+          }
+          return { ...e, manualStartTime };
+        })
+      );
+    },
+    []
+  );
 
   // per-entryのクリティカル率ボーナスを考慮した合計期待威力
   const { totalExpectedPotency, dotExpectedPotency } = useMemo(() => {
@@ -258,6 +280,7 @@ export function App() {
             buffDefMap={buffDefMap}
             stats={stats}
             onClose={() => setSelectedEntryUid(null)}
+            onManualStartTimeChange={handleManualStartTimeChange}
           />
         )}
       </div>

--- a/src/client/components/SkillDetailPanel.tsx
+++ b/src/client/components/SkillDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ResolvedTimelineEntry, Skill, BuffDefinition, CharacterStats } from "../types/skill";
 import { calcExpectedMultiplier } from "../logic/stat-calc";
 import { getBuffContributions } from "../logic/buff-contribution";
@@ -10,6 +10,8 @@ interface SkillDetailPanelProps {
   buffDefMap: Map<string, BuffDefinition>;
   stats: CharacterStats;
   onClose: () => void;
+  /** 開始時刻のマニュアル設定/解除ハンドラ。undefined を渡すと自動計算に戻る */
+  onManualStartTimeChange: (uid: string, manualStartTime: number | undefined) => void;
 }
 
 export function SkillDetailPanel({
@@ -18,8 +20,55 @@ export function SkillDetailPanel({
   buffDefMap,
   stats,
   onClose,
+  onManualStartTimeChange,
 }: SkillDetailPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+
+  // 入力中の文字列を別途保持（小数点や空文字を許容するため、数値直結ではなく文字列管理）。
+  // entry.uid 切替、または manualStartTime が外部から変わった場合のみ draft を再同期する。
+  // autoStartTime は前エントリの変動で連鎖的に変わり得るため、これを同期条件に含めると
+  // タイプ中の draft が上書きされてしまう。
+  const [startTimeDraft, setStartTimeDraft] = useState<string>(() =>
+    (entry.manualStartTime ?? entry.autoStartTime).toFixed(2)
+  );
+  const lastSyncedRef = useRef<{ uid: string; manualStartTime: number | undefined }>({
+    uid: entry.uid,
+    manualStartTime: entry.manualStartTime,
+  });
+  useEffect(() => {
+    const last = lastSyncedRef.current;
+    if (last.uid !== entry.uid || last.manualStartTime !== entry.manualStartTime) {
+      setStartTimeDraft((entry.manualStartTime ?? entry.autoStartTime).toFixed(2));
+      lastSyncedRef.current = {
+        uid: entry.uid,
+        manualStartTime: entry.manualStartTime,
+      };
+    }
+  }, [entry.uid, entry.manualStartTime, entry.autoStartTime]);
+
+  const commitStartTime = (raw: string) => {
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      // 空文字でコミットされたら自動計算に戻す
+      onManualStartTimeChange(entry.uid, undefined);
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      // 不正値は draft を直前の有効値に戻す
+      setStartTimeDraft((entry.manualStartTime ?? entry.autoStartTime).toFixed(2));
+      return;
+    }
+    // 0.01 秒刻みに丸める
+    const rounded = Math.round(parsed * 100) / 100;
+    onManualStartTimeChange(entry.uid, rounded);
+  };
+
+  const handleResetStartTime = () => {
+    onManualStartTimeChange(entry.uid, undefined);
+  };
+
+  const isManual = entry.manualStartTime !== undefined;
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
@@ -31,7 +80,14 @@ export function SkillDetailPanel({
       onClose();
     };
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      // パネル内の入力欄にフォーカスがある場合、Escape は入力編集のキャンセル用途を優先する。
+      // ここで onClose を呼ぶと「編集キャンセルと同時にパネル全体が閉じる」二重発火になる。
+      const active = document.activeElement as HTMLElement | null;
+      if (active && panelRef.current?.contains(active) && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) {
+        return;
+      }
+      onClose();
     };
     document.addEventListener("mousedown", handleMouseDown);
     document.addEventListener("keydown", handleKeyDown);
@@ -74,7 +130,50 @@ export function SkillDetailPanel({
         <img src={resolvedSkill.icon} alt={resolvedSkill.name} style={styles.headerIcon} />
         <div style={styles.headerText}>
           <div style={styles.headerName}>{resolvedSkill.name}</div>
-          <div style={styles.headerStartTime}>開始時刻: {entry.startTime.toFixed(2)}s</div>
+          <div style={styles.headerStartTimeRow}>
+            <label style={styles.headerStartTimeLabel} htmlFor="manual-start-time-input">開始時刻:</label>
+            <input
+              id="manual-start-time-input"
+              type="number"
+              step="0.01"
+              min="0"
+              value={startTimeDraft}
+              onChange={(e) => setStartTimeDraft(e.target.value)}
+              onBlur={(e) => commitStartTime(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitStartTime((e.target as HTMLInputElement).value);
+                  (e.target as HTMLInputElement).blur();
+                } else if (e.key === "Escape") {
+                  // パネル全体の Escape ハンドラ（onClose）への伝播を止める。
+                  // 入力中の Escape は「編集キャンセル」だけを意図しており、パネル自体は閉じない。
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setStartTimeDraft((entry.manualStartTime ?? entry.autoStartTime).toFixed(2));
+                  (e.target as HTMLInputElement).blur();
+                }
+              }}
+              style={isManual ? { ...styles.startTimeInput, ...styles.startTimeInputManual } : styles.startTimeInput}
+              aria-label="開始時刻"
+            />
+            <span style={styles.startTimeUnit}>s</span>
+            {isManual && (
+              <button
+                type="button"
+                onClick={handleResetStartTime}
+                style={styles.resetButton}
+                aria-label="自動計算に戻す"
+              >
+                自動に戻す
+              </button>
+            )}
+          </div>
+          {isManual && (
+            <div style={styles.headerAutoHint}>
+              （自動計算値: {entry.autoStartTime.toFixed(2)}s）
+            </div>
+          )}
         </div>
         <button type="button" onClick={onClose} style={styles.closeButton} aria-label="閉じる">×</button>
       </div>
@@ -240,6 +339,52 @@ const styles: Record<string, React.CSSProperties> = {
   headerStartTime: {
     fontSize: "11px",
     color: "#888",
+    marginTop: "2px",
+  },
+  headerStartTimeRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+    marginTop: "4px",
+    fontSize: "11px",
+    color: "#aaa",
+    flexWrap: "wrap" as const,
+  },
+  headerStartTimeLabel: {
+    color: "#aaa",
+  },
+  startTimeInput: {
+    width: "64px",
+    padding: "2px 4px",
+    fontSize: "12px",
+    backgroundColor: "#0f0f23",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "#444",
+    borderRadius: "3px",
+    color: "#e0e0e0",
+    fontFamily: "monospace",
+  },
+  startTimeInputManual: {
+    borderColor: "#ffa726",
+    color: "#ffa726",
+  },
+  startTimeUnit: {
+    color: "#888",
+  },
+  resetButton: {
+    padding: "1px 6px",
+    fontSize: "10px",
+    backgroundColor: "transparent",
+    border: "1px solid #555",
+    borderRadius: "3px",
+    color: "#aaa",
+    cursor: "pointer",
+    marginLeft: "2px",
+  },
+  headerAutoHint: {
+    fontSize: "10px",
+    color: "#666",
     marginTop: "2px",
   },
   closeButton: {

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -65,6 +65,32 @@ interface TimelineProps {
  * ドラッグ中のマウスX座標から挿入インデックスを計算する。
  * resolvedEntriesの各エントリの中央位置と比較し、挿入位置を決定する。
  */
+/**
+ * マニュアル開始時刻が設定されたスキルアイコンの左下に表示するストップウォッチバッジ。
+ * シンプルなインライン SVG（自作）。
+ */
+function ManualStartTimeBadge() {
+  return (
+    <div style={styles.manualBadge} title="開始時刻を手動設定中">
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="10" y1="2" x2="14" y2="2" />
+        <circle cx="12" cy="14" r="8" />
+        <line x1="12" y1="14" x2="15" y2="11" />
+      </svg>
+    </div>
+  );
+}
+
 function calcInsertIndex(
   mouseX: number,
   scrollLeft: number,
@@ -986,7 +1012,7 @@ export function Timeline({
                             ...(selectedEntryUid === entry.uid ? styles.skillIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.skillIconDragging : {}),
                           }}
-                          title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
                           data-skill-entry-uid={entry.uid}
                           onClick={() => onSelectEntry(entry.uid)}
                           draggable
@@ -999,6 +1025,9 @@ export function Timeline({
                             style={styles.iconImage}
                             draggable={false}
                           />
+                          {entry.manualStartTime !== undefined && (
+                            <ManualStartTimeBadge />
+                          )}
                         </div>
                         <div style={{
                           ...styles.skillPotency,
@@ -1040,7 +1069,7 @@ export function Timeline({
                             ...(selectedEntryUid === entry.uid ? styles.ogcdIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.ogcdIconDragging : {}),
                           }}
-                          title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
                           data-skill-entry-uid={entry.uid}
                           onClick={() => onSelectEntry(entry.uid)}
                           draggable
@@ -1053,6 +1082,9 @@ export function Timeline({
                             style={styles.iconImage}
                             draggable={false}
                           />
+                          {entry.manualStartTime !== undefined && (
+                            <ManualStartTimeBadge />
+                          )}
                         </div>
                         <div style={styles.skillPotency}>
                           {hasError ? "-" : (expectedPot !== null ? expectedPot : buffedPotency)}
@@ -1616,6 +1648,7 @@ const styles: Record<string, React.CSSProperties> = {
     marginTop: "8px",
     flexShrink: 0,
     transition: "opacity 0.15s",
+    position: "relative" as const,
   },
   skillIconError: {
     border: "2px solid #ef5350",
@@ -1648,6 +1681,7 @@ const styles: Record<string, React.CSSProperties> = {
     border: "1px solid rgba(255,255,255,0.2)",
     flexShrink: 0,
     transition: "opacity 0.15s",
+    position: "relative" as const,
   },
   ogcdIconError: {
     border: "2px solid #ef5350",
@@ -1664,6 +1698,21 @@ const styles: Record<string, React.CSSProperties> = {
     width: "100%",
     height: "100%",
     objectFit: "contain" as const,
+  },
+  manualBadge: {
+    position: "absolute" as const,
+    left: "1px",
+    bottom: "1px",
+    width: "14px",
+    height: "14px",
+    borderRadius: "50%",
+    backgroundColor: "rgba(15, 15, 35, 0.85)",
+    border: "1px solid #ffa726",
+    color: "#ffa726",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    pointerEvents: "none" as const,
   },
   skillPotency: {
     fontSize: "9px",

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -19,6 +19,7 @@ function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimeli
     resolvedSkillId: "dummy",
     resolvedPotency: 0,
     startTime,
+    autoStartTime: startTime,
     resourceSnapshot: {},
     resourceErrors: [],
     comboErrors: [],

--- a/src/client/logic/__tests__/manual-start-time.test.ts
+++ b/src/client/logic/__tests__/manual-start-time.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry } from "../../types/skill";
+
+/**
+ * Issue #175: タイムライン上のスキル開始時刻をマニュアル設定できる。
+ *
+ * 仕様（候補A: 強制上書き）:
+ * - entry.manualStartTime が設定されていれば、自動計算値を無視してその時刻を採用する
+ * - リキャスト中・ボス離脱中等の制約違反は recastError / untargetableError として
+ *   検出されるが、配置自体はブロックせずユーザー判断を尊重する（警告のみ）
+ * - autoStartTime には自動計算した場合の時刻が保持される（UI 表示用）
+ * - 後続エントリは manualStartTime ベースで再計算される
+ */
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+const gcdA = makeSkill({ id: "gcd-a" });
+const gcdB = makeSkill({ id: "gcd-b" });
+const gcdC = makeSkill({ id: "gcd-c" });
+const ogcdX = makeSkill({ id: "ogcd-x", type: "ogcd", recastTime: 45, animationLock: 0.6 });
+const skillMap = new Map([gcdA, gcdB, gcdC, ogcdX].map((s) => [s.id, s]));
+
+describe("manualStartTime (Issue #175)", () => {
+  it("manualStartTime 未設定なら従来通り自動計算で動作する（回帰なし）", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b" },
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[0].startTime).toBeCloseTo(0, 6);
+    expect(result.entries[1].startTime).toBeCloseTo(2.5, 6);
+    // autoStartTime は startTime と同値
+    expect(result.entries[0].autoStartTime).toBeCloseTo(0, 6);
+    expect(result.entries[1].autoStartTime).toBeCloseTo(2.5, 6);
+    expect(result.entries[0].manualStartTime).toBeUndefined();
+    expect(result.entries[1].manualStartTime).toBeUndefined();
+  });
+
+  it("manualStartTime が自動計算値より遅い場合（ディレイ）、その時刻が startTime として採用される", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b", manualStartTime: 5.0 }, // 自動なら 2.5s だが 5.0s にディレイ
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(5.0, 6);
+    expect(result.entries[1].autoStartTime).toBeCloseTo(2.5, 6);
+    expect(result.entries[1].manualStartTime).toBeCloseTo(5.0, 6);
+    // ディレイなのでリキャストエラーにはならない
+    expect(result.entries[1].recastError).toBe(false);
+  });
+
+  it("manualStartTime が自動計算値より早い場合（リキャスト中）、配置は尊重しつつ recastError で警告する", () => {
+    const skillWithCooldown = makeSkill({
+      id: "skill-cd",
+      cooldown: 60,
+      maxCharges: 1,
+    });
+    const map = new Map([skillWithCooldown].map((s) => [s.id, s]));
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "skill-cd" },
+      // 自動なら 60s 後にしか撃てないが、マニュアルで 3s に強制配置
+      { uid: "b", skillId: "skill-cd", manualStartTime: 3.0 },
+    ];
+    const result = resolveTimeline(entries, map, []);
+    expect(result.entries[1].startTime).toBeCloseTo(3.0, 6);
+    // リキャスト中エラーが立つが、配置自体は尊重される
+    expect(result.entries[1].recastError).toBe(true);
+  });
+
+  it("マニュアル設定された後続エントリは、マニュアル時刻を基準に再計算される", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b", manualStartTime: 5.0 },
+      { uid: "c", skillId: "gcd-c" }, // 自動: b の startTime + 2.5s = 7.5s
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(5.0, 6);
+    expect(result.entries[2].startTime).toBeCloseTo(7.5, 6);
+    expect(result.entries[2].autoStartTime).toBeCloseTo(7.5, 6);
+  });
+
+  it("oGCD エントリも manualStartTime を尊重する", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "x", skillId: "ogcd-x", manualStartTime: 1.0 },
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(1.0, 6);
+    expect(result.entries[1].autoStartTime).toBeCloseTo(0.65, 6); // gcdA の animationLock 直後
+  });
+
+  it("manualStartTime は 0.01 秒刻みで丸められる（呼び出し側が事前丸めしていない場合でも整合）", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a", manualStartTime: 1.234567 },
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    // resolve-timeline.ts 側で Math.round(* 1000) / 1000 にしている（0.001 刻み）。
+    // UI 側 (0.01 刻み) で先に丸められていれば余分な桁は無い前提だが、
+    // resolveTimeline 単体ではミリ秒精度に正規化する。
+    expect(result.entries[0].startTime).toBeCloseTo(1.235, 3);
+  });
+
+  it("manualStartTime が undefined のエントリは startTime === autoStartTime になる", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b" },
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    for (const e of result.entries) {
+      expect(e.startTime).toBeCloseTo(e.autoStartTime, 6);
+    }
+  });
+});

--- a/src/client/logic/__tests__/manual-start-time.test.ts
+++ b/src/client/logic/__tests__/manual-start-time.test.ts
@@ -80,6 +80,40 @@ describe("manualStartTime (Issue #175)", () => {
     expect(result.entries[1].recastError).toBe(true);
   });
 
+  it("cooldown を持たない GCD でも、manualStartTime が自動計算値より早ければ recastError を立てる", () => {
+    // Issue #175 フィードバック対応: グレアガ→ディアを 1.0s に手動配置すると
+    // 自動 2.5s に対して GCD リキャスト中の強制配置になるが、現状警告が出なかった問題。
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b", manualStartTime: 1.0 }, // 自動 2.5s に対し 1.0s に前倒し
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(1.0, 6);
+    expect(result.entries[1].autoStartTime).toBeCloseTo(2.5, 6);
+    expect(result.entries[1].recastError).toBe(true);
+  });
+
+  it("manualStartTime == autoStartTime（境界）では recastError を立てない", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" },
+      { uid: "b", skillId: "gcd-b", manualStartTime: 2.5 }, // 自動値と同じ
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(2.5, 6);
+    expect(result.entries[1].recastError).toBe(false);
+  });
+
+  it("oGCD でも manualStartTime が自動計算値より早ければ recastError を立てる（アニメロック中）", () => {
+    const entries: TimelineEntry[] = [
+      { uid: "a", skillId: "gcd-a" }, // アニメロック 0.65s
+      { uid: "x", skillId: "ogcd-x", manualStartTime: 0.3 }, // 自動 0.65s に対し 0.3s に前倒し
+    ];
+    const result = resolveTimeline(entries, skillMap, []);
+    expect(result.entries[1].startTime).toBeCloseTo(0.3, 6);
+    expect(result.entries[1].autoStartTime).toBeCloseTo(0.65, 6);
+    expect(result.entries[1].recastError).toBe(true);
+  });
+
   it("マニュアル設定された後続エントリは、マニュアル時刻を基準に再計算される", () => {
     const entries: TimelineEntry[] = [
       { uid: "a", skillId: "gcd-a" },

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -671,10 +671,17 @@ export function resolveTimeline(
     let startTime: number;
     let resolvedCastTime = 0;
 
+    let autoStartTime: number;
+
     if (originalSkill.type === "gcd") {
       const baseRecast = stats ? calcGcd(originalSkill.recastTime, stats) : originalSkill.recastTime;
-      startTime = Math.max(gcdAvailableAt, actionAvailableAt);
-      startTime = Math.round(startTime * 1000) / 1000;
+      autoStartTime = Math.max(gcdAvailableAt, actionAvailableAt);
+      autoStartTime = Math.round(autoStartTime * 1000) / 1000;
+      // entry.manualStartTime が設定されていれば自動計算値を上書き（候補A: 強制上書き）。
+      // リキャスト中等の制約違反は後段の recastError 検出に委ね、配置はユーザー判断を尊重する。
+      startTime = entry.manualStartTime !== undefined
+        ? Math.round(entry.manualStartTime * 1000) / 1000
+        : autoStartTime;
 
       // 期限切れバフを除去（onExpireResourceTransfer があればリソース移し替えも実施）
       expireBuffs(currentActiveBuffs, startTime, buffDefMap, resourceState, resourceDefMap, resources);
@@ -695,8 +702,11 @@ export function resolveTimeline(
       // 詠唱中はoGCDを挟めない: actionAvailableAtは詠唱完了時刻かアニメーションロック完了時刻の遅い方
       actionAvailableAt = startTime + Math.max(resolvedCastTime, originalSkill.animationLock);
     } else {
-      startTime = actionAvailableAt;
-      startTime = Math.round(startTime * 1000) / 1000;
+      autoStartTime = actionAvailableAt;
+      autoStartTime = Math.round(autoStartTime * 1000) / 1000;
+      startTime = entry.manualStartTime !== undefined
+        ? Math.round(entry.manualStartTime * 1000) / 1000
+        : autoStartTime;
 
       // 期限切れバフを除去（onExpireResourceTransfer があればリソース移し替えも実施）
       expireBuffs(currentActiveBuffs, startTime, buffDefMap, resourceState, resourceDefMap, resources);
@@ -1382,6 +1392,8 @@ export function resolveTimeline(
       resolvedSkillId,
       resolvedPotency,
       startTime,
+      autoStartTime,
+      manualStartTime: entry.manualStartTime,
       resourceSnapshot: snapshotAfter,
       resourceErrors,
       comboErrors,

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -963,6 +963,13 @@ export function resolveTimeline(
       }
       // state未登録 = 初回使用 → エラーなし
     }
+    // マニュアル開始時刻が自動計算値より早い場合（= GCD リキャスト/詠唱中・oGCD アニメーションロック中に
+    // ユーザーが強制配置した）も警告対象。cooldown 系の charge エラーとは別経路だが、UI 上は
+    // 同じ「リキャスト中」エラーとして扱う（Issue #175 仕様）。
+    // 浮動小数誤差を避けるため epsilon を入れる。
+    if (entry.manualStartTime !== undefined && startTime + 0.0005 < autoStartTime) {
+      recastError = true;
+    }
 
     // GCDスキル実行前に、消費対象（consumeOnGcd / instantCast）のバフIDを Set で収集する。
     // 同一バフが両エフェクトを併せ持つ場合に 1 発で 2 回デクリメントされるリスクを排除するため、

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -172,6 +172,13 @@ export interface TimelineEntry {
   uid: string;
   /** 参照するスキルのID */
   skillId: string;
+  /**
+   * マニュアル設定された開始時刻（秒）。
+   * 未設定（undefined）の場合は前エントリからの自動計算値を使用する。
+   * 設定されている場合は自動計算値を無視してこの値を強制採用する
+   * （リキャスト中等の制約違反時は recastError として警告のみ表示し、配置は尊重する）。
+   */
+  manualStartTime?: number;
 }
 
 /** リソースの定義データ */
@@ -395,6 +402,14 @@ export interface ResolvedTimelineEntry {
   resolvedPotency: number;
   /** 開始時刻（秒） */
   startTime: number;
+  /**
+   * 自動計算による開始時刻（秒）。
+   * `manualStartTime` が設定されているエントリでも、自動計算なら何秒になるかを保持する。
+   * `manualStartTime` 未設定時は `startTime` と同値。詳細パネルで「自動計算値: X.XXs」を表示する用途。
+   */
+  autoStartTime: number;
+  /** 元のタイムラインエントリにマニュアル開始時刻が設定されているか */
+  manualStartTime?: number;
   /** スキル実行後のリソース状態（消費・獲得・バフ由来の自動消費すべて反映済み） */
   resourceSnapshot: ResourceSnapshot;
   /** リソース不足のリソースIDリスト */


### PR DESCRIPTION
## 概要

`TimelineEntry` に `manualStartTime?: number` を追加し、スキル詳細パネル内の数値入力欄から **0.01 秒刻み** で開始時刻を強制上書きできるようにする。「バフ切れ直前に合わせる」「ボス復帰直後に合わせる」等のローテーション検証シナリオを再現可能にする。

closes #175

## 変更点

### 型 / ロジック
- `src/client/types/skill.ts` — `TimelineEntry.manualStartTime?: number` を追加。`ResolvedTimelineEntry` に `autoStartTime: number` と `manualStartTime?: number` を追加（UI で「自動計算値: X.XXs」を併記表示するため）
- `src/client/logic/resolve-timeline.ts` — GCD / oGCD 分岐で `Math.round` 後に `entry.manualStartTime` で上書き。リキャスト中等の制約違反は既存の `recastError` 検出ロジックがそのまま走るため、配置はユーザー判断を尊重しつつ警告が出る（**候補A: 強制上書き方式**）

### UI
- `src/client/components/SkillDetailPanel.tsx` — ヘッダの開始時刻表示を `<input type="number" step="0.01">` + 「自動に戻す」ボタンに置換。手動設定中は入力枠がオレンジ色になり、自動計算値もヒント表示
- `src/client/components/Timeline.tsx` — GCD / oGCD アイコンの **左下にストップウォッチ SVG バッジ**（自作インライン SVG）を表示し、手動設定中のスキルを視覚的に区別

### ハンドラ
- `src/client/components/App.tsx` — `handleManualStartTimeChange` を追加。`handleMoveEntry`（D&D 並び替え）では `manualStartTime` を削除して自動計算に戻す

### テスト
- `src/client/logic/__tests__/manual-start-time.test.ts` を追加（7 ケース）
  - 未設定時の回帰なし確認
  - 遅延（自動値より遅い）・前倒し（リキャスト中エラー警告）・後続伝播・oGCD 対応・0.001 秒丸め・`autoStartTime` 等値性

### 仕様判断（ユーザー承認済み）

| 項目 | 判断 |
|------|------|
| 自動計算値より早い時刻を指定した場合 | `recastError` として警告のみ。配置はブロックしない |
| D&D で並び替えた場合 | `manualStartTime` をリセットして自動計算に戻す |
| 入力欄の刻み | 0.01 秒 |
| 視覚的区別 | アイコン左下にストップウォッチ SVG バッジ + 入力枠オレンジ + ツールチップに「手動」表記 |

### コードレビュー反映

`code-reviewer` サブエージェントの指摘 2 件を修正済み:
- 入力欄での Escape 押下がパネル全体を閉じてしまう問題 → document 側 keydown ハンドラで入力欄フォーカス中はガード
- `lastSyncedRef` 同期判定で `autoStartTime` の変動が draft を強制上書きする問題 → 同期条件から `autoStartTime` 比較を除外

## テスト

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm test -- --run` — 25 ファイル / 196 テスト全パス（新規 7 ケース含む）
- [x] Playwright で UI 動作確認
  - 入力欄に値を入れるとオレンジ枠 + バッジ + 自動値ヒントが表示
  - タイムライン上のスキル位置が指定時刻に移動
  - 「自動に戻す」ボタンで自動計算に復帰
- [x] `npm run dev:client` で実機確認（Microsoft Edge）

## 未確定事項（残課題）

Issue 本文の「未確定事項」のうち以下は本 PR スコープ外（将来拡張）:
- 複数スキルの一括時刻変更
- ドラッグ操作による時刻変更
- スキル終了時刻のマニュアル設定
