### PR TITLE
feat: タイムラインに複数体ウィンドウ（敵の数指定）と AoE 計算基盤を追加 #268

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -22,8 +22,9 @@ import { SAM_ATTACK_SKILLS } from "../data/sam-skills";
 import { SAM_RESOURCES } from "../data/sam-resources";
 import { SAM_BUFFS } from "../data/sam-buffs";
 import { DEFAULT_STATS, calcExpectedMultiplier } from "../logic/stat-calc";
+import { calcEntryExpectedPotency } from "../logic/expected-potency";
 import { getSkillsForLevel, getBuffsForLevel, getResourcesForLevel } from "../logic/skill-level";
-import type { Skill, BuffDefinition, ResourceDefinition, TimelineEntry, CharacterStats, BossUntargetableWindow, PpsRange, PlayerLevel } from "../types/skill";
+import type { Skill, BuffDefinition, ResourceDefinition, TimelineEntry, CharacterStats, BossUntargetableWindow, MultiTargetWindow, PpsRange, PlayerLevel } from "../types/skill";
 
 /** ジョブID */
 export type JobId = "whm" | "drg" | "brd" | "pct" | "blm" | "sam";
@@ -55,6 +56,7 @@ export function App() {
   const [entries, setEntries] = useState<TimelineEntry[]>([]);
   const [stats, setStats] = useState<CharacterStats>(DEFAULT_STATS);
   const [untargetableWindows, setUntargetableWindows] = useState<BossUntargetableWindow[]>([]);
+  const [multiTargetWindows, setMultiTargetWindows] = useState<MultiTargetWindow[]>([]);
   const [ppsRange, setPpsRange] = useState<PpsRange | null>(null);
   const [selectedEntryUid, setSelectedEntryUid] = useState<string | null>(null);
 
@@ -111,8 +113,8 @@ export function App() {
   }, [skills, jobData.skills, level]);
 
   const timelineResult = useMemo(
-    () => resolveTimeline(entries, allSkillMap, levelResources, stats, levelBuffs, untargetableWindows),
-    [entries, allSkillMap, levelResources, stats, levelBuffs, untargetableWindows]
+    () => resolveTimeline(entries, allSkillMap, levelResources, stats, levelBuffs, untargetableWindows, multiTargetWindows),
+    [entries, allSkillMap, levelResources, stats, levelBuffs, untargetableWindows, multiTargetWindows]
   );
 
   const resolvedEntries = timelineResult.entries;
@@ -175,16 +177,14 @@ export function App() {
     []
   );
 
-  // per-entryのクリティカル率ボーナスを考慮した合計期待威力
+  // per-entryのクリティカル率ボーナスを考慮した合計期待威力（複数体ヒット合算込み）
   const { totalExpectedPotency, dotExpectedPotency } = useMemo(() => {
     const directExpected = resolvedEntries.reduce((sum, entry) => {
-      const hasError = entry.resourceErrors.length > 0 || entry.comboErrors.length > 0 || entry.untargetableError || entry.recastError;
-      if (hasError) return sum;
-      const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
-      const entryMul = calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus);
-      return sum + Math.floor(buffedPotency * entryMul);
+      const skill = allSkillMap.get(entry.resolvedSkillId);
+      return sum + calcEntryExpectedPotency(entry, skill, stats);
     }, 0);
     // DoTはティックごとにスナップショット済みのcritRateBonus・dhRateBonusを適用
+    // （DoTは保守的に1体のみ付与の前提のため targetCount は反映しない）
     const dotExpected = timelineResult.dotTicks.reduce((sum, tick) => {
       const dotMul = calcExpectedMultiplier(stats, tick.critRateBonus, tick.dhRateBonus);
       return sum + Math.floor(tick.potency * dotMul);
@@ -265,6 +265,8 @@ export function App() {
           activeDoTs={timelineResult.activeDoTs}
           untargetableWindows={untargetableWindows}
           onUntargetableWindowsChange={setUntargetableWindows}
+          multiTargetWindows={multiTargetWindows}
+          onMultiTargetWindowsChange={setMultiTargetWindows}
           overallPps={overallPps}
           rangePps={rangePps}
           ppsRange={ppsRange}

--- a/src/client/components/SkillDetailPanel.tsx
+++ b/src/client/components/SkillDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ResolvedTimelineEntry, Skill, BuffDefinition, CharacterStats } from "../types/skill";
 import { calcExpectedMultiplier } from "../logic/stat-calc";
+import { calcEntryPotencyBreakdown } from "../logic/expected-potency";
 import { getBuffContributions } from "../logic/buff-contribution";
 
 interface SkillDetailPanelProps {
@@ -114,9 +115,15 @@ export function SkillDetailPanel({
 
   const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
   const expectedMul = calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus);
-  const expectedValue = !hasError && entry.resolvedPotency > 0
+  const singleTargetExpected = !hasError && entry.resolvedPotency > 0
     ? Math.floor(buffedPotency * expectedMul)
     : null;
+  // 複数体ヒット内訳。単体時は targets.length <= 1
+  const breakdown = !hasError && entry.resolvedPotency > 0
+    ? calcEntryPotencyBreakdown(entry, resolvedSkill, stats)
+    : null;
+  const expectedValue = breakdown ? breakdown.total : singleTargetExpected;
+  const isMultiTargetHit = breakdown !== null && breakdown.targets.length > 1;
 
   const errorMessages: string[] = [];
   if (entry.resourceErrors.length > 0) errorMessages.push(`リソース不足: ${entry.resourceErrors.join(", ")}`);
@@ -231,13 +238,22 @@ export function SkillDetailPanel({
         </Section>
 
         <div style={styles.expectedBox}>
-          <div style={styles.sectionLabel}>期待値</div>
+          <div style={styles.sectionLabel}>
+            期待値{isMultiTargetHit && breakdown ? ` (×${breakdown.targets.length}体 合算)` : ""}
+          </div>
           <div style={styles.expectedValue}>
             {expectedValue !== null ? expectedValue : "—"}
           </div>
-          {expectedValue !== null && (
+          {singleTargetExpected !== null && !isMultiTargetHit && (
             <div style={styles.expectedFormula}>
-              {entry.resolvedPotency} × {entry.buffMultiplier.toFixed(2)} × {expectedMul.toFixed(3)} = {expectedValue}
+              {entry.resolvedPotency} × {entry.buffMultiplier.toFixed(2)} × {expectedMul.toFixed(3)} = {singleTargetExpected}
+            </div>
+          )}
+          {isMultiTargetHit && breakdown && (
+            <div style={styles.expectedFormula}>
+              1体: {breakdown.singleTargetPotency}
+              {breakdown.targets.slice(1).map((t, i) => ` / ${i + 2}体目: ${t}`).join("")}
+              {" = "}{breakdown.total}
             </div>
           )}
         </div>

--- a/src/client/components/Timeline.tsx
+++ b/src/client/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
-import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow, PpsRange } from "../types/skill";
+import type { Skill, ResolvedTimelineEntry, ResourceDefinition, BuffDefinition, ActiveBuff, CharacterStats, DoTTick, ActiveDoT, BossUntargetableWindow, MultiTargetWindow, PpsRange } from "../types/skill";
 import { calcGcd, calcExpectedMultiplier } from "../logic/stat-calc";
+import { calcEntryPotencyBreakdown } from "../logic/expected-potency";
 import { computeBuffTimespans } from "../logic/buff-timespans";
 import { resolveTimeline } from "../logic/resolve-timeline";
 import "./timeline.css";
@@ -52,6 +53,8 @@ interface TimelineProps {
   activeDoTs: ActiveDoT[];
   untargetableWindows: BossUntargetableWindow[];
   onUntargetableWindowsChange: (windows: BossUntargetableWindow[]) => void;
+  multiTargetWindows: MultiTargetWindow[];
+  onMultiTargetWindowsChange: (windows: MultiTargetWindow[]) => void;
   overallPps: { pps: number; totalPotency: number; directPotency: number; dotPotency: number } | null;
   rangePps: { pps: number; totalPotency: number; directPotency: number; dotPotency: number } | null;
   ppsRange: PpsRange | null;
@@ -89,6 +92,21 @@ function ManualStartTimeBadge() {
       </svg>
     </div>
   );
+}
+
+/**
+ * 期待値ツールチップに付与する複数体ヒット内訳を整形する。
+ * - 単体（`targets.length <= 1`）: 空文字
+ * - 複数体（全て同値）: ` ×N体 (1体: X)`
+ * - 複数体（減衰あり）: ` ×N体 (1体: X / 減衰時: Y)`
+ */
+function formatTargetBreakdown(
+  breakdown: { total: number; targets: number[]; singleTargetPotency: number } | null
+): string {
+  if (!breakdown || breakdown.targets.length <= 1) return "";
+  const reduced = breakdown.targets.find((t) => t !== breakdown.singleTargetPotency);
+  const reducedSuffix = reduced !== undefined ? ` / 減衰時: ${reduced}` : "";
+  return ` ×${breakdown.targets.length}体 (1体: ${breakdown.singleTargetPotency}${reducedSuffix})`;
 }
 
 function calcInsertIndex(
@@ -135,6 +153,8 @@ export function Timeline({
   activeDoTs,
   untargetableWindows,
   onUntargetableWindowsChange,
+  multiTargetWindows,
+  onMultiTargetWindowsChange,
   overallPps,
   rangePps,
   ppsRange,
@@ -199,6 +219,7 @@ export function Timeline({
   const [showDoTs, setShowDoTs] = useState(true);
   const [showRecasts, setShowRecasts] = useState(true);
   const [showUntargetableEditor, setShowUntargetableEditor] = useState(false);
+  const [showMultiTargetEditor, setShowMultiTargetEditor] = useState(false);
   const [showPpsRange, setShowPpsRange] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   /** 末尾追加時のみ自動スクロールするためのフラグ */
@@ -284,8 +305,8 @@ export function Timeline({
     const filteredRaw = resolvedEntries
       .filter((e) => e.uid !== draggingEntryUid)
       .map((e) => ({ uid: e.uid, skillId: e.skillId }));
-    return resolveTimeline(filteredRaw, skillMap, resources, stats, buffs, untargetableWindows).entries;
-  }, [resolvedEntries, draggingEntryUid, skillMap, resources, stats, buffs, untargetableWindows]);
+    return resolveTimeline(filteredRaw, skillMap, resources, stats, buffs, untargetableWindows, multiTargetWindows).entries;
+  }, [resolvedEntries, draggingEntryUid, skillMap, resources, stats, buffs, untargetableWindows, multiTargetWindows]);
 
   /**
    * マウス位置と突き合わせる用の「見えている並び」。
@@ -353,6 +374,10 @@ export function Timeline({
     for (const w of untargetableWindows) {
       if (w.endTime > maxEnd) maxEnd = w.endTime;
     }
+    // 複数体ウィンドウの終了時刻も考慮
+    for (const w of multiTargetWindows) {
+      if (w.endTime > maxEnd) maxEnd = w.endTime;
+    }
     // 個別リキャストの終了時刻も考慮
     for (const spans of cooldownSpans.values()) {
       for (const span of spans) {
@@ -360,7 +385,7 @@ export function Timeline({
       }
     }
     return maxEnd;
-  }, [resolvedEntries, skillMap, getResolvedEntryRecast, activeDoTs, untargetableWindows, cooldownSpans]);
+  }, [resolvedEntries, skillMap, getResolvedEntryRecast, activeDoTs, untargetableWindows, multiTargetWindows, cooldownSpans]);
 
   const timelineWidth = Math.max(totalDuration * PX_PER_SEC + 100, 600);
 
@@ -703,6 +728,17 @@ export function Timeline({
             {showUntargetableEditor ? "離脱 ▼" : "離脱 ▶"}
             {untargetableWindows.length > 0 && ` (${untargetableWindows.length})`}
           </button>
+          <button
+            style={{
+              ...styles.toggleButton,
+              ...(multiTargetWindows.length > 0 ? { borderColor: "rgba(180, 100, 220, 0.5)", color: "#b864dc" } : {}),
+            }}
+            onClick={() => setShowMultiTargetEditor((v) => !v)}
+            title="複数体ウィンドウ設定（敵の数を指定する時間帯）"
+          >
+            {showMultiTargetEditor ? "複数体 ▼" : "複数体 ▶"}
+            {multiTargetWindows.length > 0 && ` (${multiTargetWindows.length})`}
+          </button>
           {activeDoTs.length > 0 && (
             <button
               style={styles.toggleButton}
@@ -917,6 +953,98 @@ export function Timeline({
         </div>
       )}
 
+      {showMultiTargetEditor && (
+        <div style={styles.multiTargetEditor}>
+          <div style={styles.multiTargetHeader}>
+            <span style={styles.multiTargetTitle}>複数体ウィンドウ</span>
+            <button
+              style={styles.multiTargetAddButton}
+              onClick={() => {
+                const lastEnd = multiTargetWindows.length > 0
+                  ? Math.max(...multiTargetWindows.map((w) => w.endTime))
+                  : 0;
+                onMultiTargetWindowsChange([
+                  ...multiTargetWindows,
+                  { startTime: lastEnd + 5, endTime: lastEnd + 10, targetCount: 2 },
+                ]);
+              }}
+            >
+              + 追加
+            </button>
+          </div>
+          {multiTargetWindows.length === 0 && (
+            <div style={styles.multiTargetEmpty}>複数体ウィンドウが未設定です</div>
+          )}
+          {multiTargetWindows.map((w, i) => (
+            <div key={i} style={styles.multiTargetRow}>
+              <label style={styles.multiTargetLabel}>
+                開始:
+                <input
+                  type="number"
+                  step="0.5"
+                  min="0"
+                  value={w.startTime}
+                  style={styles.multiTargetInput}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    if (isNaN(val) || val < 0) return;
+                    const next = [...multiTargetWindows];
+                    next[i] = { ...next[i], startTime: val };
+                    onMultiTargetWindowsChange(next);
+                  }}
+                />
+                s
+              </label>
+              <label style={styles.multiTargetLabel}>
+                終了:
+                <input
+                  type="number"
+                  step="0.5"
+                  min="0"
+                  value={w.endTime}
+                  style={styles.multiTargetInput}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    if (isNaN(val) || val < 0) return;
+                    const next = [...multiTargetWindows];
+                    next[i] = { ...next[i], endTime: val };
+                    onMultiTargetWindowsChange(next);
+                  }}
+                />
+                s
+              </label>
+              <label style={styles.multiTargetLabel}>
+                敵の数:
+                <input
+                  type="number"
+                  step="1"
+                  min="2"
+                  max="8"
+                  value={w.targetCount}
+                  style={styles.multiTargetInput}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value, 10);
+                    if (isNaN(val) || val < 2) return;
+                    const next = [...multiTargetWindows];
+                    next[i] = { ...next[i], targetCount: val };
+                    onMultiTargetWindowsChange(next);
+                  }}
+                />
+              </label>
+              <button
+                style={styles.multiTargetDeleteButton}
+                onClick={() => {
+                  onMultiTargetWindowsChange(multiTargetWindows.filter((_, idx) => idx !== i));
+                }}
+                title="削除"
+              >
+                x
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div
         style={{
           ...styles.dropZone,
@@ -953,12 +1081,11 @@ export function Timeline({
                     const recast = getResolvedEntryRecast(entry, entry.skill);
                     const castTime = entry.castTime;
                     const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
-                    const entryExpMul = stats ? calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus) : null;
-                    const expectedPot = hasError ? null : (
-                      entryExpMul !== null && entry.resolvedPotency > 0
-                        ? Math.floor(buffedPotency * entryExpMul)
-                        : null
-                    );
+                    const breakdown = stats && entry.resolvedPotency > 0 && !hasError
+                      ? calcEntryPotencyBreakdown(entry, entry.displaySkill, stats)
+                      : null;
+                    const expectedPot = breakdown ? breakdown.total : null;
+                    const targetBreakdown = formatTargetBreakdown(breakdown);
                     const isAutoTransformed = entry.resolvedSkillId !== entry.skillId;
                     // castTime > recast の場合は次 GCD が打てるのは castTime 後（resolve-timeline.ts と整合）。
                     // skillBlock の幅を max(castTime, recast) に拡張し、各バーを blockDuration 基準で割合計算する。
@@ -1012,7 +1139,7 @@ export function Timeline({
                             ...(selectedEntryUid === entry.uid ? styles.skillIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.skillIconDragging : {}),
                           }}
-                          title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          title={`${entry.displaySkill.name}${isAutoTransformed ? ` (← ${entry.skill.name})` : ""} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}${targetBreakdown}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${castTime > 0 ? ` 詠唱: ${castTime}s` : " インスタント"}${entry.wsComboError ? " ⚠ コンボ不成立" : ""}${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
                           data-skill-entry-uid={entry.uid}
                           onClick={() => onSelectEntry(entry.uid)}
                           draggable
@@ -1048,12 +1175,11 @@ export function Timeline({
                   {ogcdEntries.map((entry) => {
                     const hasError = entriesWithErrors.has(entry.uid);
                     const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
-                    const entryExpMul = stats ? calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus) : null;
-                    const expectedPot = hasError ? null : (
-                      entryExpMul !== null && entry.resolvedPotency > 0
-                        ? Math.floor(buffedPotency * entryExpMul)
-                        : null
-                    );
+                    const breakdown = stats && entry.resolvedPotency > 0 && !hasError
+                      ? calcEntryPotencyBreakdown(entry, entry.displaySkill, stats)
+                      : null;
+                    const expectedPot = breakdown ? breakdown.total : null;
+                    const targetBreakdown = formatTargetBreakdown(breakdown);
                     return (
                       <div
                         key={entry.uid}
@@ -1069,7 +1195,7 @@ export function Timeline({
                             ...(selectedEntryUid === entry.uid ? styles.ogcdIconSelected : {}),
                             ...(draggingEntryUid === entry.uid ? styles.ogcdIconDragging : {}),
                           }}
-                          title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
+                          title={`${entry.displaySkill.name} (威力: ${buffedPotency}${entry.buffMultiplier !== 1 ? ` [${entry.resolvedPotency}x${entry.buffMultiplier.toFixed(2)}]` : ""}${expectedPot !== null ? ` / 期待値: ${expectedPot}${targetBreakdown}` : ""}) [${entry.startTime.toFixed(2)}s${entry.manualStartTime !== undefined ? " 手動" : ""}]${entry.resourceErrors.length > 0 ? " ⚠ リソース不足" : ""}${entry.comboErrors.length > 0 ? " ⚠ バフ条件未達成" : ""}${entry.untargetableError ? " ⚠ ボス離脱中" : ""}${entry.recastError ? " ⚠ リキャスト中" : ""}`}
                           data-skill-entry-uid={entry.uid}
                           onClick={() => onSelectEntry(entry.uid)}
                           draggable
@@ -1400,6 +1526,46 @@ export function Timeline({
                       }}
                     >
                       離脱
+                    </span>
+                  </div>
+                );
+              })}
+
+              {/* 複数体ウィンドウ */}
+              {multiTargetWindows.map((w, i) => {
+                const left = LANE_LABEL_WIDTH + w.startTime * PX_PER_SEC;
+                const width = (w.endTime - w.startTime) * PX_PER_SEC;
+                return (
+                  <div
+                    key={`multi-target-${i}`}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      bottom: RULER_HEIGHT,
+                      left,
+                      width,
+                      backgroundColor: "rgba(180, 100, 220, 0.12)",
+                      borderLeft: "2px solid rgba(180, 100, 220, 0.5)",
+                      borderRight: "2px solid rgba(180, 100, 220, 0.5)",
+                      zIndex: 4,
+                      pointerEvents: "none",
+                      display: "flex",
+                      alignItems: "flex-start",
+                      justifyContent: "center",
+                      paddingTop: "2px",
+                    }}
+                    title={`複数体 ×${w.targetCount} (${w.startTime}s - ${w.endTime}s)`}
+                  >
+                    <span
+                      style={{
+                        fontSize: "10px",
+                        color: "rgba(180, 100, 220, 0.9)",
+                        fontWeight: "bold",
+                        whiteSpace: "nowrap",
+                        pointerEvents: "none",
+                      }}
+                    >
+                      ×{w.targetCount}
                     </span>
                   </div>
                 );
@@ -2146,6 +2312,71 @@ const styles: Record<string, React.CSSProperties> = {
     border: "1px solid rgba(255, 80, 80, 0.3)",
     borderRadius: "4px",
     color: "#ef5350",
+    fontSize: "12px",
+    padding: "2px 8px",
+    cursor: "pointer",
+    lineHeight: 1,
+  },
+  // 複数体ウィンドウエディタ
+  multiTargetEditor: {
+    backgroundColor: "rgba(180, 100, 220, 0.05)",
+    border: "1px solid rgba(180, 100, 220, 0.2)",
+    borderRadius: "6px",
+    padding: "8px 12px",
+    marginBottom: "8px",
+  },
+  multiTargetHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: "6px",
+  },
+  multiTargetTitle: {
+    fontSize: "13px",
+    fontWeight: "bold",
+    color: "#b864dc",
+  },
+  multiTargetAddButton: {
+    background: "none",
+    border: "1px solid rgba(180, 100, 220, 0.4)",
+    borderRadius: "4px",
+    color: "#b864dc",
+    fontSize: "12px",
+    padding: "2px 10px",
+    cursor: "pointer",
+  },
+  multiTargetEmpty: {
+    fontSize: "12px",
+    color: "#777",
+  },
+  multiTargetRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    marginBottom: "4px",
+  },
+  multiTargetLabel: {
+    fontSize: "12px",
+    color: "#aaa",
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+  },
+  multiTargetInput: {
+    width: "60px",
+    backgroundColor: "#1a1a3e",
+    border: "1px solid #444",
+    borderRadius: "4px",
+    color: "#e0e0e0",
+    padding: "2px 6px",
+    fontSize: "12px",
+    textAlign: "right" as const,
+  },
+  multiTargetDeleteButton: {
+    background: "none",
+    border: "1px solid rgba(180, 100, 220, 0.3)",
+    borderRadius: "4px",
+    color: "#b864dc",
     fontSize: "12px",
     padding: "2px 8px",
     cursor: "pointer",

--- a/src/client/logic/__tests__/buff-timespans.test.ts
+++ b/src/client/logic/__tests__/buff-timespans.test.ts
@@ -34,6 +34,7 @@ function makeEntry(startTime: number, activeBuffs: ActiveBuff[]): ResolvedTimeli
     gcdAvailableAt: startTime,
     actionAvailableAt: startTime,
     castTime: 0,
+    targetCount: 1,
   };
 }
 

--- a/src/client/logic/__tests__/multi-target-windows.test.ts
+++ b/src/client/logic/__tests__/multi-target-windows.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import { resolveTimeline } from "../resolve-timeline";
+import {
+  calcEntryExpectedPotency,
+  calcEntryPotencyBreakdown,
+} from "../expected-potency";
+import { DEFAULT_STATS, calcExpectedMultiplier } from "../stat-calc";
+import type {
+  Skill,
+  TimelineEntry,
+  MultiTargetWindow,
+  ResolvedTimelineEntry,
+  CharacterStats,
+} from "../../types/skill";
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    name: overrides.id,
+    potency: 100,
+    type: "gcd",
+    target: "enemy",
+    icon: "",
+    recastTime: 2.5,
+    animationLock: 0.65,
+    acquiredLevel: 1,
+    ...overrides,
+  };
+}
+
+function makeEntry(skillId: string): TimelineEntry {
+  return { uid: `${skillId}-${Math.random()}`, skillId };
+}
+
+function makeResolvedEntry(overrides: Partial<ResolvedTimelineEntry>): ResolvedTimelineEntry {
+  return {
+    uid: "u",
+    skillId: "s",
+    resolvedSkillId: "s",
+    resolvedPotency: 100,
+    startTime: 0,
+    autoStartTime: 0,
+    resourceSnapshot: {},
+    resourceErrors: [],
+    comboErrors: [],
+    untargetableError: false,
+    recastError: false,
+    wsComboError: false,
+    activeBuffs: [],
+    activeBuffsAtUse: [],
+    buffMultiplier: 1,
+    critRateBonus: 0,
+    dhRateBonus: 0,
+    gcdAvailableAt: 0,
+    actionAvailableAt: 0,
+    castTime: 0,
+    targetCount: 1,
+    ...overrides,
+  };
+}
+
+// DEFAULT_STATS は critRate 最小 5% が効くため calcExpectedMultiplier ≈ 1.02。
+// テスト期待値は同じ式で動的に計算して比較する（数値の魔法定数化を避け、式変更に追従するため）。
+const STATS: CharacterStats = DEFAULT_STATS;
+const DEFAULT_MUL = calcExpectedMultiplier(STATS, 0, 0);
+
+/** 単体期待威力（バフ倍率込み）を再現する */
+function singlePot(basePotency: number, buffMul = 1): number {
+  return Math.floor(Math.floor(basePotency * buffMul) * DEFAULT_MUL);
+}
+/** 減衰後期待威力を再現する */
+function reducedPot(basePotency: number, falloffRate: number, buffMul = 1): number {
+  return Math.floor(singlePot(basePotency, buffMul) * (1 - falloffRate));
+}
+
+describe("MultiTargetWindow integration in resolveTimeline", () => {
+  it("複数体ウィンドウ外のスキルは targetCount=1", () => {
+    const skill = makeSkill({ id: "fire", potency: 100 });
+    const skillMap = new Map([[skill.id, skill]]);
+    const result = resolveTimeline(
+      [makeEntry(skill.id)],
+      skillMap,
+      [],
+      undefined,
+      [],
+      [],
+      [{ startTime: 10, endTime: 20, targetCount: 3 }]
+    );
+    expect(result.entries[0].targetCount).toBe(1);
+  });
+
+  it("複数体ウィンドウ内のスキルは targetCount=指定値", () => {
+    const skill = makeSkill({ id: "fire", potency: 100, maxTargets: 3, falloffRate: 0.5 });
+    const skillMap = new Map([[skill.id, skill]]);
+    const entries: TimelineEntry[] = [makeEntry(skill.id), makeEntry(skill.id), makeEntry(skill.id)];
+    // 1本目は 0s（外）、2本目は 2.5s（外）、3本目は 5s（中）
+    const windows: MultiTargetWindow[] = [{ startTime: 4, endTime: 20, targetCount: 3 }];
+    const result = resolveTimeline(entries, skillMap, [], undefined, [], [], windows);
+    expect(result.entries[0].targetCount).toBe(1);
+    expect(result.entries[1].targetCount).toBe(1);
+    expect(result.entries[2].targetCount).toBe(3);
+  });
+
+  it("半開区間: startTime と一致する瞬間は内側、endTime と一致する瞬間は外側", () => {
+    const skill = makeSkill({ id: "fire", potency: 100 });
+    const skillMap = new Map([[skill.id, skill]]);
+    // 開始時刻が 0s, 2.5s, 5s の3スキル。ウィンドウ [2.5, 5) → 2.5s のみ中
+    const entries: TimelineEntry[] = [makeEntry(skill.id), makeEntry(skill.id), makeEntry(skill.id)];
+    const windows: MultiTargetWindow[] = [{ startTime: 2.5, endTime: 5, targetCount: 2 }];
+    const result = resolveTimeline(entries, skillMap, [], undefined, [], [], windows);
+    expect(result.entries[0].targetCount).toBe(1); // 0s: 外
+    expect(result.entries[1].targetCount).toBe(2); // 2.5s: 内側（境界 = 内）
+    expect(result.entries[2].targetCount).toBe(1); // 5s: 外側（境界 = 外）
+  });
+
+  it("味方対象（target='party'）のスキルは複数体ウィンドウ内でも targetCount=1", () => {
+    const heal = makeSkill({ id: "heal", potency: 0, target: "party" });
+    const skillMap = new Map([[heal.id, heal]]);
+    const result = resolveTimeline(
+      [makeEntry(heal.id)],
+      skillMap,
+      [],
+      undefined,
+      [],
+      [],
+      [{ startTime: 0, endTime: 10, targetCount: 5 }]
+    );
+    expect(result.entries[0].targetCount).toBe(1);
+  });
+
+  it("multiTargetWindows 未指定なら全エントリ targetCount=1", () => {
+    const skill = makeSkill({ id: "fire", potency: 100 });
+    const skillMap = new Map([[skill.id, skill]]);
+    const result = resolveTimeline([makeEntry(skill.id)], skillMap, [], undefined, [], []);
+    expect(result.entries[0].targetCount).toBe(1);
+  });
+
+  it("targetCount は最小 1 にクランプ（不正な targetCount=0 等が来ても安全）", () => {
+    const skill = makeSkill({ id: "fire", potency: 100 });
+    const skillMap = new Map([[skill.id, skill]]);
+    const result = resolveTimeline(
+      [makeEntry(skill.id)],
+      skillMap,
+      [],
+      undefined,
+      [],
+      [],
+      // targetCount: 0 は不正だが、内部で max(1, x) でクランプされる
+      [{ startTime: 0, endTime: 10, targetCount: 0 }]
+    );
+    expect(result.entries[0].targetCount).toBe(1);
+  });
+});
+
+describe("calcEntryExpectedPotency / calcEntryPotencyBreakdown", () => {
+  it("単体スキル（maxTargets 未設定）は複数体ウィンドウ内でも1体分のみ", () => {
+    const skill = makeSkill({ id: "fire", potency: 100 });
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 3 });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    expect(breakdown.targets).toEqual([singlePot(100)]);
+    expect(breakdown.total).toBe(singlePot(100));
+  });
+
+  it("maxTargets=3, targetCount=2 → 2体分（減衰なし）", () => {
+    const skill = makeSkill({ id: "aoe", potency: 100, maxTargets: 3 });
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 2 });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    expect(breakdown.targets).toEqual([singlePot(100), singlePot(100)]);
+    expect(breakdown.total).toBe(singlePot(100) * 2);
+  });
+
+  it("maxTargets=3, targetCount=5 → 3体までしかヒットしない", () => {
+    const skill = makeSkill({ id: "aoe", potency: 100, maxTargets: 3 });
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 5 });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    expect(breakdown.targets).toHaveLength(3);
+    expect(breakdown.total).toBe(singlePot(100) * 3);
+  });
+
+  it("falloffRate=0.5, targetCount=3 → 2体目以降50%減衰", () => {
+    const skill = makeSkill({
+      id: "aoe",
+      potency: 100,
+      maxTargets: 8,
+      falloffRate: 0.5,
+    });
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 3 });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    const full = singlePot(100);
+    const half = reducedPot(100, 0.5);
+    expect(breakdown.targets).toEqual([full, half, half]);
+    expect(breakdown.total).toBe(full + half + half);
+  });
+
+  it("falloffStartTarget=3 → 1,2体目フル、3体目以降減衰", () => {
+    const skill = makeSkill({
+      id: "aoe",
+      potency: 100,
+      maxTargets: 8,
+      falloffRate: 0.25,
+      falloffStartTarget: 3,
+    });
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 4 });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    const full = singlePot(100);
+    const reduced = reducedPot(100, 0.25);
+    expect(breakdown.targets).toEqual([full, full, reduced, reduced]);
+    expect(breakdown.total).toBe(full * 2 + reduced * 2);
+  });
+
+  it("hasError なエントリは 0 を返す", () => {
+    const skill = makeSkill({ id: "aoe", potency: 100, maxTargets: 3 });
+    const entry = makeResolvedEntry({
+      resolvedPotency: 100,
+      targetCount: 3,
+      untargetableError: true,
+    });
+    expect(calcEntryExpectedPotency(entry, skill, STATS)).toBe(0);
+    expect(calcEntryPotencyBreakdown(entry, skill, STATS).total).toBe(0);
+  });
+
+  it("バフ倍率込みの計算: buffMultiplier=1.2, falloffRate=0.5, targetCount=2", () => {
+    const skill = makeSkill({ id: "aoe", potency: 100, maxTargets: 3, falloffRate: 0.5 });
+    const entry = makeResolvedEntry({
+      resolvedPotency: 100,
+      buffMultiplier: 1.2,
+      targetCount: 2,
+    });
+    const breakdown = calcEntryPotencyBreakdown(entry, skill, STATS);
+    const full = singlePot(100, 1.2);
+    const half = reducedPot(100, 0.5, 1.2);
+    expect(breakdown.singleTargetPotency).toBe(full);
+    expect(breakdown.targets).toEqual([full, half]);
+    expect(breakdown.total).toBe(full + half);
+  });
+
+  it("skill=undefined（マップに無いスキル）は単体扱い", () => {
+    const entry = makeResolvedEntry({ resolvedPotency: 100, targetCount: 3 });
+    const breakdown = calcEntryPotencyBreakdown(entry, undefined, STATS);
+    expect(breakdown.targets).toEqual([singlePot(100)]);
+    expect(breakdown.total).toBe(singlePot(100));
+  });
+
+  it("calcEntryExpectedPotency と calcEntryPotencyBreakdown.total は一致", () => {
+    const skill = makeSkill({
+      id: "aoe",
+      potency: 100,
+      maxTargets: 5,
+      falloffRate: 0.3,
+      falloffStartTarget: 2,
+    });
+    const entry = makeResolvedEntry({ resolvedPotency: 250, targetCount: 4 });
+    expect(calcEntryExpectedPotency(entry, skill, STATS)).toBe(
+      calcEntryPotencyBreakdown(entry, skill, STATS).total
+    );
+  });
+});
+
+describe("DoT は複数体ウィンドウ内でも1体のみ付与（保守的）", () => {
+  it("DoT スキルが複数体ウィンドウ内で使われても dotTotalPotency は1体分のみ", () => {
+    const dotSkill = makeSkill({
+      id: "dot",
+      potency: 0,
+      dotPotency: 50,
+      dotDuration: 30,
+    });
+    const skillMap = new Map([[dotSkill.id, dotSkill]]);
+    const windows: MultiTargetWindow[] = [{ startTime: 0, endTime: 60, targetCount: 3 }];
+    const result = resolveTimeline(
+      [makeEntry(dotSkill.id)],
+      skillMap,
+      [],
+      undefined,
+      [],
+      [],
+      windows
+    );
+    // 30秒間に 3秒ごとのティック = 10ティック × 50 威力 = 500
+    // 複数体3体でも 1体のみ付与の保守的挙動なので、合計は依然 500
+    expect(result.dotTotalPotency).toBe(500);
+  });
+});

--- a/src/client/logic/expected-potency.ts
+++ b/src/client/logic/expected-potency.ts
@@ -1,0 +1,67 @@
+import type { CharacterStats, ResolvedTimelineEntry, Skill } from "../types/skill";
+import { calcExpectedMultiplier } from "./stat-calc";
+
+/**
+ * 1 エントリ分の期待威力（クリ/DH 期待値・バフ倍率・複数体合計を全て反映した値）。
+ * App.tsx の `totalExpectedPotency` と `calcPps` の `directPotency` の重複計算を一本化するためのヘルパー。
+ *
+ * 計算規則:
+ * - `hasError`（resourceErrors / comboErrors / untargetableError / recastError）のエントリは 0
+ * - 単体スキル（`maxTargets` 未設定 or ≤1）または `entry.targetCount` ≤1 のとき 1 体分のみ
+ * - 複数体時は `min(targetCount, maxTargets)` 体まで、`falloffStartTarget` (default 2) 以降は `(1 - falloffRate)` (default 0) 倍に減衰
+ */
+export function calcEntryExpectedPotency(
+  entry: ResolvedTimelineEntry,
+  skill: Skill | undefined,
+  stats: CharacterStats
+): number {
+  return calcEntryPotencyBreakdown(entry, skill, stats).total;
+}
+
+/**
+ * 期待威力の内訳（ツールチップ表示用）。
+ * - `singleTargetPotency`: 1 体目の期待威力（複数体ヒットでも非減衰の基準値）
+ * - `targets`: 各体ごとの期待威力配列（長さ = effectiveTargets）。単体 or 複数体ウィンドウ外なら長さ 1
+ * - `total`: 配列合計
+ *
+ * `hasError` 時は全フィールドを 0 / 空配列で返す。
+ */
+export function calcEntryPotencyBreakdown(
+  entry: ResolvedTimelineEntry,
+  skill: Skill | undefined,
+  stats: CharacterStats
+): { total: number; targets: number[]; singleTargetPotency: number } {
+  const hasError =
+    entry.resourceErrors.length > 0 ||
+    entry.comboErrors.length > 0 ||
+    entry.untargetableError ||
+    entry.recastError;
+  if (hasError) {
+    return { total: 0, targets: [], singleTargetPotency: 0 };
+  }
+
+  const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
+  const entryMul = calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus);
+  const singleTargetPotency = Math.floor(buffedPotency * entryMul);
+
+  const targetCount = entry.targetCount ?? 1;
+  const maxTargets = skill?.maxTargets ?? 1;
+  if (maxTargets <= 1 || targetCount <= 1) {
+    return { total: singleTargetPotency, targets: [singleTargetPotency], singleTargetPotency };
+  }
+
+  const effectiveTargets = Math.min(maxTargets, targetCount);
+  const falloffRate = skill?.falloffRate ?? 0;
+  const falloffStart = skill?.falloffStartTarget ?? 2;
+  const reducedPotency = Math.floor(singleTargetPotency * (1 - falloffRate));
+
+  const targets: number[] = [];
+  for (let n = 1; n <= effectiveTargets; n++) {
+    targets.push(n < falloffStart ? singleTargetPotency : reducedPotency);
+  }
+  return {
+    total: targets.reduce((sum, p) => sum + p, 0),
+    targets,
+    singleTargetPotency,
+  };
+}

--- a/src/client/logic/resolve-timeline.ts
+++ b/src/client/logic/resolve-timeline.ts
@@ -12,8 +12,10 @@ import type {
   ActiveDoT,
   TimelineResult,
   BossUntargetableWindow,
+  MultiTargetWindow,
 } from "../types/skill";
 import { calcGcd, calcExpectedMultiplier } from "./stat-calc";
+import { calcEntryExpectedPotency } from "./expected-potency";
 
 /** DoTティック間隔（秒） */
 const DOT_TICK_INTERVAL = 3;
@@ -391,6 +393,26 @@ function isInUntargetableWindow(
 }
 
 /**
+ * 指定時刻における敵の数を返す（複数体ウィンドウ判定）。
+ * - `skill.target !== "enemy"` のスキル（味方対象・自己対象）は常に 1
+ * - `multiTargetWindows` 未定義 / 該当なしの場合は 1
+ * - 半開区間 `[startTime, endTime)`（`isInUntargetableWindow` と同仕様）
+ */
+function getTargetCountAt(
+  time: number,
+  windows: MultiTargetWindow[] | undefined,
+  skill: Skill
+): number {
+  if (!windows || windows.length === 0 || skill.target !== "enemy") return 1;
+  for (const w of windows) {
+    if (time >= w.startTime && time < w.endTime) {
+      return Math.max(1, w.targetCount);
+    }
+  }
+  return 1;
+}
+
+/**
  * 同一 displayGroup 内の他リソース合計を取得する（groupMaxStacks キャップ判定用）。
  */
 function getGroupOtherSum(
@@ -634,7 +656,8 @@ export function resolveTimeline(
   resources: ResourceDefinition[],
   stats?: CharacterStats,
   buffs?: BuffDefinition[],
-  untargetableWindows?: BossUntargetableWindow[]
+  untargetableWindows?: BossUntargetableWindow[],
+  multiTargetWindows?: MultiTargetWindow[]
 ): TimelineResult {
   const resolved: ResolvedTimelineEntry[] = [];
   const resourceDefMap = new Map(resources.map((r) => [r.id, r]));
@@ -950,6 +973,7 @@ export function resolveTimeline(
     const untargetableError = skill.target === "enemy" && untargetableWindows
       ? isInUntargetableWindow(startTime, untargetableWindows)
       : false;
+    const targetCount = getTargetCountAt(startTime, multiTargetWindows, skill);
 
     // チャージ回復処理 & リキャストチェック
     // cooldownGroup 設定時は同一グループ内でチャージ・クールダウンを共有する
@@ -1426,6 +1450,7 @@ export function resolveTimeline(
       gcdAvailableAt,
       actionAvailableAt,
       castTime: resolvedCastTime,
+      targetCount,
     });
   }
 
@@ -1531,13 +1556,8 @@ export function calcPps(
   let directPotency = 0;
   for (const entry of resolvedEntries) {
     if (entry.startTime >= rangeStart && entry.startTime < rangeEnd) {
-      // ハードエラーのあるスキルはダメージ計算対象外
-      const hasError = entry.resourceErrors.length > 0 || entry.comboErrors.length > 0 || entry.untargetableError || entry.recastError;
-      if (hasError) continue;
-      // resolvedPotencyを使用（コンボ成否・自動変化を反映済み）
-      const buffedPotency = Math.floor(entry.resolvedPotency * entry.buffMultiplier);
-      const entryMul = calcExpectedMultiplier(stats, entry.critRateBonus, entry.dhRateBonus);
-      directPotency += Math.floor(buffedPotency * entryMul);
+      const skill = skillMap.get(entry.resolvedSkillId);
+      directPotency += calcEntryExpectedPotency(entry, skill, stats);
     }
   }
 

--- a/src/client/types/skill.ts
+++ b/src/client/types/skill.ts
@@ -173,6 +173,22 @@ export interface Skill {
   guaranteedCrit?: boolean;
   /** スキル固有の確定ダイレクトヒット（バフ経由ではない常時DH。返し波切等） */
   guaranteedDh?: boolean;
+  /**
+   * 対象数（1 = 単体、2以上 = 範囲）。
+   * 未設定または 1 の場合は単体スキルとして扱い、複数体ウィンドウ内でも 1 体分のみ威力を計上する。
+   * データ投入はジョブ別 Issue（#269〜#273）で行う。
+   */
+  maxTargets?: number;
+  /**
+   * 2体目以降（または `falloffStartTarget` 以降）の威力減衰率（0.0〜1.0）。
+   * 例: 0.5 = 50%減衰（残り 50% 威力）。未設定（または 0）は減衰なし＝フル威力。
+   */
+  falloffRate?: number;
+  /**
+   * 減衰が始まる体数（1-indexed）。未設定は 2（= 2体目から減衰）。
+   * 例: 3 を指定すると 1〜2 体目はフル威力、3 体目以降が減衰対象。
+   */
+  falloffStartTarget?: number;
 }
 
 /** タイムラインに配置されたスキル */
@@ -375,6 +391,20 @@ export interface BossUntargetableWindow {
   endTime: number;
 }
 
+/**
+ * 複数体ウィンドウ（指定時間帯に複数体の敵が居る期間）。
+ * この区間内に配置された対象 `enemy` スキルは `Skill.maxTargets` / `falloffRate` を元に合計威力が増加する。
+ * 区間判定は半開区間 `[startTime, endTime)`（`BossUntargetableWindow` と同仕様）。
+ */
+export interface MultiTargetWindow {
+  /** 開始時刻（秒） */
+  startTime: number;
+  /** 終了時刻（秒） */
+  endTime: number;
+  /** 敵の数（2以上） */
+  targetCount: number;
+}
+
 /** PPS範囲選択 */
 export interface PpsRange {
   /** 範囲開始時刻（秒） */
@@ -460,4 +490,9 @@ export interface ResolvedTimelineEntry {
    * UI 側で activeBuffs を再解釈しなくても、この値を直接描画できる。
    */
   castTime: number;
+  /**
+   * このスキル使用時の敵の数。`multiTargetWindows` の内側であれば 2 以上、外側または対象 `enemy` 以外のスキルでは 1。
+   * 合計威力計算は `Skill.maxTargets` で頭打ち、`falloffRate` / `falloffStartTarget` で減衰される。
+   */
+  targetCount: number;
 }


### PR DESCRIPTION
## 概要

絶等の一部コンテンツで複数体の敵を相手にする時間帯を表現するため、タイムライン上に「複数体ウィンドウ」を設定可能にした。データ構造・UI・威力計算基盤を整備し、各ジョブ別 AoE データ追加（#269〜#273）を受け入れる準備を完了。

## 変更点

### 型 / ロジック
- `src/client/types/skill.ts` — `Skill` に `maxTargets?` / `falloffRate?` / `falloffStartTarget?` を追加、`MultiTargetWindow` 型を新規追加、`ResolvedTimelineEntry.targetCount: number` を追加
- `src/client/logic/expected-potency.ts` — 新規。`calcEntryExpectedPotency` / `calcEntryPotencyBreakdown` を抽出し、App.tsx と `calcPps` の重複していた直接威力計算式を一本化。複数体合算（`maxTargets` 頭打ち + `falloffStartTarget` 以降の `(1 - falloffRate)` 倍減衰）もこの関数で処理
- `src/client/logic/resolve-timeline.ts` — `resolveTimeline` シグネチャに第7引数 `multiTargetWindows?` を追加（既存テスト 27 ファイル全件無修正で済む後方互換性のある形）、`getTargetCountAt` を新設（`isInUntargetableWindow` と同形の半開区間判定、`skill.target === "enemy"` のみ対象）、各エントリ生成時に `targetCount` を付与し `resolved.push` で書き出し、`calcPps` の直接威力ループを `calcEntryExpectedPotency` 呼び出しに置換

### UI
- `src/client/components/App.tsx` — `multiTargetWindows` state を追加（`untargetableWindows` の隣）、`resolveTimeline` 第7引数と `useMemo` deps に追加、`totalExpectedPotency` 計算を `calcEntryExpectedPotency` に置換、Timeline へ prop ドリル
- `src/client/components/Timeline.tsx` — ヘッダに紫系の「複数体 ▶」トグルボタン、ボス離脱エディタの直下に複数体ウィンドウエディタ（開始 / 終了 / 敵の数 の 3 入力フィールド）、タイムライン上に紫の色帯（`rgba(180, 100, 220, X)`、`zIndex: 4` で離脱の `zIndex: 5` と分離）、`totalDuration` に `multiTargetWindows.endTime` を含めて軸自動延長、`formatTargetBreakdown` ヘルパで GCD/oGCD ツールチップに `×N体 (1体: X / 減衰時: Y)` 内訳追加
- `src/client/components/SkillDetailPanel.tsx` — 期待値ボックスに複数体ヒット時の見出し `期待値 (×N体 合算)` と各体ごとの内訳行を追加

### 設計判断（Issue で確認済み）

| 項目 | 決定 |
|------|------|
| UI 配置 | ボス離脱エディタの直下に別セクション |
| 表示色 | 紫 `rgba(180, 100, 220, X)`（ボス離脱の赤と区別） |
| 威力表示 | 期待威力欄に合計 + ツールチップで内訳 |
| DoT 扱い | 1 体のみ付与の保守的挙動（targetCount は DoT 計算に影響させない） |
| PPS | 合計威力÷時間（複数体込みの実効 PPS） |
| 軸延長 | ボス離脱と同仕様で延長 |
| 重複式リファクタ | `calcEntryExpectedPotency` ヘルパー抽出として本 PR 内で同時実施（ユーザー承認済み） |

### テスト

- `src/client/logic/__tests__/multi-target-windows.test.ts` を新規追加（16 ケース）
  - `resolveTimeline` 統合: 6 件（ウィンドウ外 / 内、半開区間、味方対象、未指定、不正値クランプ）
  - `calcEntryExpectedPotency` / `calcEntryPotencyBreakdown`: 9 件（単体スキル、maxTargets 頭打ち、`falloffRate` 減衰、`falloffStartTarget` シフト、hasError、バフ倍率込み、skill undefined、両関数の一致性）
  - DoT 保守: 1 件（複数体ウィンドウ内でも `dotTotalPotency` は 1 体分のみ）
- `src/client/logic/__tests__/buff-timespans.test.ts` — 既存 mock に `targetCount: 1` を追加

## テスト

- [x] `npx tsc --noEmit` exit 0
- [x] `npm test -- --run` 230/230 passed（既存 214 + 新規 16）
- [x] Playwright で UI 動作確認:
  - 「複数体 ▶」トグルでエディタ開閉
  - 「+ 追加」で開始 5s / 終了 10s / 敵の数 2 のウィンドウ生成
  - タイムライン上に紫帯描画（5s-10s、幅 400px = 5s × 80px/s）と `×2` ラベル表示を確認
  - 終了を 100s に変更すると軸が `8152px` に延長されることを確認
  - 単体スキル（`maxTargets` 未設定）は複数体ウィンドウ内でも 1 体分のみ計上されることを確認
  - 削除ボタンでウィンドウが消え、空状態メッセージ「複数体ウィンドウが未設定です」が表示されることを確認

## 影響範囲

- ジョブ別 AoE データを持たないスキル（現状すべてのスキル）は targetCount=1 として従来通り単体計算され、回帰なし
- DoT スキルは保守的に 1 体のみ付与され、`dotTotalPotency` も従来同値
- `resolveTimeline` の第 7 引数は optional のため、既存呼び出し（テスト 27 ファイル、App.tsx、Timeline.tsx 1 箇所のドラッグプレビュー）の修正不要

## 関連 Issue

各ジョブ別 AoE データ追加 Issue（本 PR マージ後に着手予定）:
- #269 WHM / #270 DRG / #271 BRD / #272 PCT / #273 BLM

closes #268
