### PR TITLE
feat: トゥルーノース（近接DPSロールアクション）をDRG/SAMに追加 #260

### DIFF
--- a/src/client/data/drg-buffs.ts
+++ b/src/client/data/drg-buffs.ts
@@ -14,6 +14,9 @@ import starcrossIcon from "../assets/icons/drg/Starcross.png";
 import drakesbaneIcon from "../assets/icons/drg/Drakesbane.png";
 import piercingTalonIcon from "../assets/icons/drg/Piercing_Talon.png";
 
+// === ロールアクション アイコン ===
+import trueNorthIcon from "../assets/icons/drg/role_actions/True_North.png";
+
 /**
  * 竜騎士（DRG）バフ定義
  */
@@ -188,5 +191,18 @@ export const DRG_BUFFS: BuffDefinition[] = [
     color: "#00bcd4",
     maxStacks: 1,
     acquiredLevel: 76,
+  },
+  // ロールアクション: トゥルーノース（方向指定無視）
+  // effects は空（方向指定ボーナス計算が本ツール未実装のため）
+  {
+    id: "true-north",
+    name: "トゥルーノース",
+    shortName: "ﾄｩﾙｰ\nﾉｰｽ",
+    icon: trueNorthIcon,
+    duration: 10,
+    effects: [],
+    color: "#ce93d8",
+    maxStacks: 1,
+    acquiredLevel: 50,
   },
 ];

--- a/src/client/data/drg-skills.ts
+++ b/src/client/data/drg-skills.ts
@@ -37,6 +37,9 @@ import wyrmwindThrustIcon from "../assets/icons/drg/Wyrmwind_Thrust.png";
 import riseOfTheDragonIcon from "../assets/icons/drg/Rise_of_the_Dragon.png";
 import starcrossIcon from "../assets/icons/drg/Starcross.png";
 
+// === ロールアクション アイコン ===
+import trueNorthIcon from "../assets/icons/drg/role_actions/True_North.png";
+
 /** GCDのデフォルトリキャストタイム（秒） */
 const GCD_RECAST = 2.5;
 
@@ -577,5 +580,25 @@ export const DRG_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     cooldown: 60,
     acquiredLevel: 45,
+  },
+
+  // ============================================================
+  // oGCD: 近接DPSロールアクション
+  // ============================================================
+  // 方向指定ボーナスを無視するアビリティ。本ツールは方向指定ボーナス計算自体を
+  // 実装していないため、バフ effects は空。リキャスト枠の管理用途で配置可能。
+  {
+    id: "true-north",
+    name: "トゥルーノース",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: trueNorthIcon,
+    recastTime: DEFAULT_ANIMATION_LOCK,
+    animationLock: DEFAULT_ANIMATION_LOCK,
+    cooldown: 45,
+    maxCharges: 2,
+    acquiredLevel: 50,
+    buffApplications: ["true-north"],
   },
 ];

--- a/src/client/data/sam-buffs.ts
+++ b/src/client/data/sam-buffs.ts
@@ -14,6 +14,9 @@ import kaeshiNamikiriIcon from "../assets/icons/sam/Kaeshi_Namikiri.png";
 import tendoSetsugekkaIcon from "../assets/icons/sam/Tendo_Setsugekka.png";
 import enpiIcon from "../assets/icons/sam/Enpi.png";
 
+// === ロールアクション アイコン ===
+import trueNorthIcon from "../assets/icons/sam/role_actions/True_North.png";
+
 /**
  * 明鏡止水でコンボ条件無視（bypassCombo）の対象となるWS群。
  * - 1段目（刃風/暁風/風雅/風光）は comboFrom を持たないのでバイパス不要
@@ -229,5 +232,18 @@ export const SAM_BUFFS: BuffDefinition[] = [
     maxStacks: 1,
     acquiredLevel: 90,
     exclusiveGroup: "tsubame-ready",
+  },
+  // ロールアクション: トゥルーノース（方向指定無視）
+  // effects は空（方向指定ボーナス計算が本ツール未実装のため）
+  {
+    id: "true-north",
+    name: "トゥルーノース",
+    shortName: "ﾄｩﾙｰ\nﾉｰｽ",
+    icon: trueNorthIcon,
+    duration: 10,
+    effects: [],
+    color: "#ce93d8",
+    maxStacks: 1,
+    acquiredLevel: 50,
   },
 ];

--- a/src/client/data/sam-skills.ts
+++ b/src/client/data/sam-skills.ts
@@ -39,6 +39,9 @@ import hagakureIcon from "../assets/icons/sam/Hagakure.png";
 import meikyoShisuiIcon from "../assets/icons/sam/Meikyo_Shisui.png";
 import zanshinIcon from "../assets/icons/sam/Zanshin.png";
 
+// === ロールアクション アイコン ===
+import trueNorthIcon from "../assets/icons/sam/role_actions/True_North.png";
+
 /**
  * 侍（SAM）攻撃スキル定義（Lv100まで）
  *
@@ -670,5 +673,25 @@ export const SAM_ATTACK_SKILLS: Skill[] = [
     acquiredLevel: 82,
     cooldown: 15,
     resourceChanges: [{ resourceId: "meditation", amount: -3 }],
+  },
+
+  // ============================================================
+  // oGCD: 近接DPSロールアクション
+  // ============================================================
+  // 方向指定ボーナスを無視するアビリティ。本ツールは方向指定ボーナス計算自体を
+  // 実装していないため、バフ effects は空。リキャスト枠の管理用途で配置可能。
+  {
+    id: "true-north",
+    name: "トゥルーノース",
+    potency: 0,
+    type: "ogcd",
+    target: "self",
+    icon: trueNorthIcon,
+    recastTime: 1.0,
+    animationLock: 0.65,
+    cooldown: 45,
+    maxCharges: 2,
+    acquiredLevel: 50,
+    buffApplications: ["true-north"],
   },
 ];


### PR DESCRIPTION
## 概要

近接DPS共通ロールアクション「トゥルーノース」（True North）を竜騎士（DRG）・侍（SAM）のスキルパレットとバフ定義に追加した。本ツールは方向指定ボーナスの威力計算自体を実装していないため、バフ効果は空（`effects: []`）とし、**リキャスト枠の管理用途**（タイムライン上で「このタイミングで使えるか」を確認）として配置可能にする。

## 設計判断

先行事例 #199（迅速魔）と同じく、共通ロールアクションファイルは作成せず、各ジョブの `*-skills.ts` / `*-buffs.ts` に独立して定義する方針を採用。コードベースの既存パターンと一貫性を保つ。アイコンはリポジトリにすでにある `<job>/role_actions/True_North.png` を使用（新規追加不要）。

## 変更点

### DRG（竜騎士）
- `src/client/data/drg-skills.ts`: oGCDスキル `true-north` を末尾に追加
  - `potency: 0` / `cooldown: 45` / `maxCharges: 2` / `acquiredLevel: 50` / `buffApplications: ["true-north"]`
  - `recastTime` / `animationLock` は同ファイル他スキルと同じ `DEFAULT_ANIMATION_LOCK` を流用
- `src/client/data/drg-buffs.ts`: バフ `true-north` を末尾に追加
  - `duration: 10` / `effects: []` / `shortName: "ﾄｩﾙｰ\nﾉｰｽ"` / `color: "#ce93d8"`

### SAM（侍）
- `src/client/data/sam-skills.ts`: oGCDスキル `true-north` を末尾に追加（DRGと同じ仕様、`recastTime: 1.0` / `animationLock: 0.65` は同ファイル他oGCDの値を踏襲）
- `src/client/data/sam-buffs.ts`: バフ `true-north` を末尾に追加（DRGと同じ仕様）

合計 78 行の追加のみ（ロジック変更なし）。

## テスト

- `npx tsc --noEmit`: exit 0
- `npm test`: 199/199 passed（既存テストへの影響なし）
- UI 動作確認（Playwright MCP）:
  - **DRG**: パレットにトゥルーノース表示 → タイムラインへ配置 → エントリ `トゥルーノース (威力: 0) [0.00s]` / バフバー `トゥルーノース x1 (0.00s - 10.00s)` / リキャスト枠 `トゥルーノース リキャスト (0.00s - 45.00s / 45s)` を確認
  - **2チャージ動作**: 2発連続配置（0.00s と 0.65s）でリキャストエラーなく両方配置可能
  - **SAM**: ジョブ切替後、パレット表示・タイムライン配置・バフバー・リキャスト枠とも DRG と同じ挙動

## やらないこと（Issueから踏襲）

- 方向指定ボーナスの威力計算の実装（別Issueで検討）
- 他の近接DPSロールアクション（牽制・内丹等）の追加
- 他ジョブ（MNK/NIN/RPR/VPR）への適用（該当ジョブ実装時にあわせて追加）

closes #260