### PR TITLE
fix: ハンマーコンボをWSコンボ方式に移行し色魔法でのバフ消費を防止 #275

### DIFF
--- a/src/client/data/pct-buffs.ts
+++ b/src/client/data/pct-buffs.ts
@@ -67,11 +67,7 @@ export const PCT_BUFFS: BuffDefinition[] = [
     shortName: "ﾊﾝﾏｰ\nｺﾝﾎﾞ",
     icon: hammerStampIcon,
     duration: null,
-    maxStacks: 3,
-    effects: [
-      { type: "guaranteedCrit", value: 1 },
-      { type: "guaranteedDh", value: 1 },
-    ],
+    effects: [],
     color: "#ffb74d",
   },
   {

--- a/src/client/data/pct-skills.ts
+++ b/src/client/data/pct-skills.ts
@@ -163,7 +163,8 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 50,
     requiredBuff: "hammer-combo-ready",
-    buffConsumptions: [{ buffId: "hammer-combo-ready", stacks: 1 }],
+    guaranteedCrit: true,
+    guaranteedDh: true,
     buffApplications: ["hammer-brush-ready"],
     autoTransform: [
       { buffId: "hammer-polish-ready", skillId: "polishing-hammer" },
@@ -187,7 +188,10 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 86,
     requiredBuff: "hammer-combo-ready",
-    buffConsumptions: [{ buffId: "hammer-combo-ready", stacks: 1 }, { buffId: "hammer-brush-ready", stacks: 1 }],
+    comboFrom: ["hammer-stamp"],
+    guaranteedCrit: true,
+    guaranteedDh: true,
+    buffConsumptions: [{ buffId: "hammer-brush-ready", stacks: 1 }],
     buffApplications: ["hammer-polish-ready"],
   },
   {
@@ -201,7 +205,13 @@ export const PCT_ATTACK_SKILLS: Skill[] = [
     animationLock: DEFAULT_ANIMATION_LOCK,
     acquiredLevel: 86,
     requiredBuff: "hammer-combo-ready",
-    buffConsumptions: [{ buffId: "hammer-combo-ready", stacks: 1 }, { buffId: "hammer-polish-ready", stacks: 1 }],
+    comboFrom: ["hammer-brush"],
+    guaranteedCrit: true,
+    guaranteedDh: true,
+    buffConsumptions: [
+      { buffId: "hammer-combo-ready", stacks: 1 },
+      { buffId: "hammer-polish-ready", stacks: 1 },
+    ],
   },
 
   // ============================================================


### PR DESCRIPTION
## 概要

ピクトマンサーのハンマーコンボに存在した2つのバグを修正する。

1. 色魔法（レッドファイア等）を使用すると `hammer-combo-ready` の `guaranteedCrit`/`guaranteedDh` 効果が `consumeGuaranteedCritBuffs` の自動消費対象になり、スタックが意図せず減ってコンボが破綻する
2. バフベース（3スタック消費）のコンボ管理が複雑で不具合の温床になっている

closes #275

## 変更点

### `src/client/data/pct-buffs.ts`

- `hammer-combo-ready`:
  - `maxStacks: 3` を削除（スタックなしバフ化）
  - `effects` から `guaranteedCrit` / `guaranteedDh` を削除（スキル属性へ移管）
  - 役割は「コンボ実行可フラグ」として `requiredBuff` 用にのみ残す

### `src/client/data/pct-skills.ts`

- `hammer-stamp`（1段目）:
  - `guaranteedCrit: true`, `guaranteedDh: true` を追加（バフからスキル属性へ移管）
  - `buffConsumptions` から `hammer-combo-ready` を削除（消費しない、フラグはそのまま残す）
  - `requiredBuff` / `buffApplications` / `autoTransform` はそのまま維持
- `hammer-brush`（2段目）:
  - `comboFrom: ["hammer-stamp"]` を追加
  - `guaranteedCrit: true`, `guaranteedDh: true` を追加
  - `buffConsumptions` から `hammer-combo-ready` を削除（`hammer-brush-ready` は引き続き消費）
- `polishing-hammer`（3段目）:
  - `comboFrom: ["hammer-brush"]` を追加
  - `guaranteedCrit: true`, `guaranteedDh: true` を追加
  - `buffConsumptions` で `hammer-combo-ready` と `hammer-polish-ready` を消費（コンボ完了時にハンマー実行可バフを解放）

## 設計判断

### Issue本文との差異: 確定クリ/DH をスキル属性に移した理由

Issue本文では「`hammer-combo-ready` を `guaranteedCrit`/`guaranteedDh` の効果源として残す」案でしたが、現状の `hasGuaranteedCrit` / `consumeGuaranteedCritBuffs`（`src/client/logic/resolve-timeline.ts:199-241`）は `appliesToSkillIds` を見ていないため、**バフに `guaranteedCrit`/`guaranteedDh` を残す限り色魔法問題は WSコンボ方式に移行しても解決しません**。

そこで SAM の `meikyo-shisui` 系で既に採用されている `skill.guaranteedCrit` / `skill.guaranteedDh` のスキル属性（`src/client/types/skill.ts:164,166`）にハンマー3スキルへ直接付与する案で実装しました。これにより：

- コアロジックの改修なしで色魔法問題を解決
- 既存パターンと整合
- `hammer-combo-ready` はフラグとしての役割に純化（`requiredBuff` チェックと `polishing-hammer` での消費のみ）

### `hammer-brush-ready` / `hammer-polish-ready` を `buffConsumptions` で消費する理由

Issue本文には「`buffConsumptions` から削除」とありますが、これらは `autoTransform` のトリガーバフとしての性格が強く、消費しないと duration（30秒）まで残ってしまい、コンボ切れ後のハンマースタンプ起点リセットが効きません。今回は `hammer-brush` / `polishing-hammer` の各段で消費する形を維持しました（コンボ切れ後に再度 `hammer-stamp` 起点から始められる）。

## テスト

### 自動テスト

- `npx tsc --noEmit`: 型エラーなし
- `npm test -- --run`: 26 files / 206 tests すべてパス

### UI動作確認（Playwright MCP、Microsoft Edge）

**シナリオ1: イマジンハンマー → ハンマースタンプ×3 (3段コンボ)**

| スキル | resolvedSkillId | 威力 | 期待値 | 確定クリ/DH |
|--------|----------------|------|--------|-----------|
| 1段目 | hammer-stamp | 560 | 980 | ✓ (×1.75) |
| 2段目 | hammer-brush（autoTransform） | 580 | 1015 | ✓ (×1.75) |
| 3段目 | polishing-hammer（autoTransform） | 600 | 1050 | ✓ (×1.75) |

バフタイムライン:
- `ハンマーコンボ実行可 (0.00s - 5.65s)`: 3段目完了時に消費 ✓
- `ハンマーブラッシュ実行可 (0.65s - 3.15s)`: 1→2段目で消費 ✓
- `ハンマーポリッシュ実行可 (3.15s - 5.65s)`: 2→3段目で消費 ✓

警告: なし

**シナリオ2: イマジンハンマー → レッドファイア×3 → ハンマースタンプ**

| スキル | 結果 |
|--------|------|
| レッドファイア | 色魔法コンボに従って autoTransform |
| 4段目 ハンマースタンプ | 威力560 / 期待値980（確定クリ/DH適用 ×1.75）|

バフ: `ハンマーコンボ実行可 (0.00s - ∞)` ← **色魔法3回を挟んでも消費されない ✓**

警告: なし

## DoD チェック

- [x] 色魔法を使用しても `hammer-combo-ready` のスタック／バフが消費されない
- [x] ハンマースタンプ → ハンマーブラッシュ → ハンマーポリッシュが正しくコンボとして繋がる
- [x] 3段コンボ完了後にハンマーコンボ実行可バフが消費される
- [x] ハンマーコンボ3スキルすべてに確定クリティカル＆DHが適用される
- [x] `autoTransform` によるスキル置き換えが従来通り動作する
- [x] 既存のテストが通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
