### PR TITLE
fix: インスタレーションの speed バフを対象スキルに限定 #261

### DIFF
--- a/src/client/data/pct-buffs.ts
+++ b/src/client/data/pct-buffs.ts
@@ -115,7 +115,23 @@ export const PCT_BUFFS: BuffDefinition[] = [
     duration: 30,
     maxStacks: 5,
     effects: [
-      { type: "speed", value: 0.75 },
+      // 25% キャスト/リキャスト短縮の対象は色魔法・スタープリズム・ホワイトホーリー/ブラックコメットに限定。
+      // ハンマーコンボ・描画スキル・レインボードリップは対象外。
+      {
+        type: "speed",
+        value: 0.75,
+        appliesToSkillIds: [
+          "fire-in-red",
+          "aero-in-green",
+          "water-in-blue",
+          "blizzard-in-cyan",
+          "stone-in-yellow",
+          "thunder-in-magenta",
+          "star-prism",
+          "holy-in-white",
+          "comet-in-black",
+        ],
+      },
       { type: "consumeOnGcd", value: 1 },
     ],
     color: "#b39ddb",

--- a/src/client/logic/__tests__/pct-installation-speed.test.ts
+++ b/src/client/logic/__tests__/pct-installation-speed.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import type { Skill, TimelineEntry, BuffDefinition } from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+// インスタレーション相当の speed バフ（対象スキル限定）
+const installationBuff: BuffDefinition = {
+  id: "installation-test",
+  name: "インスタレーション",
+  shortName: "ｲﾝｽﾀ",
+  icon: "",
+  duration: 30,
+  maxStacks: 5,
+  effects: [
+    {
+      type: "speed",
+      value: 0.75,
+      appliesToSkillIds: [
+        "fire-in-red",
+        "aero-in-green",
+        "water-in-blue",
+        "blizzard-in-cyan",
+        "stone-in-yellow",
+        "thunder-in-magenta",
+        "star-prism",
+        "holy-in-white",
+        "comet-in-black",
+      ],
+    },
+  ],
+  color: "#b39ddb",
+};
+
+// 黒魔紋相当の speed バフ（全GCD対象、appliesToSkillIds なし）
+const leyLinesBuff: BuffDefinition = {
+  id: "ley-lines-test",
+  name: "黒魔紋",
+  shortName: "黒魔紋",
+  icon: "",
+  duration: 20,
+  effects: [{ type: "speed", value: 0.85 }],
+  color: "#ab47bc",
+};
+
+/** entry のリキャストを startTime と gcdAvailableAt から逆算する */
+function recastOf(entry: { startTime: number; gcdAvailableAt: number }): number {
+  return Math.round((entry.gcdAvailableAt - entry.startTime) * 1000) / 1000;
+}
+
+describe("インスタレーション（対象スキル限定 speed バフ）", () => {
+  it("色魔法のリキャストは 25% 短縮される", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const fireInRed = makeSkill({ id: "fire-in-red" });
+    const skillMap = new Map([[grant.id, grant], [fireInRed.id, fireInRed]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("fire-in-red")],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5 * 0.75, 3);
+  });
+
+  it("スタープリズム / ホワイトホーリー / ブラックコメットも 25% 短縮される", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const starPrism = makeSkill({ id: "star-prism" });
+    const holyInWhite = makeSkill({ id: "holy-in-white" });
+    const cometInBlack = makeSkill({ id: "comet-in-black" });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [starPrism.id, starPrism],
+      [holyInWhite.id, holyInWhite],
+      [cometInBlack.id, cometInBlack],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("star-prism"),
+        makeEntry("holy-in-white"),
+        makeEntry("comet-in-black"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5 * 0.75, 3);
+    expect(recastOf(result.entries[2])).toBeCloseTo(2.5 * 0.75, 3);
+    expect(recastOf(result.entries[3])).toBeCloseTo(2.5 * 0.75, 3);
+  });
+
+  it("ハンマーコンボのリキャストは短縮されない（対象外）", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const hammerStamp = makeSkill({ id: "hammer-stamp" });
+    const hammerBrush = makeSkill({ id: "hammer-brush" });
+    const polishingHammer = makeSkill({ id: "polishing-hammer" });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [hammerStamp.id, hammerStamp],
+      [hammerBrush.id, hammerBrush],
+      [polishingHammer.id, polishingHammer],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("hammer-stamp"),
+        makeEntry("hammer-brush"),
+        makeEntry("polishing-hammer"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5, 3);
+    expect(recastOf(result.entries[2])).toBeCloseTo(2.5, 3);
+    expect(recastOf(result.entries[3])).toBeCloseTo(2.5, 3);
+  });
+
+  it("描画スキル（creature/weapon/landscape-motif）のリキャストは短縮されない（対象外）", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const creatureMotif = makeSkill({ id: "creature-motif" });
+    const weaponMotif = makeSkill({ id: "weapon-motif" });
+    const landscapeMotif = makeSkill({ id: "landscape-motif" });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [creatureMotif.id, creatureMotif],
+      [weaponMotif.id, weaponMotif],
+      [landscapeMotif.id, landscapeMotif],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("creature-motif"),
+        makeEntry("weapon-motif"),
+        makeEntry("landscape-motif"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5, 3);
+    expect(recastOf(result.entries[2])).toBeCloseTo(2.5, 3);
+    expect(recastOf(result.entries[3])).toBeCloseTo(2.5, 3);
+  });
+
+  it("レインボードリップのリキャストは短縮されない（対象外）", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const rainbowDrip = makeSkill({ id: "rainbow-drip" });
+    const skillMap = new Map([[grant.id, grant], [rainbowDrip.id, rainbowDrip]]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("rainbow-drip")],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5, 3);
+  });
+
+  it("詠唱時間も対象スキルにのみ短縮される（色魔法は短縮 / ハンマーは対象外）", () => {
+    // ハンマー系は本来詠唱なしだが、フィルタの作用をテストするため castTime を持たせる
+    const grant = makeSkill({ id: "grant", buffApplications: ["installation-test"] });
+    const fireInRed = makeSkill({ id: "fire-in-red", castTime: 1.5 });
+    const hammerStamp = makeSkill({ id: "hammer-stamp", castTime: 1.5 });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [fireInRed.id, fireInRed],
+      [hammerStamp.id, hammerStamp],
+    ]);
+
+    const result = resolveTimeline(
+      [makeEntry("grant"), makeEntry("fire-in-red"), makeEntry("hammer-stamp")],
+      skillMap,
+      [],
+      undefined,
+      [installationBuff]
+    );
+
+    expect(result.entries[1].castTime).toBeCloseTo(1.5 * 0.75, 3);
+    expect(result.entries[2].castTime).toBeCloseTo(1.5, 3);
+  });
+});
+
+describe("黒魔紋（全GCD対象 speed バフ、appliesToSkillIds なし）回帰テスト", () => {
+  it("appliesToSkillIds が無い speed バフは全GCDのリキャストを短縮する（回帰）", () => {
+    const grant = makeSkill({ id: "grant", buffApplications: ["ley-lines-test"] });
+    const fireInRed = makeSkill({ id: "fire-in-red" });
+    const hammerStamp = makeSkill({ id: "hammer-stamp" });
+    const rainbowDrip = makeSkill({ id: "rainbow-drip" });
+    const skillMap = new Map([
+      [grant.id, grant],
+      [fireInRed.id, fireInRed],
+      [hammerStamp.id, hammerStamp],
+      [rainbowDrip.id, rainbowDrip],
+    ]);
+
+    const result = resolveTimeline(
+      [
+        makeEntry("grant"),
+        makeEntry("fire-in-red"),
+        makeEntry("hammer-stamp"),
+        makeEntry("rainbow-drip"),
+      ],
+      skillMap,
+      [],
+      undefined,
+      [leyLinesBuff]
+    );
+
+    expect(recastOf(result.entries[1])).toBeCloseTo(2.5 * 0.85, 3);
+    expect(recastOf(result.entries[2])).toBeCloseTo(2.5 * 0.85, 3);
+    expect(recastOf(result.entries[3])).toBeCloseTo(2.5 * 0.85, 3);
+  });
+});

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -86,19 +86,25 @@ function processAutoGen(
  */
 /**
  * 指定時刻にアクティブなバフから速度バフの合成倍率を計算する。
+ * targetSkillId が指定されている場合、appliesToSkillIds に
+ * 該当スキルIDが含まれないエフェクトは除外する（対象スキル限定バフ）。
+ * 例: インスタレーションは色魔法/スタープリズム/ホワイトホーリー等にのみ適用。
  */
 function getSpeedMultiplier(
   activeBuffs: ActiveBuff[],
-  buffDefMap: Map<string, BuffDefinition>
+  buffDefMap: Map<string, BuffDefinition>,
+  targetSkillId?: string
 ): number {
   let multiplier = 1;
   for (const ab of activeBuffs) {
     const def = buffDefMap.get(ab.buffId);
     if (!def) continue;
     for (const effect of def.effects) {
-      if (effect.type === "speed") {
-        multiplier *= effect.value;
+      if (effect.type !== "speed") continue;
+      if (effect.appliesToSkillIds && targetSkillId !== undefined) {
+        if (!effect.appliesToSkillIds.includes(targetSkillId)) continue;
       }
+      multiplier *= effect.value;
     }
   }
   return multiplier;
@@ -687,7 +693,8 @@ export function resolveTimeline(
       expireBuffs(currentActiveBuffs, startTime, buffDefMap, resourceState, resourceDefMap, resources);
 
       // 速度バフを適用してリキャスト・詠唱時間計算
-      const speedMul = getSpeedMultiplier(currentActiveBuffs, buffDefMap);
+      // 対象スキル限定の speed バフ（インスタレーション等）を正しくフィルタするため originalSkill.id を渡す
+      const speedMul = getSpeedMultiplier(currentActiveBuffs, buffDefMap, originalSkill.id);
       const recastTime = Math.round(baseRecast * speedMul * 1000) / 1000;
       // instantCast バフがアクティブなら詠唱時間を 0 に上書きする（三連魔・ファイアスターター等）
       // 対象スキル限定バフ（appliesToSkillIds）を正しくフィルタするため originalSkill.id を渡す
@@ -1480,7 +1487,7 @@ export function resolveTimeline(
     const skill = skillMap.get(entry.resolvedSkillId);
     if (!skill || skill.type !== "gcd") continue;
     const baseRecast = stats ? calcGcd(skill.recastTime, stats) : skill.recastTime;
-    const speedMul = getSpeedMultiplier(entry.activeBuffs, buffDefMap);
+    const speedMul = getSpeedMultiplier(entry.activeBuffs, buffDefMap, entry.resolvedSkillId);
     const recastTime = Math.round(baseRecast * speedMul * 1000) / 1000;
     const endTime = entry.startTime + recastTime;
     if (endTime > lastGcdEndTime) lastGcdEndTime = endTime;


### PR DESCRIPTION
## 概要

ピクトマンサーのインスタレーションバフ（イマジンスカイ使用時付与）の `speed: 0.75` が全GCDに無差別適用される不具合を修正。対象を色魔法6種・スタープリズム・ホワイトホーリー/ブラックコメットの9種に限定する。

## 変更点

- `getSpeedMultiplier` に `targetSkillId?: string` を追加し、`appliesToSkillIds` によるフィルタリングを実装（既存の `getPotencyMultiplier` と同じパターン）
- `getSpeedMultiplier` の呼び出し元 2 箇所にスキルIDを渡す
  - main loop（`resolve-timeline.ts:693`）: `originalSkill.id` を渡す（`hasInstantCastBuff` と整合）
  - `lastGcdEndTime` 算出ループ（`resolve-timeline.ts:1490`）: `entry.resolvedSkillId` を渡す（`baseRecast` 取得元と整合）
- `installation` バフの `speed` エフェクトに `appliesToSkillIds` を追加（9種）
  - 色魔法: `fire-in-red` / `aero-in-green` / `water-in-blue` / `blizzard-in-cyan` / `stone-in-yellow` / `thunder-in-magenta`
  - その他: `star-prism` / `holy-in-white` / `comet-in-black`
- ハンマーコンボ・描画スキル・レインボードリップは speed 短縮の対象外に
- `consumeOnGcd: 1` はそのまま維持（Issue「やらないこと」に従い、別Issue対応予定）

## テスト

- 新規追加: `pct-installation-speed.test.ts`（7 ケース）
  - 色魔法・スタープリズム・ホワイトホーリー・ブラックコメットのリキャストが 25% 短縮されることを確認
  - ハンマーコンボ・描画スキル・レインボードリップのリキャストが短縮されないことを確認
  - 詠唱時間も対象スキルにのみ短縮されることを確認
  - `appliesToSkillIds` を持たない speed バフ（黒魔紋相当）が全GCDを短縮する回帰テスト
- 全テスト 26 ファイル / 213 ケース通過（既存 206 + 新規 7）
- `tsc --noEmit` エラーなし

closes #261